### PR TITLE
docs: record scoped strengthening plan from Prophet benchmark

### DIFF
--- a/artifacts/PRD.md
+++ b/artifacts/PRD.md
@@ -253,3 +253,24 @@ Outputs:
 - SQLite FTS5 full‑text search: https://www.sqlite.org/fts5.html  
 - SEC EDGAR fair access guidance (rate limits / moderation): https://www.sec.gov/search-filings/edgar-search-assistance/accessing-edgar-data
 
+
+## 14. In-Scope Strengthening Backlog (2026-02-19)
+These improvements are inspired by peer financial AI product patterns and constrained to this PRD's local-first, citation-grounded, and non-advisory scope.
+
+1. Decision record per run
+- Persist run artifacts with claims, citations used, rejected alternatives, risk flags, budget usage, and final rationale.
+
+2. Retrieval memory from validated historical outputs
+- Embed/index only approved historical syntheses and retrieve similar prior cases before synthesis.
+
+3. Internal role-lane orchestration in one runtime
+- Add explicit phases: research (evidence), risk (guardrails), editorial (structure), reviewer (adversarial checks).
+
+4. Stronger pre-delivery quality gates
+- Hard-fail or abstain on citation coverage, paywall policy, source-diversity, and budget violations.
+
+5. Operational templates
+- Add fixed templates for daily brief, event-risk brief, and portfolio-delta review with section-level checks.
+
+6. Feedback-loop metrics
+- Track citation failure rate, retry rate, abstain rate, budget per successful report, and time to delivery.

--- a/artifacts/modelling/MODELLING_CHECKLIST.md
+++ b/artifacts/modelling/MODELLING_CHECKLIST.md
@@ -25,3 +25,12 @@ Modelling phase complete when:
 - Citation validator passes
 - Budget guard implemented and enabled by default
 
+## Strengthening Tracks (Prophet Benchmark Review - 2026-02-19)
+
+- [IN_PROGRESS] **S1) Decision record schema** - Define persisted per-run rationale artifact (claims, citations, rejected alternatives, risk flags, budget usage)
+- [FAILING] **S2) Retrieval memory for validated outputs** - Add embedding + retrieval flow for approved historical syntheses
+- [FAILING] **S3) Role-lane orchestration** - Add phased prompts/checks (research, risk, editorial, reviewer) in one runtime
+- [FAILING] **S4) Pre-delivery gate hardening** - Enforce deterministic fail/abstain gates for citation/paywall/diversity/budget
+- [FAILING] **S5) Operational report templates** - Standardize daily brief, event-risk brief, and portfolio-delta outputs
+- [FAILING] **S6) Reliability metrics** - Track citation failure, retry, abstain, budget-per-report, and latency-to-delivery
+

--- a/artifacts/modelling/TODO.md
+++ b/artifacts/modelling/TODO.md
@@ -1,0 +1,31 @@
+# Modelling TODO (Prophet-Inspired, Project-Scoped)
+
+Last updated: 2026-02-19
+
+## Priority Queue
+
+- [ ] P0: Define `decision_record` artifact schema and storage location
+  - Acceptance: markdown spec + JSON example + field-level validation rules.
+
+- [ ] P0: Wire `decision_record` generation into synthesis pipeline output
+  - Acceptance: stage contract updated and one fixture demonstrating persisted output.
+
+- [ ] P1: Add validated-synthesis memory retrieval design
+  - Acceptance: retrieval flow doc with ingest criteria (approved-only) and ranking fields.
+
+- [ ] P1: Add role-lane orchestration spec (research/risk/editorial/reviewer)
+  - Acceptance: phase prompts, inputs/outputs, and failover behavior documented.
+
+- [ ] P1: Extend validator gates for deterministic fail/abstain behavior
+  - Acceptance: explicit gate matrix for citation, paywall, diversity, and budget constraints.
+
+- [ ] P2: Define fixed output templates (daily brief, event-risk brief, portfolio delta)
+  - Acceptance: template examples with required sections and max-length constraints.
+
+- [ ] P2: Define reliability metrics and weekly review report format
+  - Acceptance: metric definitions, SQL/source mapping, and reporting cadence.
+
+## Notes
+
+- Keep all work aligned with PRD v1.1 constraints: local-first, citation-grounded, no trading instructions.
+- Do not relax paywall, budget hard-stop, or evidence requirements.

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -166,3 +166,26 @@
   - Next MR step after push: identify/open PR tied to current branch and continue standard review/check flow
 - Next single step:
   - Push `chore/update-progress-log` with commits for skills import and this progress update
+
+[2026-02-19 Session 10] Recorded Prophet benchmark recommendations into scoped planning docs
+- External benchmark reviewed:
+  - https://github.com/JakeNesler/Claude_Prophet (architecture, MCP tools, agent role split, logging, memory patterns)
+- Updated docs within project scope:
+  - `artifacts/PRD.md`
+    - Added section `14. In-Scope Strengthening Backlog (2026-02-19)` with six scoped enhancements:
+      - per-run decision records
+      - validated-output retrieval memory
+      - role-lane orchestration
+      - stronger pre-delivery gates
+      - operational templates
+      - reliability metrics
+  - `artifacts/modelling/MODELLING_CHECKLIST.md`
+    - Added `Strengthening Tracks (Prophet Benchmark Review - 2026-02-19)` with S1-S6 status tracking
+  - `artifacts/modelling/TODO.md`
+    - Created prioritized implementation queue (P0/P1/P2) and acceptance criteria
+- Verification run + outcome:
+  - Verified new/updated files are present and readable
+  - Verified checklist and todo entries align with PRD constraints (local-first, paywall-safe, budget hard-stop, citation-grounded)
+  - Outcome: PASS (recommendations recorded and converted into actionable tracked work)
+- Next single step:
+  - Open MR for `chore/prophet-inspired-strengthening-plan` and request review on docs scope


### PR DESCRIPTION
## Summary\n- add an in-scope strengthening backlog to PRD based on benchmarked patterns\n- add dedicated strengthening tracks (S1-S6) to modelling checklist\n- add prioritized modelling TODO file with acceptance criteria\n- log progress in claude-progress.txt\n\n## Scope guardrails\n- keeps local-first, citation-grounded, paywall-safe, non-advisory constraints\n- does not relax budget hard-stop or approval requirements\n\n## Validation\n- verified updated docs are present and readable\n- verified checklist/todo alignment with PRD constraints