### PR TITLE
feat(evals): extend golden eval coverage

### DIFF
--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -451,3 +451,27 @@
 - Outcome: PASS (issue `#41` now has an executable retrieval helper that bridges indexed chunks to evidence-pack assembly)
 - Next single step:
   - Open PR for issue `#41`, perform reviewer pass, address findings if any, merge, and summarize the outcome on the issue
+
+[2026-03-10 Session 26] Extended eval harness for retrieval and abstain coverage
+- Created:
+  - `tests/evals/test_run_eval_suite.py`
+  - `evals/golden/case11.json`
+  - `evals/golden/case12.json`
+- Updated:
+  - `evals/run_eval_suite.py`
+  - `evals/README.md`
+  - `claude-progress.txt`
+- Implemented:
+  - multi-type eval dispatch for `citation`, `retrieval`, and `postprocess` cases
+  - retrieval golden coverage for evidence-pack ordering and pack-size bounds
+  - postprocess golden coverage for deterministic abstain output
+  - per-case exception handling so malformed eval inputs report failures instead of aborting the suite
+  - explicit README TODO for future chained `retrieval -> validation -> abstain` eval cases
+- Verification run + outcome:
+  - `python -m unittest tests.evals.test_run_eval_suite -v` -> PASS (6 tests)
+  - `python evals/run_eval_suite.py` -> PASS (12 golden cases)
+  - `python -m unittest discover -s tests -p "test_*.py" -v` -> PASS (78 tests)
+  - `python -m compileall -q apps tests scripts evals` -> PASS
+- Outcome: PASS (issue `#35` now has executable eval coverage beyond citation validation)
+- Next single step:
+  - Open PR for issue `#35`, perform reviewer pass, address findings if any, merge, and summarize the outcome on the issue

--- a/docs/plans/2026-03-10-issue-35-eval-harness-design.md
+++ b/docs/plans/2026-03-10-issue-35-eval-harness-design.md
@@ -1,0 +1,98 @@
+# Issue #35 Eval Harness Design
+
+## Goal
+
+Extend the existing eval harness so it catches regressions in retrieval ordering and abstain/postprocess behavior, not just citation validation.
+
+## Scope
+
+This slice covers:
+- extending `evals/run_eval_suite.py` with additional case dispatch
+- adding `retrieval` golden cases for evidence-pack ordering and pack-size bounds
+- adding `postprocess` golden cases for deterministic abstain handling
+- documenting the new case types and a follow-on TODO for chained end-to-end evals
+
+This slice does not cover:
+- delivery evals
+- alert evals
+- chained retrieval -> validation -> abstain execution in a single case
+- CI workflow restructuring
+
+## Why This Slice
+
+The repo already has:
+- citation validation runtime and golden evals
+- retrieval ranking/runtime helpers
+- deterministic abstain/postprocess behavior
+
+The missing piece is regression coverage across those newer contracts. Extending the existing harness is the smallest change that makes that coverage real.
+
+## Approaches Considered
+
+### Option A: Extend the existing golden-case runner
+
+Add new `type` values and case evaluators inside `evals/run_eval_suite.py`.
+
+Why this is preferred:
+- reuses the current harness shape
+- stays fast and deterministic
+- minimizes review surface
+
+### Option B: Add more citation-only cases
+
+Why this is not preferred:
+- does not measure retrieval or abstain behavior
+- leaves the most recent runtime slices uncovered
+
+### Option C: Build a mini end-to-end eval runner now
+
+Why this is not preferred:
+- too wide for the first increment
+- mixes multiple contracts and makes failures harder to localize
+
+## Selected Design
+
+### Runner Changes
+
+Extend `evals/run_eval_suite.py` to support:
+- `citation`
+- `retrieval`
+- `postprocess`
+
+Each case type gets:
+- a dedicated runner helper
+- a common failure-collection pattern
+
+### Golden Case Shapes
+
+#### `retrieval`
+- inputs:
+  - `query_text`
+  - `pack_size`
+  - `fts_rows`
+- expected:
+  - ordered `chunk_id` list
+  - expected pack length
+
+#### `postprocess`
+- inputs:
+  - `validation_result`
+- expected:
+  - final `status`
+  - `abstain_reason` when relevant
+  - optional per-section checks on the synthesized abstain output
+
+### Documentation
+
+Update `evals/README.md` to:
+- describe each supported case type
+- note the local command to run the suite
+- add an explicit TODO for future chained retrieval -> validation -> abstain eval cases
+
+### Testing Strategy
+
+Use TDD against the eval runner itself:
+- write failing tests for dispatch and failure reporting
+- add minimal golden fixtures that exercise the new case types
+- verify the runner stays compatible with the existing citation cases
+

