### PR TITLE
feat(runtime): add v1 active source subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ Completed modelling artifacts:
 - `artifacts/modelling/alert_scoring.md`
 - `artifacts/modelling/backlog.json`
 
+Current runtime validation narrows the full catalogue to an active source subset first:
+- `artifacts/runtime/v1_active_sources.yaml`
+- initial US-first active source subset:
+  - `fed_press_releases`
+  - `us_bls_news`
+  - `us_bea_news`
+  - `reuters_business`
+  - `wsj_markets`
+
 ## Core Non-Negotiables
 
 1. No uncited factual claims in generated analysis.

--- a/apps/agent/runtime/source_scope.py
+++ b/apps/agent/runtime/source_scope.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_REGISTRY_PATH = ROOT / "artifacts" / "modelling" / "source_registry.yaml"
+DEFAULT_ACTIVE_IDS_PATH = ROOT / "artifacts" / "runtime" / "v1_active_sources.yaml"
+
+
+def load_source_registry(*, registry_path: Path | None = None) -> dict[str, dict[str, Any]]:
+    path = registry_path or DEFAULT_REGISTRY_PATH
+    with path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+
+    sources = payload.get("sources", [])
+    return {str(source["id"]): dict(source) for source in sources}
+
+
+def load_active_source_subset(
+    *,
+    registry: Mapping[str, Mapping[str, Any]] | None = None,
+    registry_path: Path | None = None,
+    active_ids_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    resolved_registry = dict(registry) if registry is not None else load_source_registry(registry_path=registry_path)
+    path = active_ids_path or DEFAULT_ACTIVE_IDS_PATH
+    with path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+
+    active_source_ids = payload.get("active_source_ids", [])
+    active_sources: list[dict[str, Any]] = []
+    missing_ids: list[str] = []
+
+    for source_id in active_source_ids:
+        source = resolved_registry.get(str(source_id))
+        if source is None:
+            missing_ids.append(str(source_id))
+            continue
+        active_sources.append(dict(source))
+
+    if missing_ids:
+        raise ValueError(f"Unknown active source ids: {', '.join(missing_ids)}")
+
+    return active_sources

--- a/artifacts/runtime/v1_active_sources.yaml
+++ b/artifacts/runtime/v1_active_sources.yaml
@@ -1,0 +1,8 @@
+profile: v1_us_first
+purpose: Narrow runtime validation to a small US-first source surface before broader expansion.
+active_source_ids:
+  - fed_press_releases
+  - us_bls_news
+  - us_bea_news
+  - reuters_business
+  - wsj_markets

--- a/claude-progress.txt
+++ b/claude-progress.txt
@@ -475,3 +475,27 @@
 - Outcome: PASS (issue `#35` now has executable eval coverage beyond citation validation)
 - Next single step:
   - Open PR for issue `#35`, perform reviewer pass, address findings if any, merge, and summarize the outcome on the issue
+
+[2026-03-10 Session 27] Added v1 active source subset for runtime validation
+- Created:
+  - `artifacts/runtime/v1_active_sources.yaml`
+  - `apps/agent/runtime/source_scope.py`
+  - `tests/agent/runtime/test_source_scope.py`
+- Updated:
+  - `scripts/validate_artifacts.py`
+  - `README.md`
+  - `claude-progress.txt`
+- Implemented:
+  - explicit US-first runtime allowlist artifact for the v1 active source subset
+  - deterministic helper to resolve the subset against the full source registry
+  - validation that unknown active IDs fail clearly
+  - README guidance that runtime validation targets the active subset first
+  - artifact validation coverage for the new runtime subset artifact
+- Verification run + outcome:
+  - `python -m unittest tests.agent.runtime.test_source_scope -v` -> PASS (5 tests)
+  - `python scripts/validate_artifacts.py` -> PASS
+  - `python -m unittest discover -s tests -p "test_*.py" -v` -> PASS (83 tests)
+  - `python -m compileall -q apps tests scripts evals` -> PASS
+- Outcome: PASS (issue `#33` now has an executable source-of-truth for the first runtime source surface)
+- Next single step:
+  - Open PR for issue `#33`, perform reviewer pass, address findings if any, merge, and summarize the outcome on the issue

--- a/docs/plans/2026-03-10-issue-33-source-subset-design.md
+++ b/docs/plans/2026-03-10-issue-33-source-subset-design.md
@@ -1,0 +1,94 @@
+# Issue #33 V1 Active Source Subset Design
+
+## Goal
+
+Define and enforce a small US-first source subset for v1 runtime validation so downstream work can build and debug against a stable, intentionally narrow source surface.
+
+## Scope
+
+This slice covers:
+- a runtime-readable artifact containing the v1 active source IDs
+- a helper that resolves the active subset against the full modelling registry
+- tests that validate subset integrity and intended source mix
+- documentation describing the subset and its purpose
+
+This slice does not cover:
+- changing the full source catalog into an active/inactive matrix
+- network fetch implementation
+- dynamic source enable/disable configuration
+- broader international runtime scope
+
+## Why This Slice
+
+The repository has a strong full modelling registry, but the runtime path does not yet have a narrow source scope. A small explicit subset lowers debugging cost while preserving the full catalog for future phases.
+
+## Approaches Considered
+
+### Option A: Separate runtime allowlist artifact plus resolver helper
+
+Store the full registry unchanged and add a small artifact listing the v1 active source IDs. Runtime helpers resolve those IDs against the full registry when needed.
+
+Why this is preferred:
+- smallest runtime-usable step
+- avoids overloading the full registry with short-term scope flags
+- easy to test and reuse later
+
+### Option B: Mark active/inactive directly inside `source_registry.yaml`
+
+Why this is not preferred:
+- mixes permanent catalogue modelling with temporary runtime rollout scope
+- creates more drift pressure when the subset changes
+
+### Option C: Docs-only subset description
+
+Why this is not preferred:
+- gives no executable source-of-truth to downstream code
+- forces later branches to re-encode the same decision
+
+## Selected Design
+
+### Artifact Layout
+
+- `artifacts/runtime/v1_active_sources.yaml`
+  - contains the explicit list of active source IDs
+  - includes brief rationale and intended v1 properties
+
+### Runtime Helper
+
+- `apps/agent/runtime/source_scope.py`
+  - load the full modelling registry
+  - load the v1 allowlist
+  - return the resolved active source records in stable order
+  - fail clearly if the allowlist references a missing source
+
+### Tests
+
+- `tests/agent/runtime/test_source_scope.py`
+  - resolves the configured active subset
+  - preserves the declared order
+  - fails when an allowlist entry is missing from the full registry
+  - asserts the subset contains:
+    - official US policy/macro sources
+    - one full-text secondary source
+    - one metadata-only source
+
+### Initial US-First Subset
+
+- `fed_press_releases`
+- `us_bls_news`
+- `us_bea_news`
+- `reuters_business`
+- `wsj_markets`
+
+### Documentation
+
+Update:
+- `README.md` or a small runtime-facing doc reference to clarify that v1 runtime work targets the active subset first
+- artifact validation so the new YAML file is checked
+
+### Error Handling
+
+- missing artifact file -> explicit `FileNotFoundError`
+- malformed YAML -> validation failure via existing artifact validation flow
+- unknown source ID in allowlist -> explicit `ValueError`
+

--- a/docs/plans/2026-03-10-issue-33-source-subset-implementation-plan.md
+++ b/docs/plans/2026-03-10-issue-33-source-subset-implementation-plan.md
@@ -1,0 +1,154 @@
+# Issue #33 V1 Active Source Subset Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a US-first runtime source subset artifact and a helper that resolves it against the full source registry so downstream work can target a stable v1 scope.
+
+**Architecture:** Keep the full modelling registry unchanged and add a small runtime allowlist artifact plus a deterministic resolver helper. This preserves long-term catalogue coverage while giving the runtime path a narrow, testable source-of-truth.
+
+**Tech Stack:** Python 3.11+, `pathlib`, `yaml`, `unittest`
+
+---
+
+### Task 1: Add source-scope tests
+
+**Files:**
+- Create: `tests/agent/runtime/test_source_scope.py`
+
+**Step 1: Write the failing test**
+
+Add tests asserting:
+- the helper resolves the configured active source IDs in order
+- the resolved subset contains the expected five source IDs
+- a missing source ID in an allowlist input raises `ValueError`
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.agent.runtime.test_source_scope -v`
+Expected: FAIL because `apps.agent.runtime.source_scope` does not exist.
+
+**Step 3: Write minimal implementation shape**
+
+Create a module stub with public functions such as:
+
+```python
+def load_source_registry(*, registry_path=None):
+    raise NotImplementedError
+
+def load_active_source_subset(*, registry_path=None, active_ids_path=None):
+    raise NotImplementedError
+```
+
+**Step 4: Run test to verify it still fails for missing behavior**
+
+Run: `python -m unittest tests.agent.runtime.test_source_scope -v`
+Expected: FAIL on `NotImplementedError` or assertion mismatch rather than import failure.
+
+**Step 5: Commit**
+
+```bash
+git add tests/agent/runtime/test_source_scope.py apps/agent/runtime/source_scope.py
+git commit -m "test(runtime): scaffold active source subset coverage"
+```
+
+### Task 2: Add runtime subset artifact and resolver
+
+**Files:**
+- Create: `artifacts/runtime/v1_active_sources.yaml`
+- Create: `apps/agent/runtime/source_scope.py`
+- Modify: `tests/agent/runtime/test_source_scope.py`
+
+**Step 1: Write the next failing test**
+
+Add assertions for:
+- one metadata-only source is included
+- at least three official Tier 1 sources are included
+- the helper returns full source records, not just IDs
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.agent.runtime.test_source_scope -v`
+Expected: FAIL because the artifact or resolver behavior is incomplete.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- full source-registry loading from YAML
+- active allowlist loading from YAML
+- source resolution with stable order and missing-ID validation
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m unittest tests.agent.runtime.test_source_scope -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add artifacts/runtime/v1_active_sources.yaml apps/agent/runtime/source_scope.py tests/agent/runtime/test_source_scope.py
+git commit -m "feat(runtime): add v1 active source subset"
+```
+
+### Task 3: Update docs and artifact validation
+
+**Files:**
+- Modify: `scripts/validate_artifacts.py`
+- Modify: `README.md`
+
+**Step 1: Write the failing test**
+
+Add a test or verification assertion that the new runtime artifact is included in artifact validation and that the runtime-first subset is documented.
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.agent.runtime.test_source_scope -v`
+Expected: FAIL because docs/validation expectations are not yet reflected.
+
+**Step 3: Write minimal implementation**
+
+Update:
+- artifact validation script to include `artifacts/runtime/v1_active_sources.yaml`
+- README to state that v1 runtime validation targets the active subset first
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m unittest tests.agent.runtime.test_source_scope -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add scripts/validate_artifacts.py README.md tests/agent/runtime/test_source_scope.py
+git commit -m "docs(runtime): document v1 active source subset"
+```
+
+### Task 4: Full verification and progress logging
+
+**Files:**
+- Modify: `claude-progress.txt`
+
+**Step 1: Update progress log**
+
+Append the active-source-subset summary, verification commands, and next step to `claude-progress.txt`.
+
+**Step 2: Run verification**
+
+Run:
+- `python -m unittest tests.agent.runtime.test_source_scope -v`
+- `python scripts/validate_artifacts.py`
+- `python -m unittest discover -s tests -p "test_*.py" -v`
+- `python -m compileall -q apps tests scripts evals`
+
+Expected:
+- source-scope tests PASS
+- artifact validation PASS
+- full suite PASS
+- compile check PASS
+
+**Step 3: Commit**
+
+```bash
+git add claude-progress.txt
+git commit -m "docs: log active source subset progress"
+```
+

--- a/scripts/validate_artifacts.py
+++ b/scripts/validate_artifacts.py
@@ -12,6 +12,7 @@ def main() -> None:
     ]
     yaml_paths = [
         Path("artifacts/modelling/source_registry.yaml"),
+        Path("artifacts/runtime/v1_active_sources.yaml"),
     ]
 
     for path in json_paths:

--- a/tests/agent/runtime/test_source_scope.py
+++ b/tests/agent/runtime/test_source_scope.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import tempfile
+import unittest
+
+import yaml
+
+from apps.agent.runtime.source_scope import load_active_source_subset, load_source_registry
+
+
+class SourceScopeTests(unittest.TestCase):
+    def test_load_active_source_subset_resolves_expected_ids_in_order(self):
+        subset = load_active_source_subset()
+
+        self.assertEqual(
+            [source["id"] for source in subset],
+            [
+                "fed_press_releases",
+                "us_bls_news",
+                "us_bea_news",
+                "reuters_business",
+                "wsj_markets",
+            ],
+        )
+
+    def test_subset_contains_required_source_mix(self):
+        subset = load_active_source_subset()
+
+        tier_1_count = sum(1 for source in subset if source["credibility_tier"] == 1)
+        metadata_only_count = sum(1 for source in subset if source["paywall_policy"] == "metadata_only")
+
+        self.assertGreaterEqual(tier_1_count, 3)
+        self.assertEqual(metadata_only_count, 1)
+        self.assertIn("Reuters - Business News", {source["name"] for source in subset})
+
+    def test_missing_source_id_in_allowlist_raises_value_error(self):
+        registry = load_source_registry()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            active_ids_path = Path(temp_dir) / "active_sources.yaml"
+            active_ids_path.write_text(
+                yaml.safe_dump({"active_source_ids": ["fed_press_releases", "missing_source"]}, sort_keys=False),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError):
+                load_active_source_subset(registry=registry, active_ids_path=active_ids_path)
+
+    def test_validate_artifacts_script_includes_runtime_subset_artifact(self):
+        validate_script = (Path(__file__).resolve().parents[3] / "scripts" / "validate_artifacts.py").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("artifacts/runtime/v1_active_sources.yaml", validate_script)
+
+    def test_readme_documents_v1_active_subset_first(self):
+        readme_text = (Path(__file__).resolve().parents[3] / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("active source subset", readme_text)
+        self.assertIn("fed_press_releases", readme_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a runtime-readable US-first active source subset artifact for v1 validation
- add a resolver helper and tests so downstream code can load the subset from the full registry
- document the subset in the README and include it in artifact validation

## Verification
- `python -m unittest tests.agent.runtime.test_source_scope -v`
- `python scripts/validate_artifacts.py`
- `python -m unittest discover -s tests -p test_*.py -v`
- `python -m compileall -q apps tests scripts evals`

Closes #33