### PR TITLE
chore: adopt dnd repo agent/mr policies and local skills

### DIFF
--- a/.agents/skills/pr-reviewer/SKILL.md
+++ b/.agents/skills/pr-reviewer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: pr-reviewer
+description: Review a pull request for correctness, regressions, and missing tests. Use for structured, risk-focused code review.
+---
+
+# PR Reviewer
+
+## Purpose
+Review a pull request for correctness, regressions, and missing tests.
+
+## Inputs to request
+- PR diff and context of change.
+- Related issues or requirements.
+- Test results and coverage data.
+
+## Workflow
+1. Scan for logic errors, edge cases, and data handling issues.
+2. Check for missing tests or test coverage gaps.
+3. Call out risk areas and suggest concrete improvements.
+
+## Output
+- Prioritized review findings with file references.
+
+## Quality bar
+- Focus on correctness and risk over style.
+- Provide actionable, specific feedback.
+

--- a/.codex/mr-flow-and-approvals.md
+++ b/.codex/mr-flow-and-approvals.md
@@ -1,0 +1,34 @@
+# MR Flow And Approval Preferences
+
+## User Preferences
+- Do not repeatedly ask for GitHub-related approvals when an approved command prefix already exists.
+- Prefer reusing saved approved prefixes for `gh`/GitHub operations.
+- Batch GitHub operations to minimize approval prompts.
+- If all comments are addressed and all CI checks pass, proceed to merge.
+- If approval is required and self-approval is blocked, use admin merge when explicitly requested by user workflow.
+
+## Standard MR Flow
+1. Identify latest/open MR tied to current branch.
+2. Check CI status and review state.
+3. Pull unresolved review threads/comments.
+4. Address unaddressed comments in code/docs/workflows.
+5. Resolve addressed threads.
+6. Re-request review and re-check CI.
+7. Iterate steps 3-6 until review threads are resolved and checks pass.
+8. Merge MR (prefer normal merge; use `--admin` only when required by policy/workflow).
+9. Verify merged state and report merge commit SHA.
+
+## Operational Rules For Future Sessions
+- Read this file at the start of MR-related tasks.
+- Assume user wants end-to-end completion (fix -> resolve -> review -> merge) unless user says otherwise.
+- Surface only hard blockers (policy limitations, failed CI, missing required reviewer approval).
+- Keep user updates brief and action-focused.
+
+## Agent Direction For This Repo
+- Prefer repo-local skill prompts under `.agents/skills/` or `.codex/skills/` when they match the task.
+- Before MR actions, check this file first for approval and flow preferences.
+
+## Platform Constraints
+- GitHub does not allow approving your own PR.
+- If branch protection requires approval and no other approver is available, use admin merge only when user workflow explicitly allows it.
+

--- a/.codex/skills/repo-standards/SKILL.md
+++ b/.codex/skills/repo-standards/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: repo-standards
+description: Use when making repository changes, preparing PRs, or running build/test/lint workflows. Skip for pure Q&A.
+---
+
+# Repo Standards
+
+1. Inspect repository state first (`git status`, current branch, pending local changes).
+2. Keep changes minimal and aligned with existing style and architecture.
+3. Run relevant validation for touched areas (format, lint, typecheck, tests).
+4. Update docs/README when commands, workflows, or behavior change.
+5. Summarize what changed, what was validated, and any remaining risk.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Agent Policy
+
+### Core workflow
+Use `explore -> plan -> code -> verify -> commit` for implementation tasks.
+
+### Operating standards
+1. Inspect repository state first (`git status`, current branch, pending local changes).
+2. Keep changes minimal and aligned with existing architecture and conventions.
+3. Run relevant validation for touched areas.
+4. Update docs when behavior, commands, or workflow changes.
+5. Summarize what changed, what was validated, and any residual risk.
+
+### Repo-specific non-negotiables
+1. No uncited factual claims in generated analysis outputs.
+2. Respect local-first design and paywall policies from project artifacts.
+3. Enforce budget and safety guardrails; stop on configured hard limits.
+4. Minimize context bloat by reading only files needed for the current step.
+
+### Policy references
+- MR policy and approval workflow: `.codex/mr-flow-and-approvals.md`
+- Reusable local skills: `.codex/skills/`, `.agents/skills/`
+


### PR DESCRIPTION
## Summary
- add AGENTS.md with adopted agent policy
- add MR workflow policy under .codex/mr-flow-and-approvals.md
- add local repo skills: repo-standards and pr-reviewer

## Verification
- files added and committed on dedicated chore branch