--- a/docs/plans/2026-03-10-issue-35-eval-harness-implementation-plan.md
+++ b/docs/plans/2026-03-10-issue-35-eval-harness-implementation-plan.md
@@ -1,0 +1,147 @@
+# Issue #35 Eval Harness Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend the current eval harness so it validates retrieval ordering and abstain/postprocess behavior in addition to citation validation.
+
+**Architecture:** Preserve the existing golden-case runner and add narrow case-type dispatch instead of creating a separate eval framework. Keep all cases deterministic and offline-friendly so they remain fast in CI and local development.
+
+**Tech Stack:** Python 3.11+, `json`, `pathlib`, `unittest`
+
+---
+
+### Task 1: Add eval-runner tests for new case types
+
+**Files:**
+- Create: `tests/evals/test_run_eval_suite.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+- unknown case types still fail clearly
+- `retrieval` cases dispatch and validate expected ordering
+- `postprocess` cases dispatch and validate final abstain output
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.evals.test_run_eval_suite -v`
+Expected: FAIL because the eval runner does not expose the required helpers or behaviors yet.
+
+**Step 3: Write minimal implementation shape**
+
+Add the smallest test-facing hooks or refactors needed in `evals/run_eval_suite.py` so the runner logic is callable from tests.
+
+**Step 4: Run test to verify it still fails for missing behavior**
+
+Run: `python -m unittest tests.evals.test_run_eval_suite -v`
+Expected: FAIL on behavioral assertions rather than import errors.
+
+**Step 5: Commit**
+
+```bash
+git add tests/evals/test_run_eval_suite.py evals/run_eval_suite.py
+git commit -m "test(evals): scaffold multi-type eval runner coverage"
+```
+
+### Task 2: Implement retrieval and postprocess case dispatch
+
+**Files:**
+- Modify: `evals/run_eval_suite.py`
+- Modify: `tests/evals/test_run_eval_suite.py`
+
+**Step 1: Write the next failing test**
+
+Add assertions for:
+- retrieval case expected pack size
+- postprocess case expected abstain reason and status
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.evals.test_run_eval_suite -v`
+Expected: FAIL because the new case evaluators are incomplete.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- retrieval-case execution via `build_evidence_pack`
+- postprocess-case execution via `finalize_validation_outcome`
+- common failure formatting
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m unittest tests.evals.test_run_eval_suite -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add evals/run_eval_suite.py tests/evals/test_run_eval_suite.py
+git commit -m "feat(evals): add retrieval and postprocess eval coverage"
+```
+
+### Task 3: Add golden fixtures and README updates
+
+**Files:**
+- Create: `evals/golden/case11.json`
+- Create: `evals/golden/case12.json`
+- Modify: `evals/README.md`
+
+**Step 1: Write the failing test**
+
+Add tests or assertions that the new golden fixtures are loadable and that README-documented case types match actual runner support.
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.evals.test_run_eval_suite -v`
+Expected: FAIL because fixtures or docs are missing.
+
+**Step 3: Write minimal implementation**
+
+Add:
+- one retrieval golden case
+- one postprocess golden case
+- README documentation for supported case types
+- explicit TODO note for future chained retrieval -> validation -> abstain evals
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m unittest tests.evals.test_run_eval_suite -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add evals/golden/case11.json evals/golden/case12.json evals/README.md tests/evals/test_run_eval_suite.py
+git commit -m "docs(evals): add golden coverage for retrieval and abstain"
+```
+
+### Task 4: Full verification and progress logging
+
+**Files:**
+- Modify: `claude-progress.txt`
+
+**Step 1: Update progress log**
+
+Append the eval-harness extension summary, verification commands, and next step to `claude-progress.txt`.
+
+**Step 2: Run verification**
+
+Run:
+- `python -m unittest tests.evals.test_run_eval_suite -v`
+- `python evals/run_eval_suite.py`
+- `python -m unittest discover -s tests -p "test_*.py" -v`
+- `python -m compileall -q apps tests scripts evals`
+
+Expected:
+- eval-runner tests PASS
+- golden suite PASS
+- full suite PASS
+- compile check PASS
+
+**Step 3: Commit**
+
+```bash
+git add claude-progress.txt
+git commit -m "docs: log eval harness extension progress"
+```
+

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,6 +1,6 @@
 # Evals
 
