### PR TITLE
fix(pipeline): re-land missing stage10 decision_record persistence

### DIFF
--- a/apps/agent/pipeline/stage10_decision_record.py
+++ b/apps/agent/pipeline/stage10_decision_record.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.validate_decision_record_schema import validate_decision_record
+
+SECTION_ALIASES = {
+    "counterarguments": "counter",
+    "what_to_watch": "watch",
+    "what to watch": "watch",
+}
+ALLOWED_CLAIM_SECTIONS = {"prevailing", "counter", "minority", "watch", "changed"}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(8192)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _normalize_status(stage8_status: str) -> str:
+    if stage8_status == "retry":
+        return "abstained"
+    if stage8_status in {"ok", "partial", "failed", "abstained"}:
+        return stage8_status
+    return "failed"
+
+
+def _normalize_section(section: str) -> str:
+    return SECTION_ALIASES.get(section, section)
+
+
+def build_and_persist_decision_record(
+    *,
+    base_dir: Path,
+    run_id: str,
+    run_type: str,
+    stage8_status: str,
+    synthesis: Mapping[str, Any],
+    removed_bullets: int,
+    budget_snapshot: Mapping[str, Any],
+    guardrail_checks: Mapping[str, Any],
+    output_path: Path | None = None,
+    generated_at_utc: str | None = None,
+) -> dict[str, Any]:
+    timestamp = generated_at_utc or _utc_now_iso()
+    date_partition = timestamp[:10]
+    status = _normalize_status(stage8_status)
+
+    claims: list[dict[str, Any]] = []
+    claim_counter = 1
+    for section, bullets in synthesis.items():
+        if not isinstance(bullets, list):
+            continue
+        for bullet in bullets:
+            if not isinstance(bullet, Mapping):
+                continue
+            citation_ids = bullet.get("citation_ids")
+            if not isinstance(citation_ids, list):
+                citation_ids = []
+            claim = {
+                "claim_id": f"c_{claim_counter:03d}",
+                "section": _normalize_section(str(section)),
+                "text": str(bullet.get("text", "")),
+                "citation_ids": citation_ids,
+                "coverage_status": "supported" if len(citation_ids) >= 1 else "insufficient_evidence",
+            }
+            if claim["section"] not in ALLOWED_CLAIM_SECTIONS:
+                continue
+            claims.append(claim)
+            claim_counter += 1
+
+    rejected_alternatives: list[dict[str, str]] = []
+    if removed_bullets > 0:
+        rejected_alternatives.append(
+            {
+                "candidate_summary": "Claim candidates removed by citation validation",
+                "reason_code": "insufficient_evidence",
+                "notes": f"{removed_bullets} claim(s) removed or downgraded at stage 8",
+            }
+        )
+
+    risk_flags = []
+    for key, value in guardrail_checks.items():
+        if key.endswith("_check") and value in {"warn", "fail"}:
+            risk_flags.append(key.replace("_check", ""))
+
+    artifacts: dict[str, Any] = {}
+    if output_path is not None:
+        artifacts["output_path"] = str(output_path)
+        if output_path.exists():
+            artifacts["output_sha256"] = _hash_file(output_path)
+            artifacts["synthesis_id"] = f"syn_{run_id}"
+    if status != "failed" and "output_sha256" not in artifacts:
+        status = "failed"
+        guardrail_notes = guardrail_checks.get("notes")
+        if isinstance(guardrail_notes, list):
+            guardrail_notes = list(guardrail_notes)
+        else:
+            guardrail_notes = []
+        guardrail_notes.append("Missing output artifact/hash; decision record downgraded to failed.")
+        guardrail_checks = {**dict(guardrail_checks), "notes": guardrail_notes}
+
+    uncertainties: list[str] = []
+    if status == "abstained":
+        uncertainties.append("Synthesis required retry/abstain after citation validation.")
+    if removed_bullets > 0:
+        uncertainties.append(f"{removed_bullets} claim(s) had insufficient evidence coverage.")
+
+    decision_record = {
+        "schema_version": "decision_record.v1",
+        "record_id": f"dr_{run_id}",
+        "run_id": run_id,
+        "run_type": run_type,
+        "generated_at_utc": timestamp,
+        "status": status,
+        "claims": claims,
+        "rejected_alternatives": rejected_alternatives,
+        "risk_flags": risk_flags,
+        "budget_snapshot": dict(budget_snapshot),
+        "guardrail_checks": dict(guardrail_checks),
+        "artifacts": artifacts,
+        "decision_rationale": {
+            "summary": "Decision record generated from pipeline stage outputs.",
+            "confidence_label": "medium" if removed_bullets > 0 else "high",
+            "key_drivers": ["citation_validation", "budget_guard", "guardrail_checks"],
+            "uncertainties": uncertainties,
+        },
+    }
+
+    records_dir = base_dir / "artifacts" / "decision_records" / date_partition
+    records_dir.mkdir(parents=True, exist_ok=True)
+    record_path = records_dir / f"{run_id}.json"
+    validation_errors = validate_decision_record(decision_record)
+    if validation_errors:
+        joined = "; ".join(validation_errors)
+        raise ValueError(f"Invalid decision record for run {run_id}: {joined}")
+    record_path.write_text(json.dumps(decision_record, indent=2), encoding="utf-8")
+
+    return {"record_path": str(record_path), "decision_record": decision_record}

