### PR TITLE
feat(retrieval): add evidence pack retrieval helper

### DIFF
--- a/apps/agent/retrieval/evidence_pack.py
+++ b/apps/agent/retrieval/evidence_pack.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def build_evidence_pack(
+    *,
+    fts_rows: Iterable[Mapping[str, Any]],
+    query_text: str,
+    pack_size: int = 30,
+) -> list[dict[str, Any]]:
+    query_terms = _tokenize(query_text)
+    candidate_rows = list(fts_rows)
+    if not query_terms or pack_size <= 0:
+        return []
+
+    matching_rows: list[dict[str, Any]] = []
+    for row in candidate_rows:
+        _validate_row(row)
+        keyword_score = _keyword_score(text=str(row["text"]), query_terms=query_terms)
+        if keyword_score <= 0:
+            continue
+        matching_rows.append(
+            {
+                "row": row,
+                "keyword_score": keyword_score,
+                "published_timestamp": _published_timestamp(row),
+            }
+        )
+
+    published_timestamps = [row["published_timestamp"] for row in matching_rows]
+    oldest_timestamp = min(published_timestamps, default=0.0)
+    newest_timestamp = max(published_timestamps, default=0.0)
+
+    scored_rows: list[dict[str, Any]] = []
+    for match in matching_rows:
+        row = match["row"]
+        recency_score = _recency_score(
+            published_timestamp=float(match["published_timestamp"]),
+            oldest_timestamp=oldest_timestamp,
+            newest_timestamp=newest_timestamp,
+        )
+        credibility_score = _credibility_score(int(row["credibility_tier"]))
+        retrieval_score = round(float(match["keyword_score"]) * 0.5 + recency_score * 0.3 + credibility_score * 0.2, 6)
+
+        scored_rows.append(
+            {
+                "chunk_id": row["chunk_id"],
+                "source_id": row["source_id"],
+                "publisher": row["publisher"],
+                "credibility_tier": row["credibility_tier"],
+                "retrieval_score": retrieval_score,
+                "semantic_score": None,
+                "recency_score": recency_score,
+                "credibility_score": credibility_score,
+                "_published_timestamp": match["published_timestamp"],
+            }
+        )
+
+    scored_rows.sort(
+        key=lambda row: (
+            -float(row["retrieval_score"]),
+            -float(row["_published_timestamp"]),
+            str(row["chunk_id"]),
+        )
+    )
+
+    pack_rows: list[dict[str, Any]] = []
+    for index, row in enumerate(scored_rows[:pack_size], start=1):
+        pack_rows.append(
+            {
+                "chunk_id": row["chunk_id"],
+                "source_id": row["source_id"],
+                "publisher": row["publisher"],
+                "credibility_tier": row["credibility_tier"],
+                "retrieval_score": row["retrieval_score"],
+                "semantic_score": row["semantic_score"],
+                "recency_score": row["recency_score"],
+                "credibility_score": row["credibility_score"],
+                "rank_in_pack": index,
+            }
+        )
+
+    return pack_rows
+
+
+def _tokenize(value: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", value.lower())
+
+
+def _keyword_score(*, text: str, query_terms: list[str]) -> float:
+    tokens = _tokenize(text)
+    return float(sum(tokens.count(term) for term in query_terms))
+
+
+def _published_timestamp(row: Mapping[str, Any]) -> float:
+    published_at = row.get("published_at")
+    if not published_at:
+        return 0.0
+    try:
+        return datetime.fromisoformat(str(published_at).replace("Z", "+00:00")).astimezone(timezone.utc).timestamp()
+    except ValueError as exc:
+        raise ValueError(f"Invalid evidence-pack row published_at value: {published_at}") from exc
+
+
+def _recency_score(
+    *,
+    published_timestamp: float,
+    oldest_timestamp: float,
+    newest_timestamp: float,
+) -> float:
+    if newest_timestamp <= oldest_timestamp:
+        return 1.0
+    return round((published_timestamp - oldest_timestamp) / (newest_timestamp - oldest_timestamp), 6)
+
+
+def _credibility_score(credibility_tier: int) -> float:
+    scores = {
+        1: 1.0,
+        2: 0.8,
+        3: 0.6,
+        4: 0.3,
+    }
+    if credibility_tier not in scores:
+        raise ValueError(f"Invalid evidence-pack credibility tier: {credibility_tier}")
+    return scores[credibility_tier]
+
+
+def _validate_row(row: Mapping[str, Any]) -> None:
+    required_fields = ("chunk_id", "text", "source_id", "publisher", "credibility_tier")
+    missing_fields = [field for field in required_fields if row.get(field) in (None, "")]
+    if missing_fields:
+        raise ValueError(f"Invalid evidence-pack row: missing {', '.join(missing_fields)}")

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -429,3 +429,25 @@
 - Outcome: PASS (M004 now has the missing deterministic abstain postprocess needed for downstream delivery contracts)
 - Next single step:
   - Open PR for issue `#39`, perform reviewer pass, address findings if any, merge, and summarize the outcome on the issue
+
+[2026-03-10 Session 25] Implemented issue #41 evidence-pack retrieval helper
+- Created:
+  - `apps/agent/retrieval/evidence_pack.py`
+  - `tests/agent/retrieval/test_evidence_pack.py`
+- Updated:
+  - `docs/plans/2026-03-10-issue-41-evidence-pack-design.md`
+  - `docs/plans/2026-03-10-issue-41-evidence-pack-implementation-plan.md`
+  - `claude-progress.txt`
+- Implemented:
+  - deterministic evidence-pack assembly from FTS-shaped rows
+  - retrieval scoring using keyword, recency, and credibility components
+  - bounded pack-size enforcement with stable rank ordering
+  - evidence-pack-item-compatible output rows for downstream synthesis work
+  - explicit validation for missing required fields and unsupported credibility tiers
+- Verification run + outcome:
+  - `python -m unittest tests.agent.retrieval.test_evidence_pack -v` -> PASS (7 tests)
+  - `python -m unittest discover -s tests -p "test_*.py" -v` -> PASS (78 tests)
+  - `python -m compileall -q apps tests scripts evals` -> PASS
+- Outcome: PASS (issue `#41` now has an executable retrieval helper that bridges indexed chunks to evidence-pack assembly)
+- Next single step:
+  - Open PR for issue `#41`, perform reviewer pass, address findings if any, merge, and summarize the outcome on the issue

--- a/docs/plans/2026-03-10-issue-41-evidence-pack-design.md
+++ b/docs/plans/2026-03-10-issue-41-evidence-pack-design.md
@@ -1,0 +1,136 @@
+# Issue #41 Evidence-Pack Retrieval Design
+
+## Goal
+
+Build the next retrieval runtime slice after chunking and FTS indexing: a deterministic helper that converts indexed chunk candidates into evidence-pack-item-compatible rows for downstream synthesis.
+
+## Scope
+
+This slice covers:
+- deterministic ranking over FTS-shaped rows
+- retrieval score composition from keyword, recency, and credibility inputs
+- bounded pack-size enforcement
+- evidence-pack-item-compatible output rows with stable ranking
+- focused unit tests for ordering and size caps
+
+This slice does not cover:
+- semantic/vector retrieval
+- full diversity enforcement by publisher or tier quotas
+- SQLite persistence for `evidence_packs` or `evidence_pack_items`
+- synthesis or delivery wiring
+
+## Why This Slice
+
+The repository already implements:
+- ingestion primitives
+- document chunking
+- FTS-shaped indexing rows
+- citation validation and abstain postprocess
+
+The next concrete runtime gap is Stage 6 evidence retrieval. A deterministic helper closes that contract gap without prematurely expanding into the whole daily-brief vertical slice.
+
+## Approaches Considered
+
+### Option A: Deterministic in-memory evidence-pack builder
+
+Take FTS-shaped rows plus source metadata, compute a retrieval score, sort, and emit bounded pack rows.
+
+Why this is preferred:
+- smallest useful runtime step
+- directly addresses issue `#41`
+- easy to test locally without database or network dependencies
+
+### Option B: Full Stage 6 retrieval implementation now
+
+Add pack assembly plus diversity constraints and future synthesis hooks.
+
+Why this is not preferred:
+- expands scope into multiple modelling concerns at once
+- makes the first retrieval MR harder to review and stabilize
+
+### Option C: Extend `search_fts_rows()` only
+
+Add more fields to the existing search helper and stop there.
+
+Why this is not preferred:
+- leaves no explicit evidence-pack contract
+- pushes ranking and row shaping complexity into the wrong module boundary
+
+## Selected Design
+
+### Module Layout
+
+- `apps/agent/retrieval/evidence_pack.py`
+  - build scored evidence candidates from FTS-shaped rows
+  - normalize recency and credibility inputs
+  - sort and truncate to the requested pack size
+  - emit evidence-pack-item-compatible dictionaries
+
+- `tests/agent/retrieval/test_evidence_pack.py`
+  - relevance ordering test
+  - pack-size cap test
+  - stable tie-break ordering test
+
+### Input Contract
+
+The helper will operate on rows that already contain:
+- `chunk_id`
+- `doc_id`
+- `text`
+- `source_id`
+- `publisher`
+- `published_at`
+- `credibility_tier`
+
+This keeps the module downstream of current FTS row generation while extending the row shape only as much as retrieval now requires.
+
+### Scoring
+
+The first slice uses a deterministic composite score:
+
+`retrieval_score = keyword_score * 0.5 + recency_score * 0.3 + credibility_score * 0.2`
+
+Where:
+- `keyword_score` comes from exact token frequency over query terms
+- `recency_score` prefers newer rows based on `published_at`
+- `credibility_score` maps tiers as:
+  - Tier 1 -> `1.0`
+  - Tier 2 -> `0.8`
+  - Tier 3 -> `0.6`
+  - Tier 4 -> `0.3`
+
+### Output Contract
+
+Each output row will match the `evidence_pack_items` contract shape needed later:
+- `chunk_id`
+- `source_id`
+- `publisher`
+- `credibility_tier`
+- `retrieval_score`
+- `semantic_score` set to `None`
+- `recency_score`
+- `credibility_score`
+- `rank_in_pack`
+
+### Ordering Rules
+
+- sort by descending `retrieval_score`
+- break ties by descending `published_at`
+- break remaining ties by ascending `chunk_id`
+
+This keeps output deterministic for tests and future reviewers.
+
+### Error Handling
+
+- invalid or missing required row fields should raise `ValueError`
+- missing `published_at` should be treated as the oldest possible item
+- invalid credibility tiers should raise `ValueError`
+
+### Testing Strategy
+
+Tests will verify:
+- stronger keyword match outranks weaker match when other factors are comparable
+- newer, more credible rows can outrank older, weaker rows when text relevance is similar
+- the final pack is capped at the requested size
+- tie-breaks remain stable and deterministic
+

--- a/docs/plans/2026-03-10-issue-41-evidence-pack-implementation-plan.md
+++ b/docs/plans/2026-03-10-issue-41-evidence-pack-implementation-plan.md
@@ -1,0 +1,148 @@
+# Issue #41 Evidence-Pack Retrieval Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a deterministic evidence-pack retrieval helper that ranks indexed chunk rows, caps final pack size, and emits evidence-pack-item-compatible rows.
+
+**Architecture:** Add a narrow retrieval module downstream of FTS row generation. Keep it in-memory and deterministic so it can validate the evidence-pack contract before SQLite persistence or broader Stage 6 diversity logic exists.
+
+**Tech Stack:** Python 3.11+, `datetime`, `math`, `unittest`
+
+---
+
+### Task 1: Add evidence-pack ordering tests
+
+**Files:**
+- Create: `tests/agent/retrieval/test_evidence_pack.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+- stronger text relevance ranks ahead of weaker relevance
+- bounded result size truncates the final pack
+- ties resolve deterministically
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.agent.retrieval.test_evidence_pack -v`
+Expected: FAIL because `apps.agent.retrieval.evidence_pack` does not exist.
+
+**Step 3: Write minimal implementation shape**
+
+Create a module stub with a public function:
+
+```python
+def build_evidence_pack(*, fts_rows, query_text, pack_size=30):
+    raise NotImplementedError
+```
+
+**Step 4: Run test to verify it still fails for missing behavior**
+
+Run: `python -m unittest tests.agent.retrieval.test_evidence_pack -v`
+Expected: FAIL on `NotImplementedError` or assertion mismatch rather than import failure.
+
+**Step 5: Commit**
+
+```bash
+git add tests/agent/retrieval/test_evidence_pack.py apps/agent/retrieval/evidence_pack.py
+git commit -m "test(retrieval): scaffold evidence pack retrieval coverage"
+```
+
+### Task 2: Implement scoring and bounded pack assembly
+
+**Files:**
+- Create: `apps/agent/retrieval/evidence_pack.py`
+- Modify: `tests/agent/retrieval/test_evidence_pack.py`
+
+**Step 1: Write the next failing test**
+
+Add a test asserting:
+- the output row contains `source_id`, `publisher`, `credibility_tier`, `retrieval_score`, `semantic_score`, `recency_score`, `credibility_score`, and `rank_in_pack`
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.agent.retrieval.test_evidence_pack -v`
+Expected: FAIL because output rows do not yet match the evidence-pack-item contract.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- query token counting
+- recency normalization from `published_at`
+- credibility score mapping
+- deterministic sort and truncation
+- evidence-pack-item-compatible output rows
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m unittest tests.agent.retrieval.test_evidence_pack -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/agent/retrieval/evidence_pack.py tests/agent/retrieval/test_evidence_pack.py
+git commit -m "feat(retrieval): add evidence pack retrieval helper"
+```
+
+### Task 3: Add defensive validation
+
+**Files:**
+- Modify: `apps/agent/retrieval/evidence_pack.py`
+- Modify: `tests/agent/retrieval/test_evidence_pack.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+- missing required row fields raise `ValueError`
+- unsupported credibility tiers raise `ValueError`
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.agent.retrieval.test_evidence_pack -v`
+Expected: FAIL because validation is incomplete.
+
+**Step 3: Write minimal implementation**
+
+Add row validation helpers for required fields, timestamp parsing, and supported tier mapping.
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m unittest tests.agent.retrieval.test_evidence_pack -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/agent/retrieval/evidence_pack.py tests/agent/retrieval/test_evidence_pack.py
+git commit -m "feat(retrieval): validate evidence pack inputs"
+```
+
+### Task 4: Full verification and progress logging
+
+**Files:**
+- Modify: `claude-progress.txt`
+
+**Step 1: Update progress log**
+
+Append the evidence-pack retrieval summary, validation commands, and next step to `claude-progress.txt`.
+
+**Step 2: Run verification**
+
+Run:
+- `python -m unittest tests.agent.retrieval.test_evidence_pack -v`
+- `python -m unittest discover -s tests -p "test_*.py" -v`
+- `python -m compileall -q apps tests scripts evals`
+
+Expected:
+- evidence-pack tests PASS
+- full suite PASS
+- compile check PASS
+
+**Step 3: Commit**
+
+```bash
+git add claude-progress.txt
+git commit -m "docs: log evidence pack retrieval progress"
+```
+

--- a/tests/agent/retrieval/test_evidence_pack.py
+++ b/tests/agent/retrieval/test_evidence_pack.py
@@ -1,0 +1,220 @@
+import unittest
+
+from apps.agent.retrieval.evidence_pack import build_evidence_pack
+
+
+class EvidencePackTests(unittest.TestCase):
+    def test_orders_results_by_retrieval_score(self):
+        fts_rows = [
+            {
+                "chunk_id": "chunk_002",
+                "doc_id": "doc_002",
+                "text": "inflation slows but rates stay restrictive",
+                "source_id": "src_reuters",
+                "publisher": "Reuters",
+                "published_at": "2026-03-08T10:00:00Z",
+                "credibility_tier": 2,
+            },
+            {
+                "chunk_id": "chunk_001",
+                "doc_id": "doc_001",
+                "text": "inflation inflation inflation and rates",
+                "source_id": "src_fed",
+                "publisher": "Federal Reserve",
+                "published_at": "2026-03-10T10:00:00Z",
+                "credibility_tier": 1,
+            },
+            {
+                "chunk_id": "chunk_003",
+                "doc_id": "doc_003",
+                "text": "employment gains accelerate",
+                "source_id": "src_blog",
+                "publisher": "Macro Blog",
+                "published_at": "2026-03-10T08:00:00Z",
+                "credibility_tier": 3,
+            },
+        ]
+
+        pack = build_evidence_pack(fts_rows=fts_rows, query_text="inflation rates", pack_size=3)
+
+        self.assertEqual([row["chunk_id"] for row in pack], ["chunk_001", "chunk_002"])
+        self.assertEqual(pack[0]["rank_in_pack"], 1)
+        self.assertEqual(pack[1]["rank_in_pack"], 2)
+        self.assertGreater(pack[0]["retrieval_score"], pack[1]["retrieval_score"])
+
+    def test_caps_pack_size_after_sorting(self):
+        fts_rows = [
+            {
+                "chunk_id": "chunk_003",
+                "doc_id": "doc_003",
+                "text": "inflation",
+                "source_id": "src_c",
+                "publisher": "C",
+                "published_at": "2026-03-08T10:00:00Z",
+                "credibility_tier": 2,
+            },
+            {
+                "chunk_id": "chunk_001",
+                "doc_id": "doc_001",
+                "text": "inflation inflation",
+                "source_id": "src_a",
+                "publisher": "A",
+                "published_at": "2026-03-10T10:00:00Z",
+                "credibility_tier": 1,
+            },
+            {
+                "chunk_id": "chunk_002",
+                "doc_id": "doc_002",
+                "text": "inflation rates",
+                "source_id": "src_b",
+                "publisher": "B",
+                "published_at": "2026-03-09T10:00:00Z",
+                "credibility_tier": 2,
+            },
+        ]
+
+        pack = build_evidence_pack(fts_rows=fts_rows, query_text="inflation", pack_size=2)
+
+        self.assertEqual(len(pack), 2)
+        self.assertEqual([row["chunk_id"] for row in pack], ["chunk_001", "chunk_002"])
+
+    def test_tie_breaks_by_newer_timestamp_then_chunk_id(self):
+        fts_rows = [
+            {
+                "chunk_id": "chunk_002",
+                "doc_id": "doc_002",
+                "text": "inflation",
+                "source_id": "src_b",
+                "publisher": "B",
+                "published_at": "2026-03-09T10:00:00Z",
+                "credibility_tier": 2,
+            },
+            {
+                "chunk_id": "chunk_001",
+                "doc_id": "doc_001",
+                "text": "inflation",
+                "source_id": "src_a",
+                "publisher": "A",
+                "published_at": "2026-03-09T10:00:00Z",
+                "credibility_tier": 2,
+            },
+            {
+                "chunk_id": "chunk_003",
+                "doc_id": "doc_003",
+                "text": "inflation",
+                "source_id": "src_c",
+                "publisher": "C",
+                "published_at": "2026-03-10T10:00:00Z",
+                "credibility_tier": 2,
+            },
+        ]
+
+        pack = build_evidence_pack(fts_rows=fts_rows, query_text="inflation", pack_size=3)
+
+        self.assertEqual([row["chunk_id"] for row in pack], ["chunk_003", "chunk_001", "chunk_002"])
+
+    def test_emits_evidence_pack_item_compatible_rows(self):
+        fts_rows = [
+            {
+                "chunk_id": "chunk_001",
+                "doc_id": "doc_001",
+                "text": "inflation inflation",
+                "source_id": "src_a",
+                "publisher": "Federal Reserve",
+                "published_at": "2026-03-10T10:00:00Z",
+                "credibility_tier": 1,
+            }
+        ]
+
+        pack = build_evidence_pack(fts_rows=fts_rows, query_text="inflation", pack_size=1)
+
+        self.assertEqual(
+            pack,
+            [
+                {
+                    "chunk_id": "chunk_001",
+                    "source_id": "src_a",
+                    "publisher": "Federal Reserve",
+                    "credibility_tier": 1,
+                    "retrieval_score": pack[0]["retrieval_score"],
+                    "semantic_score": None,
+                    "recency_score": 1.0,
+                    "credibility_score": 1.0,
+                    "rank_in_pack": 1,
+                }
+            ],
+        )
+        self.assertGreater(pack[0]["retrieval_score"], 0.0)
+
+    def test_missing_required_row_field_raises_value_error(self):
+        fts_rows = [
+            {
+                "chunk_id": "chunk_001",
+                "doc_id": "doc_001",
+                "text": "inflation",
+                "source_id": "src_a",
+                "published_at": "2026-03-10T10:00:00Z",
+                "credibility_tier": 1,
+            }
+        ]
+
+        with self.assertRaises(ValueError):
+            build_evidence_pack(fts_rows=fts_rows, query_text="inflation", pack_size=1)
+
+    def test_invalid_credibility_tier_raises_value_error(self):
+        fts_rows = [
+            {
+                "chunk_id": "chunk_001",
+                "doc_id": "doc_001",
+                "text": "inflation",
+                "source_id": "src_a",
+                "publisher": "Federal Reserve",
+                "published_at": "2026-03-10T10:00:00Z",
+                "credibility_tier": 9,
+            }
+        ]
+
+        with self.assertRaises(ValueError):
+            build_evidence_pack(fts_rows=fts_rows, query_text="inflation", pack_size=1)
+
+    def test_recency_normalization_only_uses_matching_rows(self):
+        fts_rows = [
+            {
+                "chunk_id": "chunk_001",
+                "doc_id": "doc_001",
+                "text": "inflation inflation",
+                "source_id": "src_a",
+                "publisher": "Federal Reserve",
+                "published_at": "2026-03-09T10:00:00Z",
+                "credibility_tier": 1,
+            },
+            {
+                "chunk_id": "chunk_002",
+                "doc_id": "doc_002",
+                "text": "inflation rates",
+                "source_id": "src_b",
+                "publisher": "Reuters",
+                "published_at": "2026-03-10T10:00:00Z",
+                "credibility_tier": 2,
+            },
+            {
+                "chunk_id": "chunk_099",
+                "doc_id": "doc_099",
+                "text": "employment gains accelerate",
+                "source_id": "src_c",
+                "publisher": "Macro Blog",
+                "published_at": "2026-03-20T10:00:00Z",
+                "credibility_tier": 3,
+            },
+        ]
+
+        pack = build_evidence_pack(fts_rows=fts_rows, query_text="inflation", pack_size=2)
+
+        self.assertEqual(pack[0]["chunk_id"], "chunk_001")
+        self.assertEqual(pack[1]["chunk_id"], "chunk_002")
+        self.assertEqual(pack[0]["recency_score"], 0.0)
+        self.assertEqual(pack[1]["recency_score"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add deterministic evidence-pack retrieval over FTS-shaped rows
- score candidates using keyword, recency, and credibility inputs
- add focused tests for ordering, caps, validation, and deterministic tie-breaks

## Verification
- `python -m unittest tests.agent.retrieval.test_evidence_pack -v`
- `python -m unittest discover -s tests -p test_*.py -v`
- `python -m compileall -q apps tests scripts evals`

Closes #41