-`run_eval_suite.py` executes golden citation-validation cases.
+`run_eval_suite.py` executes deterministic golden eval cases for current runtime contracts.
 
 ## Run
 
@@ -12,5 +12,11 @@ python evals/run_eval_suite.py
 
 - Path: `evals/golden/case*.json`
 - Minimum required: 10
-- Type:
+- Supported types:
   - `citation`: validates stage-8 citation behavior (`ok`/`partial`/`retry`)
+  - `retrieval`: validates evidence-pack ordering and pack-size enforcement
+  - `postprocess`: validates abstain shaping for failed validation outcomes
+
+## TODO
+
+- Add chained `retrieval -> validation -> abstain` golden cases once the first integrated path is ready.

--- a/evals/golden/case11.json
+++ b/evals/golden/case11.json
@@ -1,0 +1,42 @@
+{
+    "id": "RET-011",
+    "type": "retrieval",
+    "query_text": "inflation",
+    "pack_size": 2,
+    "fts_rows": [
+        {
+            "chunk_id": "chunk_001",
+            "doc_id": "doc_001",
+            "text": "inflation inflation and rates",
+            "source_id": "src_fed",
+            "publisher": "Federal Reserve",
+            "published_at": "2026-03-10T10:00:00Z",
+            "credibility_tier": 1
+        },
+        {
+            "chunk_id": "chunk_002",
+            "doc_id": "doc_002",
+            "text": "inflation cools",
+            "source_id": "src_reuters",
+            "publisher": "Reuters",
+            "published_at": "2026-03-09T10:00:00Z",
+            "credibility_tier": 2
+        },
+        {
+            "chunk_id": "chunk_003",
+            "doc_id": "doc_003",
+            "text": "employment gains accelerate",
+            "source_id": "src_blog",
+            "publisher": "Macro Blog",
+            "published_at": "2026-03-10T08:00:00Z",
+            "credibility_tier": 3
+        }
+    ],
+    "expected": {
+        "chunk_ids": [
+            "chunk_001",
+            "chunk_002"
+        ],
+        "pack_size": 2
+    }
+}

--- a/evals/golden/case12.json
+++ b/evals/golden/case12.json
@@ -1,0 +1,23 @@
+{
+    "id": "POST-012",
+    "type": "postprocess",
+    "validation_result": {
+        "status": "retry",
+        "synthesis": {
+            "prevailing": [
+                {
+                    "text": "[Insufficient evidence to support this claim]",
+                    "citation_ids": []
+                }
+            ]
+        },
+        "report": {
+            "removed_bullets": 4
+        }
+    },
+    "expected": {
+        "status": "abstained",
+        "abstain_reason": "validation_retry_exhausted",
+        "core_section_text": "[Insufficient evidence to produce a validated output]"
+    }
+}

