### PR TITLE
docs: update modelling dashboard status

### DIFF
--- a/artifacts/modelling/MODELLING_CHECKLIST.md
+++ b/artifacts/modelling/MODELLING_CHECKLIST.md
@@ -15,7 +15,7 @@ Status: `PASSING`, `FAILING`, `IN_PROGRESS`
 
 - [PASSING] **G) Citation validator** - Validate every bullet has >=1 citation
 - [PASSING] **H) Budget guard** - Enforce daily/hourly/monthly caps
-- [PASSING] **I) Eval cases** - At least 10 golden test cases in `evals/`
+- [IN_PROGRESS] **I) Eval cases** - 10 golden cases exist, but `evals/run_eval_suite.py` is failing on citation status expectation drift
 
 ## Definition of Done
 
@@ -37,4 +37,8 @@ Modelling phase complete when:
 ## Known Gaps
 
 - Eval fixture drift exists in `evals/run_eval_suite.py` expectations for several citation cases (`partial` vs `retry`), even though the required 10 golden cases are present.
+
+## Operational Gate Status
+
+- [IN_PROGRESS] CI workflow merge pending in PR #13 (`chore/add-ci-baseline`); branch protection already expects `validate-and-test`.
 

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -234,3 +234,14 @@
   - Outcome: PASS (incremental MCP adoption plan ready for execution)
 - Next single step:
   - Open MR for `docs/mcp-incremental-adoption-plan` and request review before implementation
+
+[2026-02-19 Session 16] Updated modelling dashboard status for current repo reality
+- Updated: `artifacts/modelling/MODELLING_CHECKLIST.md`
+  - Changed item I (Eval cases) from PASSING -> IN_PROGRESS because golden files exist but eval suite currently fails on status expectation drift.
+  - Added operational status section noting CI baseline workflow is still pending merge in PR #13.
+- Verification run + outcome:
+  - `python -m unittest discover -s tests -p "test_*.py" -v` -> PASS (30 tests)
+  - `python evals/run_eval_suite.py` -> FAIL (known and reflected in checklist)
+  - Outcome: PASS (dashboard now reflects true implementation + operational state)
+- Next single step:
+  - Merge PR #13, then align eval fixture expectations with current validator contract


### PR DESCRIPTION
## Summary
- update modelling dashboard to reflect actual repo status
- set eval item (I) to IN_PROGRESS because eval runner currently fails despite golden files existing
- add operational gate status noting CI baseline is still pending merge in PR #13
- log dashboard update in `claude-progress.txt`

## Validation
- `python -m unittest discover -s tests -p "test_*.py" -v` (PASS)
- `python evals/run_eval_suite.py` (known FAIL reflected in checklist)
