### PR TITLE
docs(policy): enforce step commits and separate MRs for independent tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ Use `explore -> plan -> code -> verify -> commit` for implementation tasks.
 3. Run relevant validation for touched areas.
 4. Update docs when behavior, commands, or workflow changes.
 5. Summarize what changed, what was validated, and any residual risk.
+6. When a step is finalized, commit it and include it in a new MR (or the active MR) without leaving completed local-only work unpushed.
+7. For independent tasks that are unlikely to conflict, use separate branches and separate MRs instead of combining them in one MR.
 
 ### Repo-specific non-negotiables
 1. No uncited factual claims in generated analysis outputs.


### PR DESCRIPTION
## Summary
- update AGENTS.md operating standards to require:
  - finalized steps are committed and included in an MR
  - independent low-conflict tasks use separate branches and separate MRs

## Why
- aligns workflow with user preference for smaller, task-focused review units
