### PR TITLE
docs: add overall repository README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# MVP Agent
+
+Local-first financial news and macro literature-review assistant.
+
+This repository contains the modelling artifacts and early runtime components for an assistant that:
+- ingests financial/macro sources (RSS, HTML, PDF),
+- produces citation-grounded daily briefs and major-event alerts,
+- enforces strict budget and safety guardrails.
+
+## Current Phase
+
+This project is currently in the modelling + early implementation phase.
+
+Completed modelling artifacts:
+- `artifacts/modelling/source_registry.yaml`
+- `artifacts/modelling/data_model.md`
+- `artifacts/modelling/pipeline.md`
+- `artifacts/modelling/citation_contract.md`
+- `artifacts/modelling/alert_scoring.md`
+- `artifacts/modelling/backlog.json`
+
+## Core Non-Negotiables
+
+1. No uncited factual claims in generated analysis.
+2. Respect paywall policies (`metadata_only` means no fabricated full text).
+3. Enforce hard budget caps and stop on limit violations.
+4. Keep the system local-first for data and portfolio context.
+
+See:
+- `artifacts/PRD.md`
+- `artifacts/PROJECT_FACT.md`
+- `AGENTS.md`
+
+## Repository Layout
+
+```text
+apps/
+  agent/
+    runtime/              # Early runtime modules (e.g., budget guard)
+artifacts/
+  PRD.md                  # Product requirements
+  PROJECT_FACT.md         # Hard constraints
+  modelling/              # Modelling pack and planning docs
+tests/
+  agent/runtime/          # Unit tests
+docs/plans/               # Planning notes
+```
+
+## Quick Start
+
+Use Python 3.11+ (3.14 also works for current test scope).
+
+Run tests:
+
+```bash
+python -m unittest discover -s tests -p "test_*.py" -v
+```
+
+Run syntax compilation check:
+
+```bash
+python -m compileall -q apps tests
+```
+
+## Working Conventions
+
+- Use small, isolated branches and separate MRs for independent tasks.
+- Follow `explore -> plan -> code -> verify -> commit`.
+- Update progress tracking in `claude-progress.txt` for significant work.
+- Follow MR policy in `.codex/mr-flow-and-approvals.md`.
+
+## Notes
+
+- This project is not a trading signal engine and should not produce buy/sell instructions.
+- Outputs are intended to provide evidence-grounded scenarios and risk flags.

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -167,6 +167,18 @@
 - Next single step:
   - Push `chore/update-progress-log` with commits for skills import and this progress update
 
+[2026-02-19 Session 12] Added top-level repository README
+- Created: `README.md`
+  - Added project overview and current phase status
+  - Added completed modelling artifact list
+  - Added non-negotiables summary aligned with PRD/PROJECT_FACT
+  - Added repository structure, quick-start validation commands, and working conventions
+- Verification run + outcome:
+  - Verified `README.md` renders and references existing files/paths
+  - Outcome: PASS (repo now has a clear entry-point document for contributors)
+- Next single step:
+  - Open MR for `docs/add-overall-readme`
+
 [2026-02-19 Session 10] Recorded Prophet benchmark recommendations into scoped planning docs
 - External benchmark reviewed:
   - https://github.com/JakeNesler/Claude_Prophet (architecture, MCP tools, agent role split, logging, memory patterns)


### PR DESCRIPTION
## Summary
- add top-level `README.md` as the repository entry point
- document project purpose, current phase, key constraints, and file layout
- include quick-start validation commands and contribution conventions
- record work in `claude-progress.txt`

## Validation
- `python -m unittest discover -s tests -p "test_*.py" -v`
