### PR TITLE
docs: add canonical status matrix and demote alert delivery

### DIFF
--- a/artifacts/modelling/MODELLING_CHECKLIST.md
+++ b/artifacts/modelling/MODELLING_CHECKLIST.md
@@ -25,6 +25,9 @@ Modelling phase complete when:
 - Citation validator passes
 - Budget guard implemented and enabled by default
 
+Canonical runtime status view:
+- `docs/status-matrix.md` is the single modelled/coded/verified matrix for current repo state.
+
 ## Strengthening Tracks (Prophet Benchmark Review - 2026-02-19)
 
 - [PASSING] **S1) Decision record schema** - Define persisted per-run rationale artifact (claims, citations, rejected alternatives, risk flags, budget usage)

--- a/artifacts/modelling/TODO.md
+++ b/artifacts/modelling/TODO.md
@@ -29,3 +29,5 @@ Last updated: 2026-02-19
 
 - Keep all work aligned with PRD v1.1 constraints: local-first, citation-grounded, no trading instructions.
 - Do not relax paywall, budget hard-stop, or evidence requirements.
+- Treat alert delivery as post-daily-brief scope until the daily-brief path is stable.
+- Use `docs/status-matrix.md` as the canonical modelled/coded/verified status view.

--- a/artifacts/modelling/backlog.json
+++ b/artifacts/modelling/backlog.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_on": "2026-02-19",
+  "generated_on": "2026-03-10",
   "phase": "modelling",
   "tickets": [
     {
@@ -104,18 +104,18 @@
     },
     {
       "id": "M007",
-      "title": "Implement daily brief and alert delivery",
+      "title": "Implement daily brief delivery",
       "status": "planned",
       "priority": "P1",
-      "depends_on": ["M004", "M006"],
+      "depends_on": ["M004"],
       "files": [
         "apps/agent/delivery/html_report.py",
-        "apps/agent/delivery/email_sender.py"
+        "scripts/run_daily_brief_fixture.py"
       ],
       "acceptance_criteria": [
         "Daily brief local HTML output generated in stable structure",
-        "Alert output follows 3-6 bullet format with citations",
-        "Delivery failures are logged and retry-eligible next run"
+        "Daily brief runtime produces validated or explicit abstained output",
+        "Daily brief delivery failures are logged and retry-eligible next run"
       ]
     },
     {
@@ -149,6 +149,21 @@
         "Users can input and update ticker + weight locally",
         "Outputs relevance tags and risk flags without buy/sell guidance",
         "Relevance is included in daily brief and alert context"
+      ]
+    },
+    {
+      "id": "M010",
+      "title": "Implement alert delivery after the daily-brief path is stable",
+      "status": "planned",
+      "priority": "P2",
+      "depends_on": ["M006", "M007"],
+      "files": [
+        "apps/agent/delivery/email_sender.py"
+      ],
+      "acceptance_criteria": [
+        "Alert output follows 3-6 bullet format with citations",
+        "Alert delivery happens only after the daily-brief path is working",
+        "Alert delivery failures are logged and retry-eligible next run"
       ]
     }
   ]

--- a/docs/status-matrix.md
+++ b/docs/status-matrix.md
@@ -1,0 +1,25 @@
+# Status Matrix
+
+This is the canonical modelled/coded/verified status view for the repository's major delivery areas.
+
+Definitions:
+- `modelled`: the area is described in the modelling artifacts or backlog.
+- `coded`: the area has committed runtime or support code in the repository.
+- `verified`: the coded area has committed tests or validators covering it in the current tree.
+
+| Area | Modelled | Coded | Verified | Evidence |
+|------|----------|-------|----------|----------|
+| Source registry and active source subset | yes | yes | yes | `artifacts/modelling/source_registry.yaml`, `artifacts/runtime/v1_active_sources.yaml`, `apps/agent/runtime/source_scope.py`, `tests/agent/runtime/test_source_scope.py` |
+| Orchestrator and pipeline stage framework | yes | yes | yes | `artifacts/modelling/pipeline.md`, `apps/agent/orchestrator.py`, `apps/agent/pipeline/types.py`, `tests/agent/test_orchestrator.py` |
+| Ingestion, extraction, normalization, and dedup | yes | yes | yes | `artifacts/modelling/pipeline.md`, `apps/agent/ingest/`, `tests/agent/ingest/` |
+| Retrieval and evidence-pack assembly | yes | yes | yes | `artifacts/modelling/pipeline.md`, `apps/agent/retrieval/`, `tests/agent/retrieval/` |
+| Citation validation and abstain shaping | yes | yes | yes | `artifacts/modelling/citation_contract.md`, `apps/agent/validators/citation_validator.py`, `apps/agent/synthesis/postprocess.py`, `tests/agent/validators/test_citation_validator.py`, `tests/agent/synthesis/test_postprocess.py` |
+| Budget guard and budget ledger | yes | yes | yes | `artifacts/PRD.md`, `artifacts/PROJECT_FACT.md`, `apps/agent/runtime/budget_guard.py`, `apps/agent/runtime/cost_ledger.py`, `tests/agent/runtime/test_budget_guard.py`, `tests/agent/runtime/test_cost_ledger.py` |
+| Daily-brief runtime and local HTML output | yes | yes | yes | `artifacts/PRD.md`, `apps/agent/daily_brief/runner.py`, `apps/agent/daily_brief/synthesis.py`, `apps/agent/delivery/html_report.py`, `tests/agent/daily_brief/test_runner.py`, `tests/agent/daily_brief/test_synthesis.py`, `tests/agent/delivery/test_html_report.py` |
+| Alert scoring and policy gates | yes | no | no | `artifacts/modelling/alert_scoring.md`, `artifacts/modelling/backlog.json` (`M006`) |
+| Alert delivery runtime | yes | no | no | `artifacts/PRD.md`, `artifacts/modelling/backlog.json` (`M010`) |
+| Eval harness and golden cases | yes | yes | yes | `evals/run_eval_suite.py`, `evals/golden/`, `tests/evals/test_run_eval_suite.py` |
+| Portfolio relevance mapping | yes | no | no | `artifacts/PRD.md`, `artifacts/modelling/backlog.json` (`M009`) |
+
+Priority note:
+- The working daily-brief path is ahead of alert delivery. Alert delivery remains modelled but is intentionally downstream of the daily-brief path in `artifacts/modelling/backlog.json`.


### PR DESCRIPTION
## Summary
- add a canonical modelled/coded/verified status matrix
- demote alert delivery behind the daily-brief path in backlog/status docs
- keep the change scoped to docs and prioritization surfaces

## Verification
- python scripts/validate_artifacts.py

Closes #32
Closes #37