--- a/artifacts/modelling/TODO.md
+++ b/artifacts/modelling/TODO.md
@@ -7,7 +7,7 @@ Last updated: 2026-02-19
 - [x] P0: Define `decision_record` artifact schema and storage location
   - Acceptance: markdown spec + JSON example + field-level validation rules.
 
-- [ ] P0: Wire `decision_record` generation into synthesis pipeline output
+- [x] P0: Wire `decision_record` generation into synthesis pipeline output
   - Acceptance: stage contract updated and one fixture demonstrating persisted output.
 
 - [ ] P1: Add validated-synthesis memory retrieval design

--- a/artifacts/modelling/examples/decision_record_pipeline_fixture.json
+++ b/artifacts/modelling/examples/decision_record_pipeline_fixture.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "decision_record.v1",
+  "record_id": "dr_run_fixture_2026_02_19",
+  "run_id": "run_fixture_2026_02_19",
+  "run_type": "daily_brief",
+  "generated_at_utc": "2026-02-19T18:00:00Z",
+  "status": "partial",
+  "claims": [
+    {
+      "claim_id": "c_001",
+      "section": "prevailing",
+      "text": "Growth-sensitive sectors remain volatile into policy week.",
+      "citation_ids": [
+        "cite_001"
+      ],
+      "coverage_status": "supported"
+    },
+    {
+      "claim_id": "c_002",
+      "section": "watch",
+      "text": "[Insufficient evidence to support this claim]",
+      "citation_ids": [],
+      "coverage_status": "insufficient_evidence"
+    }
+  ],
+  "rejected_alternatives": [
+    {
+      "candidate_summary": "High-conviction disinflation call",
+      "reason_code": "insufficient_evidence",
+      "notes": "Removed by stage8 citation validation"
+    }
+  ],
+  "risk_flags": [
+    "citation"
+  ],
+  "budget_snapshot": {
+    "hourly_spend_usd": 0.03,
+    "hourly_cap_usd": 0.1,
+    "daily_spend_usd": 1.2,
+    "daily_cap_usd": 3.0,
+    "monthly_spend_usd": 24.5,
+    "monthly_cap_usd": 100.0,
+    "allowed": true
+  },
+  "guardrail_checks": {
+    "citation_check": "warn",
+    "paywall_check": "pass",
+    "diversity_check": "pass",
+    "budget_check": "pass",
+    "notes": [
+      "1 claim downgraded for insufficient evidence."
+    ]
+  },
+  "artifacts": {
+    "synthesis_id": "syn_run_fixture_2026_02_19",
+    "output_path": "artifacts/daily/2026-02-19/brief.html",
+    "output_sha256": "d9f3668f67a4a493ee26ea7075ee2e95d59e47fd4ce5f8b8cc4a8b755f2d38f8"
+  },
+  "decision_rationale": {
+    "summary": "Partial report was delivered with one unsupported claim downgraded.",
+    "confidence_label": "medium",
+    "key_drivers": [
+      "citation_validation",
+      "budget_guard"
+    ],
+    "uncertainties": [
+      "One watchlist claim lacked sufficient corroboration."
+    ]
+  }
+}

--- a/artifacts/modelling/pipeline.md
+++ b/artifacts/modelling/pipeline.md
@@ -149,6 +149,8 @@ Actions:
 - Write daily HTML output locally.
 - Send email for daily brief and approved alerts.
 - Store run metrics, costs, and output lineage.
+- Persist a per-run `decision_record` artifact under `artifacts/decision_records/<YYYY-MM-DD>/<run_id>.json`.
+- Validate the `decision_record` schema before writing to disk.
 
 Failure handling:
 - Email send error -> keep local deliverable, queue retry in next run.

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -283,6 +283,28 @@
   - `python scripts/validate_decision_record_schema.py` -> PASS
   - `python -m unittest tests.agent.test_decision_record_schema_validation -v` -> PASS (3 tests)
   - `python -m compileall -q scripts tests` -> PASS
