### PR TITLE
docs: correct backlog status drift

### DIFF
--- a/artifacts/modelling/backlog.json
+++ b/artifacts/modelling/backlog.json
@@ -41,7 +41,7 @@
     {
       "id": "M003",
       "title": "Implement chunking and FTS indexing pipeline",
-      "status": "implemented",
+      "status": "planned",
       "priority": "P0",
       "depends_on": ["M002"],
       "files": [
@@ -73,7 +73,7 @@
     {
       "id": "M005",
       "title": "Implement runtime budget guard",
-      "status": "planned",
+      "status": "implemented",
       "priority": "P0",
       "depends_on": ["M001"],
       "files": [


### PR DESCRIPTION
## Summary
- correct the merged backlog metadata so `M003` is no longer shown as implemented
- mark `M005` as implemented to match the merged runtime budget guard work
- keep the fix scoped to `artifacts/modelling/backlog.json`

## Test Plan
- python scripts/validate_artifacts.py

Closes #29