--- a/evals/run_eval_suite.py
+++ b/evals/run_eval_suite.py
@@ -10,6 +10,8 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from apps.agent.pipeline.stage8_validation import run_stage8_citation_validation
+from apps.agent.retrieval.evidence_pack import build_evidence_pack
+from apps.agent.synthesis.postprocess import CORE_SECTIONS, finalize_validation_outcome
 
 
 def _load_cases(golden_dir: Path) -> List[Dict[str, Any]]:
@@ -34,6 +36,64 @@ def _run_citation_case(case: Dict[str, Any]) -> List[str]:
     return errors
 
 
+def _run_retrieval_case(case: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+    result = build_evidence_pack(
+        fts_rows=case["fts_rows"],
+        query_text=case["query_text"],
+        pack_size=case.get("pack_size", 30),
+    )
+
+    expected_chunk_ids = case["expected"].get("chunk_ids")
+    if expected_chunk_ids is not None:
+        actual_chunk_ids = [row["chunk_id"] for row in result]
+        if actual_chunk_ids != expected_chunk_ids:
+            errors.append(f"expected chunk_ids={expected_chunk_ids}, got {actual_chunk_ids}")
+
+    expected_pack_size = case["expected"].get("pack_size")
+    if expected_pack_size is not None and len(result) != expected_pack_size:
+        errors.append(f"expected pack_size={expected_pack_size}, got {len(result)}")
+
+    return errors
+
+
+def _run_postprocess_case(case: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+    result = finalize_validation_outcome(validation_result=case["validation_result"])
+
+    expected_status = case["expected"]["status"]
+    if result["status"] != expected_status:
+        errors.append(f"expected status={expected_status}, got {result['status']}")
+
+    expected_reason = case["expected"].get("abstain_reason")
+    if expected_reason is not None and result["abstain_reason"] != expected_reason:
+        errors.append(f"expected abstain_reason={expected_reason}, got {result['abstain_reason']}")
+
+    expected_core_text = case["expected"].get("core_section_text")
+    if expected_core_text is not None:
+        for section in CORE_SECTIONS:
+            section_text = result["synthesis"][section][0]["text"]
+            if section_text != expected_core_text:
+                errors.append(f"expected {section}[0].text={expected_core_text}, got {section_text}")
+
+    return errors
+
+
+def _run_case(case: Dict[str, Any]) -> List[str]:
+    case_id = case.get("id", "unknown")
+    case_type = case.get("type")
+    try:
+        if case_type == "citation":
+            return [f"{case_id}: {error}" for error in _run_citation_case(case)]
+        if case_type == "retrieval":
+            return [f"{case_id}: {error}" for error in _run_retrieval_case(case)]
+        if case_type == "postprocess":
+            return [f"{case_id}: {error}" for error in _run_postprocess_case(case)]
+        return [f"{case_id}: unknown case type: {case_type}"]
+    except Exception as exc:
+        return [f"{case_id}: exception: {exc}"]
+
+
 def main() -> int:
     golden_dir = ROOT / "evals" / "golden"
     cases = _load_cases(golden_dir)
@@ -44,16 +104,7 @@ def main() -> int:
 
     failures: List[str] = []
     for case in cases:
-        case_id = case.get("id", "unknown")
-        case_type = case.get("type")
-
-        if case_type != "citation":
-            failures.append(f"{case_id}: unknown case type: {case_type}")
-            continue
-
-        errors = _run_citation_case(case)
-        for error in errors:
-            failures.append(f"{case_id}: {error}")
+        failures.extend(_run_case(case))
 
     if failures:
         print("FAIL")

--- a/tests/evals/test_run_eval_suite.py
+++ b/tests/evals/test_run_eval_suite.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+import unittest
+
+from evals import run_eval_suite
+
+
+class EvalRunnerTests(unittest.TestCase):
+    def test_retrieval_case_passes_when_expected_order_and_size_match(self):
+        case = {
+            "type": "retrieval",
+            "query_text": "inflation",
+            "pack_size": 2,
+            "fts_rows": [
+                {
+                    "chunk_id": "chunk_001",
+                    "doc_id": "doc_001",
+                    "text": "inflation inflation",
+                    "source_id": "src_a",
+                    "publisher": "Federal Reserve",
+                    "published_at": "2026-03-10T10:00:00Z",
+                    "credibility_tier": 1,
+                },
+                {
+                    "chunk_id": "chunk_002",
+                    "doc_id": "doc_002",
+                    "text": "inflation",
+                    "source_id": "src_b",
+                    "publisher": "Reuters",
+                    "published_at": "2026-03-09T10:00:00Z",
+                    "credibility_tier": 2,
+                },
+            ],
+            "expected": {
+                "chunk_ids": ["chunk_001", "chunk_002"],
+                "pack_size": 2,
+            },
+        }
+
+        errors = run_eval_suite._run_retrieval_case(case)
+
+        self.assertEqual(errors, [])
+
+    def test_postprocess_case_passes_when_abstain_output_matches(self):
+        case = {
+            "type": "postprocess",
+            "validation_result": {
+                "status": "retry",
+                "synthesis": {
+                    "prevailing": [{"text": "[Insufficient evidence to support this claim]", "citation_ids": []}]
+                },
+                "report": {"removed_bullets": 4},
+            },
+            "expected": {
+                "status": "abstained",
+                "abstain_reason": "validation_retry_exhausted",
+            },
+        }
+
+        errors = run_eval_suite._run_postprocess_case(case)
+
+        self.assertEqual(errors, [])
+
+    def test_unknown_case_type_is_reported_by_main_dispatch(self):
+        case = {
+            "id": "BAD-001",
+            "type": "unknown",
+            "expected": {},
+        }
+
+        failure = run_eval_suite._run_case(case)
+
+        self.assertEqual(failure, ["BAD-001: unknown case type: unknown"])
+
+    def test_run_case_reports_runtime_exception_as_failure(self):
+        case = {
+            "id": "RET-ERR",
+            "type": "retrieval",
+            "query_text": "inflation",
+            "pack_size": 1,
+            "fts_rows": [
+                {
+                    "chunk_id": "chunk_001",
+                    "doc_id": "doc_001",
+                    "text": "inflation",
+                    "source_id": "src_a",
+                    "publisher": "Federal Reserve",
+                    "published_at": "2026-03-10T10:00:00Z",
+                    "credibility_tier": 9
+                }
+            ],
+            "expected": {
+                "chunk_ids": ["chunk_001"],
+                "pack_size": 1
+            }
+        }
+
+        failure = run_eval_suite._run_case(case)
+
+        self.assertEqual(len(failure), 1)
+        self.assertIn("RET-ERR: exception:", failure[0])
+
+    def test_golden_cases_include_retrieval_and_postprocess_types(self):
+        golden_dir = Path(run_eval_suite.ROOT / "evals" / "golden")
+
+        cases = run_eval_suite._load_cases(golden_dir)
+        case_types = {case["type"] for case in cases}
+
+        self.assertIn("retrieval", case_types)
+        self.assertIn("postprocess", case_types)
+
+    def test_readme_documents_supported_case_types_and_future_todo(self):
+        readme_text = (run_eval_suite.ROOT / "evals" / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("retrieval", readme_text)
+        self.assertIn("postprocess", readme_text)
+        self.assertIn("TODO", readme_text)
+        self.assertIn("retrieval -> validation -> abstain", readme_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend the eval harness with `retrieval` and `postprocess` golden case types
- add deterministic golden fixtures for evidence-pack ordering and abstain/postprocess behavior
- document the deferred chained `retrieval -> validation -> abstain` eval path as future TODO work

## Verification
- `python -m unittest tests.evals.test_run_eval_suite -v`
- `python evals/run_eval_suite.py`
- `python -m unittest discover -s tests -p test_*.py -v`
- `python -m compileall -q apps tests scripts evals`

Closes #35