-  - Outcome: PASS (decision record schema is now defined, validated, and enforced in CI)
+- Outcome: PASS (decision record schema is now defined, validated, and enforced in CI)
 - Next single step:
   - Implement remaining P0 task: wire `decision_record` generation into synthesis pipeline output with one fixture
+
+[2026-03-09 Session 19] Re-landed missing stage10 decision-record persistence onto default-branch fix branch
+- Root cause investigated:
+  - Confirmed PR `#20` was marked merged on GitHub but its stage10 implementation never landed on `master`
+  - Verified the stacked PR had been merged on top of `feat/decision-record-schema`, leaving `master` without the stage10 files
+- Created:
+  - `apps/agent/pipeline/stage10_decision_record.py`
+  - `tests/agent/pipeline/test_stage10_decision_record.py`
+  - `artifacts/modelling/examples/decision_record_pipeline_fixture.json`
+- Updated:
+  - `tests/agent/test_decision_record_schema_validation.py`
+  - `artifacts/modelling/TODO.md`
+  - `artifacts/modelling/pipeline.md`
+- Verification run + outcome:
+  - `python -m unittest tests.agent.pipeline.test_stage10_decision_record -v` -> PASS (4 tests)
+  - `python -m unittest tests.agent.test_decision_record_schema_validation -v` -> PASS (8 tests)
+  - `python scripts/validate_decision_record_schema.py` -> PASS
+  - `python -m compileall -q apps tests scripts evals` -> PASS
+  - `python -m unittest discover -s tests -p "test_*.py" -v` -> PASS (42 tests)
+  - Outcome: PASS (stage10 decision-record persistence is restored with coverage and modelling docs aligned)
+- Next single step:
+  - Commit fix branch changes, open PR against `master`, and link it back to issue `#22`

--- a/tests/agent/pipeline/test_stage10_decision_record.py
+++ b/tests/agent/pipeline/test_stage10_decision_record.py
@@ -1,0 +1,173 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from apps.agent.pipeline.stage10_decision_record import build_and_persist_decision_record
+from scripts.validate_decision_record_schema import validate_decision_record
+
+
+class Stage10DecisionRecordTests(unittest.TestCase):
+    def test_persists_decision_record_to_date_partitioned_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "daily" / "2026-02-19" / "brief.html"
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text("<html>brief</html>", encoding="utf-8")
+
+            result = build_and_persist_decision_record(
+                base_dir=Path(tmpdir),
+                run_id="run_123",
+                run_type="daily_brief",
+                stage8_status="partial",
+                synthesis={
+                    "prevailing": [
+                        {
+                            "text": "Claim",
+                            "citation_ids": ["c1"],
+                        }
+                    ]
+                },
+                removed_bullets=1,
+                budget_snapshot={
+                    "hourly_spend_usd": 0.03,
+                    "hourly_cap_usd": 0.10,
+                    "daily_spend_usd": 0.8,
+                    "daily_cap_usd": 3.0,
+                    "monthly_spend_usd": 12.4,
+                    "monthly_cap_usd": 100.0,
+                    "allowed": True,
+                },
+                guardrail_checks={
+                    "citation_check": "warn",
+                    "paywall_check": "pass",
+                    "diversity_check": "pass",
+                    "budget_check": "pass",
+                    "notes": ["1 uncited claim downgraded"],
+                },
+                output_path=output_path,
+                generated_at_utc="2026-02-19T08:00:00Z",
+            )
+
+            record_path = Path(result["record_path"])
+            self.assertTrue(record_path.exists())
+            self.assertIn("decision_records", str(record_path))
+            expected = Path(tmpdir) / "artifacts" / "decision_records" / "2026-02-19" / "run_123.json"
+            self.assertEqual(record_path, expected)
+
+            persisted = json.loads(record_path.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["schema_version"], "decision_record.v1")
+            self.assertEqual(persisted["run_id"], "run_123")
+            self.assertEqual(persisted["run_type"], "daily_brief")
+            self.assertEqual(persisted["status"], "partial")
+            self.assertEqual(persisted["artifacts"]["output_path"], str(output_path))
+            self.assertTrue(persisted["artifacts"]["output_sha256"])
+            self.assertEqual(validate_decision_record(persisted), [])
+
+    def test_missing_output_artifact_downgrades_to_failed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = build_and_persist_decision_record(
+                base_dir=Path(tmpdir),
+                run_id="run_missing_output",
+                run_type="daily_brief",
+                stage8_status="ok",
+                synthesis={"prevailing": [{"text": "Claim", "citation_ids": ["c1"]}]},
+                removed_bullets=0,
+                budget_snapshot={
+                    "hourly_spend_usd": 0.03,
+                    "hourly_cap_usd": 0.10,
+                    "daily_spend_usd": 0.8,
+                    "daily_cap_usd": 3.0,
+                    "monthly_spend_usd": 12.4,
+                    "monthly_cap_usd": 100.0,
+                    "allowed": True,
+                },
+                guardrail_checks={
+                    "citation_check": "pass",
+                    "paywall_check": "pass",
+                    "diversity_check": "pass",
+                    "budget_check": "pass",
+                    "notes": [],
+                },
+                output_path=None,
+            )
+
+            persisted = result["decision_record"]
+            self.assertEqual(persisted["status"], "failed")
+            self.assertEqual(validate_decision_record(persisted), [])
+
+    def test_counterarguments_section_is_normalized_to_counter(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "daily" / "2026-02-19" / "brief.html"
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text("<html>brief</html>", encoding="utf-8")
+
+            result = build_and_persist_decision_record(
+                base_dir=Path(tmpdir),
+                run_id="run_section_norm",
+                run_type="daily_brief",
+                stage8_status="ok",
+                synthesis={"counterarguments": [{"text": "Counter claim", "citation_ids": ["c2"]}]},
+                removed_bullets=0,
+                budget_snapshot={
+                    "hourly_spend_usd": 0.03,
+                    "hourly_cap_usd": 0.10,
+                    "daily_spend_usd": 0.8,
+                    "daily_cap_usd": 3.0,
+                    "monthly_spend_usd": 12.4,
+                    "monthly_cap_usd": 100.0,
+                    "allowed": True,
+                },
+                guardrail_checks={
+                    "citation_check": "pass",
+                    "paywall_check": "pass",
+                    "diversity_check": "pass",
+                    "budget_check": "pass",
+                    "notes": [],
+                },
+                output_path=output_path,
+            )
+
+            sections = [claim["section"] for claim in result["decision_record"]["claims"]]
+            self.assertIn("counter", sections)
+            self.assertNotIn("counterarguments", sections)
+            self.assertEqual(validate_decision_record(result["decision_record"]), [])
+
+    def test_non_schema_sections_are_filtered_out(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "daily" / "2026-02-19" / "brief.html"
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text("<html>brief</html>", encoding="utf-8")
+
+            result = build_and_persist_decision_record(
+                base_dir=Path(tmpdir),
+                run_id="run_filter_sections",
+                run_type="daily_brief",
+                stage8_status="ok",
+                synthesis={"metadata": [{"text": "Meta note", "citation_ids": ["c9"]}]},
+                removed_bullets=0,
+                budget_snapshot={
+                    "hourly_spend_usd": 0.03,
+                    "hourly_cap_usd": 0.10,
+                    "daily_spend_usd": 0.8,
+                    "daily_cap_usd": 3.0,
+                    "monthly_spend_usd": 12.4,
+                    "monthly_cap_usd": 100.0,
+                    "allowed": True,
+                },
+                guardrail_checks={
+                    "citation_check": "pass",
+                    "paywall_check": "pass",
+                    "diversity_check": "pass",
+                    "budget_check": "pass",
+                    "notes": [],
+                },
+                output_path=output_path,
+            )
+
+            sections = [claim["section"] for claim in result["decision_record"]["claims"]]
+            self.assertEqual(sections, [])
+            self.assertEqual(validate_decision_record(result["decision_record"]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/test_decision_record_schema_validation.py
+++ b/tests/agent/test_decision_record_schema_validation.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 from scripts.validate_decision_record_schema import validate_decision_record, validate_example_file
 
@@ -6,6 +7,12 @@ from scripts.validate_decision_record_schema import validate_decision_record, va
 class DecisionRecordSchemaValidationTests(unittest.TestCase):
     def test_valid_example_passes(self):
         errors = validate_example_file()
+        self.assertEqual(errors, [])
+
+    def test_pipeline_fixture_passes(self):
+        errors = validate_example_file(
+            Path("artifacts/modelling/examples/decision_record_pipeline_fixture.json")
+        )
         self.assertEqual(errors, [])
 
     def test_supported_claim_requires_citation(self):


### PR DESCRIPTION
## Summary
- restore the missing stage10 decision_record persistence module onto the default-branch line
- re-land the stage10 regression tests and persisted fixture coverage
- align modelling docs/progress with the restored P0 pipeline capability

## Root cause
PR #20 was stacked on `feat/decision-record-schema` and showed as merged on GitHub, but its stage10 commits never landed on `master`.

## Validation
- python -m unittest tests.agent.pipeline.test_stage10_decision_record -v
- python -m unittest tests.agent.test_decision_record_schema_validation -v
- python scripts/validate_decision_record_schema.py
- python -m compileall -q apps tests scripts evals
- python -m unittest discover -s tests -p "test_*.py" -v

Fixes #22
