### PR TITLE
fix: make daily-brief guardrails truthful

### DIFF
--- a/apps/agent/daily_brief/runner.py
+++ b/apps/agent/daily_brief/runner.py
@@ -34,8 +34,10 @@ from apps.agent.pipeline.types import (
     StageResult,
 )
 from apps.agent.retrieval.chunker import build_chunk_rows
-from apps.agent.retrieval.evidence_pack import build_evidence_pack
+from apps.agent.retrieval.evidence_pack import build_evidence_pack_report
 from apps.agent.retrieval.fts_index import build_fts_rows
+from apps.agent.runtime.budget_guard import BudgetCaps
+from apps.agent.runtime.cost_ledger import BudgetWindowSnapshot
 from apps.agent.runtime.source_scope import load_active_source_subset
 from apps.agent.runtime.source_scope import load_source_registry
 from apps.agent.synthesis.postprocess import finalize_validation_outcome
@@ -104,6 +106,7 @@ def run_fixture_daily_brief(
     fixture_path: Path | None = None,
     run_id: str = "run_daily_fixture",
     generated_at_utc: str | None = None,
+    budget_preflight: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     lifecycle: list[dict[str, Any]] = []
     execution: dict[str, Any] = {}
@@ -136,8 +139,18 @@ def run_fixture_daily_brief(
         run_type="daily_brief",
         stages=[stage],
         recorder=lifecycle.append,
+        budget_preflight=budget_preflight or _default_budget_preflight(generated_at_utc=timestamp),
     )
-    execution.setdefault("status", "failed")
+    if pipeline_result["status"] == "stopped_budget" and not execution:
+        execution.update(
+            _persist_budget_stop_outputs(
+                base_dir=base_dir,
+                run_id=run_id,
+                generated_at_utc=timestamp,
+                pipeline_result=pipeline_result,
+            )
+        )
+    execution.setdefault("status", pipeline_result["status"])
     execution["lifecycle"] = lifecycle
     execution["pipeline_status"] = pipeline_result["status"]
     execution["error_summary"] = pipeline_result.get("error_summary")
@@ -168,12 +181,20 @@ def _execute_daily_brief_slice(
     )
     report_date = generated_at_utc[:10]
     output_path = base_dir / "artifacts" / "daily" / report_date / "brief.html"
+    budget_snapshot = _budget_snapshot(context=context)
+    guardrail_checks = _guardrail_checks(
+        stage8_result=synthesis_data.stage8_result,
+        final_status=synthesis_data.final_result["status"],
+        budget_snapshot=budget_snapshot,
+        diversity_report=synthesis_data.evidence_pack_report,
+    )
     render_daily_brief_html(
         output_path=output_path,
         report_date=report_date,
         run_id=run_id,
         synthesis=synthesis_data.final_result["synthesis"],
         citation_store=synthesis_data.stage8_result["citation_store"],
+        guardrail_checks=guardrail_checks,
     )
 
     decision_record = build_and_persist_decision_record(
@@ -183,17 +204,13 @@ def _execute_daily_brief_slice(
         stage8_status=synthesis_data.stage8_result["status"],
         synthesis=synthesis_data.final_result["synthesis"],
         removed_bullets=int(synthesis_data.stage8_result["report"]["removed_bullets"]),
-        budget_snapshot=_budget_snapshot(),
-        guardrail_checks=_guardrail_checks(
-            stage8_result=synthesis_data.stage8_result,
-            final_status=synthesis_data.final_result["status"],
-        ),
+        budget_snapshot=budget_snapshot,
+        guardrail_checks=guardrail_checks,
         output_path=output_path,
         generated_at_utc=generated_at_utc,
     )
 
-    artifact_dir = base_dir / "artifacts" / "runtime" / "daily_brief_runs" / report_date / run_id
-    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_dir = _artifact_dir(base_dir=base_dir, report_date=report_date, run_id=run_id)
     _write_json(artifact_dir / "sources.json", corpus_data.source_rows)
     _write_json(artifact_dir / "documents.json", corpus_data.documents)
     _write_json(artifact_dir / "chunks.json", corpus_data.chunks)
@@ -214,6 +231,10 @@ def _execute_daily_brief_slice(
             "chunks_indexed": context.counters.chunks_indexed,
             "stage8_status": synthesis_data.stage8_result["status"],
             "final_status": synthesis_data.final_result["status"],
+            "budget_snapshot": budget_snapshot,
+            "budget_ledger_rows": list(context.budget_ledger_rows),
+            "guardrail_checks": guardrail_checks,
+            "diversity_stats": synthesis_data.evidence_pack_report["diversity_stats"],
         },
     )
 
@@ -300,7 +321,12 @@ def build_daily_brief_synthesis(
     run_id: str,
 ) -> DailyBriefSynthesisStageData:
     query_text = build_daily_brief_query(documents=stage_data.documents)
-    evidence_pack_items = build_evidence_pack(fts_rows=stage_data.fts_rows, query_text=query_text, pack_size=30)
+    evidence_pack_report = build_evidence_pack_report(
+        fts_rows=stage_data.fts_rows,
+        query_text=query_text,
+        pack_size=30,
+    )
+    evidence_pack_items = evidence_pack_report["items"]
     evidence_pack_items = _attach_doc_ids(
         evidence_pack_items=evidence_pack_items,
         fts_rows=stage_data.fts_rows,
@@ -334,6 +360,7 @@ def build_daily_brief_synthesis(
     return DailyBriefSynthesisStageData(
         query_text=query_text,
         evidence_pack_items=evidence_pack_items,
+        evidence_pack_report=evidence_pack_report,
         citation_store=stage8_result["citation_store"],
         stage8_result=stage8_result,
         final_result=final_result,
@@ -467,7 +494,10 @@ def _write_json(path: Path, payload: Any) -> None:
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
-def _budget_snapshot() -> dict[str, Any]:
+def _budget_snapshot(*, context: Any) -> dict[str, Any]:
+    snapshot = getattr(context, "budget_snapshot", None)
+    if isinstance(snapshot, Mapping):
+        return dict(snapshot)
     return {
         "hourly_spend_usd": 0.0,
         "hourly_cap_usd": 0.10,
@@ -479,28 +509,138 @@ def _budget_snapshot() -> dict[str, Any]:
     }
 
 
-def _guardrail_checks(*, stage8_result: Mapping[str, Any], final_status: str) -> dict[str, Any]:
-    citation_level = "pass"
-    if stage8_result["status"] == "partial":
+def _guardrail_checks(
+    *,
+    stage8_result: Mapping[str, Any] | None,
+    final_status: str,
+    budget_snapshot: Mapping[str, Any],
+    diversity_report: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    citation_level = "warn" if stage8_result is None else "pass"
+    if stage8_result is not None and stage8_result["status"] == "partial":
         citation_level = "warn"
-    if stage8_result["status"] == "retry":
+    if stage8_result is not None and stage8_result["status"] == "retry":
         citation_level = "fail"
 
     notes: list[str] = []
+    if stage8_result is None:
+        notes.append("Citation validation did not run because budget preflight stopped the run.")
     if final_status == "abstained":
         notes.append("Daily brief downgraded to abstain after citation validation.")
-    removed_bullets = int(stage8_result["report"]["removed_bullets"])
+    removed_bullets = 0
+    if stage8_result is not None:
+        removed_bullets = int(stage8_result["report"]["removed_bullets"])
     if removed_bullets > 0:
         notes.append(f"{removed_bullets} bullet(s) were removed or downgraded during validation.")
+    budget_allowed = bool(budget_snapshot.get("allowed", True))
+    if not budget_allowed:
+        notes.append("Budget preflight blocked the run before delivery work started.")
 
-    diversity_level = "warn" if final_status == "abstained" else "pass"
+    diversity_level = "warn"
+    if isinstance(diversity_report, Mapping):
+        diversity_level = str(diversity_report.get("diversity_check", "warn"))
+        for note in diversity_report.get("notes", []):
+            if isinstance(note, str):
+                notes.append(note)
+    elif not budget_allowed:
+        notes.append("Diversity check did not run because budget preflight stopped the run.")
 
     return {
         "citation_check": citation_level,
         "paywall_check": "pass",
         "diversity_check": diversity_level,
-        "budget_check": "pass",
+        "budget_check": "pass" if budget_allowed else "fail",
         "notes": notes,
+    }
+
+
+def _default_budget_preflight(*, generated_at_utc: str) -> dict[str, Any]:
+    date_prefix = generated_at_utc[:10]
+    month_prefix = generated_at_utc[:7]
+    return {
+        "hourly_spend_usd": 0.0,
+        "daily_spend_usd": 0.0,
+        "monthly_spend_usd": 0.0,
+        "next_estimated_cost_usd": 0.0,
+        "caps": BudgetCaps(),
+        "windows": {
+            "hourly": BudgetWindowSnapshot(
+                window_start=f"{date_prefix}T00:00:00Z",
+                window_end=f"{date_prefix}T00:59:59Z",
+                cost_usd=0.0,
+            ),
+            "daily": BudgetWindowSnapshot(
+                window_start=f"{date_prefix}T00:00:00Z",
+                window_end=f"{date_prefix}T23:59:59Z",
+                cost_usd=0.0,
+            ),
+            "monthly": BudgetWindowSnapshot(
+                window_start=f"{month_prefix}-01T00:00:00Z",
+                window_end=f"{month_prefix}-31T23:59:59Z",
+                cost_usd=0.0,
+            ),
+        },
+    }
+
+
+def _artifact_dir(*, base_dir: Path, report_date: str, run_id: str) -> Path:
+    artifact_dir = base_dir / "artifacts" / "runtime" / "daily_brief_runs" / report_date / run_id
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    return artifact_dir
+
+
+def _persist_budget_stop_outputs(
+    *,
+    base_dir: Path,
+    run_id: str,
+    generated_at_utc: str,
+    pipeline_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    report_date = generated_at_utc[:10]
+    artifact_dir = _artifact_dir(base_dir=base_dir, report_date=report_date, run_id=run_id)
+    budget_snapshot = dict(pipeline_result.get("budget_snapshot", {}))
+    guardrail_checks = _guardrail_checks(
+        stage8_result=None,
+        final_status="stopped_budget",
+        budget_snapshot=budget_snapshot,
+        diversity_report=None,
+    )
+    decision_record = build_and_persist_decision_record(
+        base_dir=base_dir,
+        run_id=run_id,
+        run_type="daily_brief",
+        stage8_status="failed",
+        synthesis={},
+        removed_bullets=0,
+        budget_snapshot=budget_snapshot,
+        guardrail_checks=guardrail_checks,
+        output_path=None,
+        generated_at_utc=generated_at_utc,
+    )
+    _write_json(
+        artifact_dir / "run_summary.json",
+        {
+            "run_id": run_id,
+            "report_date": report_date,
+            "query_text": None,
+            "docs_fetched": 0,
+            "docs_ingested": 0,
+            "chunks_indexed": 0,
+            "stage8_status": None,
+            "final_status": "stopped_budget",
+            "budget_snapshot": budget_snapshot,
+            "budget_ledger_rows": list(pipeline_result.get("budget_ledger_rows", [])),
+            "guardrail_checks": guardrail_checks,
+            "diversity_stats": {},
+        },
+    )
+    return {
+        "status": "stopped_budget",
+        "html_path": None,
+        "decision_record_path": decision_record["record_path"],
+        "artifact_dir": str(artifact_dir),
+        "query_text": None,
+        "abstain_reason": pipeline_result.get("error_summary"),
     }
 
 

--- a/apps/agent/delivery/html_report.py
+++ b/apps/agent/delivery/html_report.py
@@ -20,6 +20,7 @@ def render_daily_brief_html(
     run_id: str,
     synthesis: Mapping[str, list[Mapping[str, Any]]],
     citation_store: Mapping[str, Mapping[str, Any]],
+    guardrail_checks: Mapping[str, Any] | None = None,
 ) -> Path:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     abstained = _is_abstained(synthesis)
@@ -35,12 +36,14 @@ def render_daily_brief_html(
         _render_citation(citation_id=citation_id, citation=citation_store[citation_id])
         for citation_id in citation_store
     )
+    guardrails_html = _render_guardrails(guardrail_checks)
 
     html = (
         "<html><head><meta charset=\"utf-8\"><title>Daily Brief</title></head><body>"
         f"<header><h1>Daily Brief</h1><p>Date: {escape(report_date)}</p><p>Run: {escape(run_id)}</p>"
         f"<p>Status: {escape(status_title)}</p></header>"
         f"{''.join(sections_html)}"
+        f"{guardrails_html}"
         f"<section><h2>Citations</h2><ol>{citations_html}</ol></section>"
         "</body></html>"
     )
@@ -60,6 +63,29 @@ def _render_citation(*, citation_id: str, citation: Mapping[str, Any]) -> str:
     title = escape(str(citation.get("title") or citation_id))
     url = escape(str(citation.get("url") or ""))
     return f"<li id=\"{escape(citation_id)}\"><a href=\"{url}\">{title}</a></li>"
+
+
+def _render_guardrails(guardrail_checks: Mapping[str, Any] | None) -> str:
+    if guardrail_checks is None:
+        return ""
+
+    notes = "".join(
+        f"<li>{escape(str(note))}</li>"
+        for note in guardrail_checks.get("notes", [])
+        if isinstance(note, str)
+    )
+    return (
+        "<section><h2>Guardrails</h2><ul>"
+        f"<li>Budget: {escape(_label(str(guardrail_checks.get('budget_check', 'warn'))))}</li>"
+        f"<li>Diversity: {escape(_label(str(guardrail_checks.get('diversity_check', 'warn'))))}</li>"
+        f"<li>Citations: {escape(_label(str(guardrail_checks.get('citation_check', 'warn'))))}</li>"
+        f"{notes}"
+        "</ul></section>"
+    )
+
+
+def _label(value: str) -> str:
+    return value[:1].upper() + value[1:].lower()
 
 
 def _is_abstained(synthesis: Mapping[str, list[Mapping[str, Any]]]) -> bool:

--- a/apps/agent/orchestrator.py
+++ b/apps/agent/orchestrator.py
@@ -8,6 +8,7 @@ from apps.agent.pipeline.types import RunContext, RunStatus, RunType, StageResul
 from apps.agent.runtime.budget_guard import evaluate_budget_guard
 from apps.agent.runtime.cost_ledger import build_budget_ledger_rows
 
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -54,12 +55,21 @@ def run_pipeline(
             decision=decision,
             windows=budget_preflight["windows"],
         )
+        context.budget_snapshot = {
+            "hourly_spend_usd": decision.projected_spend["hourly"],
+            "hourly_cap_usd": decision.caps["hourly"],
+            "daily_spend_usd": decision.projected_spend["daily"],
+            "daily_cap_usd": decision.caps["daily"],
+            "monthly_spend_usd": decision.projected_spend["monthly"],
+            "monthly_cap_usd": decision.caps["monthly"],
+            "allowed": decision.allowed,
+        }
+        context.budget_ledger_rows = budget_ledger_rows
         if not decision.allowed:
             context.status = RunStatus.STOPPED_BUDGET
             context.ended_at = _utc_now_iso()
             context.error_summary = decision.reason
             stopped_result = context.to_dict()
-            stopped_result["budget_ledger_rows"] = budget_ledger_rows
             recorder(stopped_result)
             return stopped_result
 

--- a/apps/agent/pipeline/types.py
+++ b/apps/agent/pipeline/types.py
@@ -230,9 +230,11 @@ class RunContext:
     ended_at: str | None = None
     error_summary: str | None = None
     counters: RunCounters = field(default_factory=RunCounters)
+    budget_snapshot: dict[str, object] | None = None
+    budget_ledger_rows: list[dict[str, object]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "run_id": self.run_id,
             "run_type": self.run_type.value,
             "started_at": self.started_at,
@@ -249,6 +251,11 @@ class RunContext:
             "error_summary": self.error_summary,
             "created_at": self.started_at,
         }
+        if self.budget_snapshot is not None:
+            payload["budget_snapshot"] = dict(self.budget_snapshot)
+        if self.budget_ledger_rows:
+            payload["budget_ledger_rows"] = [dict(row) for row in self.budget_ledger_rows]
+        return payload
 
 
 @dataclass
@@ -278,6 +285,7 @@ class DailyBriefCorpusStageData:
 class DailyBriefSynthesisStageData:
     query_text: str
     evidence_pack_items: list[EvidencePackItem]
+    evidence_pack_report: dict[str, Any]
     citation_store: dict[str, CitationStoreEntry]
     stage8_result: CitationValidationResult
     final_result: FinalSynthesisResult

--- a/apps/agent/retrieval/evidence_pack.py
+++ b/apps/agent/retrieval/evidence_pack.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import math
 import re
+from collections import Counter
 from datetime import datetime, timezone
 from collections.abc import Iterable, Mapping
 from typing import Any
@@ -12,13 +14,79 @@ def build_evidence_pack(
     query_text: str,
     pack_size: int = 30,
 ) -> list[dict[str, Any]]:
-    query_terms = _tokenize(query_text)
-    candidate_rows = list(fts_rows)
-    if not query_terms or pack_size <= 0:
-        return []
+    return build_evidence_pack_report(
+        fts_rows=fts_rows,
+        query_text=query_text,
+        pack_size=pack_size,
+    )["items"]
 
+
+def build_evidence_pack_report(
+    *,
+    fts_rows: Iterable[Mapping[str, Any]],
+    query_text: str,
+    pack_size: int = 30,
+) -> dict[str, Any]:
+    query_terms = _tokenize(query_text)
+    if not query_terms or pack_size <= 0:
+        return {
+            "items": [],
+            "diversity_check": "fail",
+            "diversity_stats": _diversity_stats([]),
+            "notes": ["No matching evidence rows were available for evidence-pack construction."],
+        }
+
+    matching_rows = _matching_rows(fts_rows=fts_rows, query_terms=query_terms)
+    if not matching_rows:
+        return {
+            "items": [],
+            "diversity_check": "fail",
+            "diversity_stats": _diversity_stats([]),
+            "notes": ["No rows matched the evidence-pack query terms."],
+        }
+
+    published_timestamps = [row["published_timestamp"] for row in matching_rows]
+    oldest_timestamp = min(published_timestamps, default=0.0)
+    newest_timestamp = max(published_timestamps, default=0.0)
+
+    scored_rows = _score_rows(
+        matching_rows=matching_rows,
+        oldest_timestamp=oldest_timestamp,
+        newest_timestamp=newest_timestamp,
+    )
+    scored_rows.sort(
+        key=lambda row: (
+            -float(row["retrieval_score"]),
+            -float(row["_published_timestamp"]),
+            str(row["chunk_id"]),
+        )
+    )
+
+    selected_rows = _select_diverse_rows(scored_rows=scored_rows, pack_size=pack_size)
+    pack_rows = [_public_row(row=row, rank=index) for index, row in enumerate(selected_rows, start=1)]
+    diversity_stats = _diversity_stats(pack_rows)
+    violations = _diversity_violations(diversity_stats=diversity_stats)
+    notes = _diversity_notes(violations=violations, target_size=min(pack_size, len(scored_rows)), actual_size=len(pack_rows))
+    return {
+        "items": pack_rows,
+        "diversity_check": _diversity_level(violations=violations, items=pack_rows),
+        "diversity_stats": diversity_stats,
+        "notes": notes,
+    }
+
+
+def _tokenize(value: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", value.lower())
+
+
+def _keyword_score(*, text: str, query_terms: list[str]) -> float:
+    tokens = _tokenize(text)
+    return float(sum(tokens.count(term) for term in query_terms))
+
+
+def _matching_rows(*, fts_rows: Iterable[Mapping[str, Any]], query_terms: list[str]) -> list[dict[str, Any]]:
     matching_rows: list[dict[str, Any]] = []
-    for row in candidate_rows:
+    for row in fts_rows:
         _validate_row(row)
         keyword_score = _keyword_score(text=str(row["text"]), query_terms=query_terms)
         if keyword_score <= 0:
@@ -30,11 +98,15 @@ def build_evidence_pack(
                 "published_timestamp": _published_timestamp(row),
             }
         )
+    return matching_rows
 
-    published_timestamps = [row["published_timestamp"] for row in matching_rows]
-    oldest_timestamp = min(published_timestamps, default=0.0)
-    newest_timestamp = max(published_timestamps, default=0.0)
 
+def _score_rows(
+    *,
+    matching_rows: Iterable[Mapping[str, Any]],
+    oldest_timestamp: float,
+    newest_timestamp: float,
+) -> list[dict[str, Any]]:
     scored_rows: list[dict[str, Any]] = []
     for match in matching_rows:
         row = match["row"]
@@ -45,7 +117,6 @@ def build_evidence_pack(
         )
         credibility_score = _credibility_score(int(row["credibility_tier"]))
         retrieval_score = round(float(match["keyword_score"]) * 0.5 + recency_score * 0.3 + credibility_score * 0.2, 6)
-
         scored_rows.append(
             {
                 "chunk_id": row["chunk_id"],
@@ -59,41 +130,143 @@ def build_evidence_pack(
                 "_published_timestamp": match["published_timestamp"],
             }
         )
+    return scored_rows
 
-    scored_rows.sort(
-        key=lambda row: (
-            -float(row["retrieval_score"]),
-            -float(row["_published_timestamp"]),
-            str(row["chunk_id"]),
+
+def _select_diverse_rows(*, scored_rows: list[dict[str, Any]], pack_size: int) -> list[dict[str, Any]]:
+    target_size = min(pack_size, len(scored_rows))
+    if target_size <= 0:
+        return []
+
+    publisher_limit = max(1, int(math.floor(target_size * 0.4)))
+    tier4_limit = int(math.floor(target_size * 0.15))
+    min_high_tier = int(math.ceil(target_size * 0.5))
+
+    selected: list[dict[str, Any]] = []
+    publisher_counts: Counter[str] = Counter()
+    tier4_count = 0
+
+    def can_add(row: Mapping[str, Any]) -> bool:
+        publisher = str(row["publisher"])
+        if publisher_counts[publisher] >= publisher_limit:
+            return False
+        if int(row["credibility_tier"]) == 4 and tier4_count >= tier4_limit:
+            return False
+        return True
+
+    for row in scored_rows:
+        if len(selected) >= target_size:
+            break
+        if int(row["credibility_tier"]) > 2:
+            continue
+        if not can_add(row):
+            continue
+        selected.append(row)
+        publisher_counts[str(row["publisher"])] += 1
+        if int(row["credibility_tier"]) == 4:
+            tier4_count += 1
+        if sum(1 for item in selected if int(item["credibility_tier"]) <= 2) >= min_high_tier:
+            break
+
+    for row in scored_rows:
+        if len(selected) >= target_size:
+            break
+        if row in selected:
+            continue
+        if not can_add(row):
+            continue
+        selected.append(row)
+        publisher_counts[str(row["publisher"])] += 1
+        if int(row["credibility_tier"]) == 4:
+            tier4_count += 1
+
+    for row in scored_rows:
+        if len(selected) >= target_size:
+            break
+        if row in selected:
+            continue
+        selected.append(row)
+
+    return selected
+
+
+def _public_row(*, row: Mapping[str, Any], rank: int) -> dict[str, Any]:
+    return {
+        "chunk_id": row["chunk_id"],
+        "source_id": row["source_id"],
+        "publisher": row["publisher"],
+        "credibility_tier": row["credibility_tier"],
+        "retrieval_score": row["retrieval_score"],
+        "semantic_score": row["semantic_score"],
+        "recency_score": row["recency_score"],
+        "credibility_score": row["credibility_score"],
+        "rank_in_pack": rank,
+    }
+
+
+def _diversity_stats(items: Iterable[Mapping[str, Any]]) -> dict[str, float | int]:
+    rows = list(items)
+    total = len(rows)
+    if total == 0:
+        return {
+            "selected_count": 0,
+            "unique_publishers": 0,
+            "tier_1_pct": 0.0,
+            "tier_2_pct": 0.0,
+            "tier_3_pct": 0.0,
+            "tier_4_pct": 0.0,
+            "tier_1_2_pct": 0.0,
+            "max_publisher_pct": 0.0,
+        }
+
+    publisher_counts = Counter(str(item["publisher"]) for item in rows)
+    tier_counts = Counter(int(item["credibility_tier"]) for item in rows)
+    return {
+        "selected_count": total,
+        "unique_publishers": len(publisher_counts),
+        "tier_1_pct": round(tier_counts[1] / total * 100, 2),
+        "tier_2_pct": round(tier_counts[2] / total * 100, 2),
+        "tier_3_pct": round(tier_counts[3] / total * 100, 2),
+        "tier_4_pct": round(tier_counts[4] / total * 100, 2),
+        "tier_1_2_pct": round((tier_counts[1] + tier_counts[2]) / total * 100, 2),
+        "max_publisher_pct": round(max(publisher_counts.values()) / total * 100, 2),
+    }
+
+
+def _diversity_violations(*, diversity_stats: Mapping[str, Any]) -> list[str]:
+    violations: list[str] = []
+    if float(diversity_stats["max_publisher_pct"]) > 40.0:
+        violations.append("publisher_dominance")
+    if float(diversity_stats["tier_1_2_pct"]) < 50.0:
+        violations.append("tier_1_2_minimum")
+    if float(diversity_stats["tier_4_pct"]) > 15.0:
+        violations.append("tier_4_maximum")
+    return violations
+
+
+def _diversity_notes(*, violations: Iterable[str], target_size: int, actual_size: int) -> list[str]:
+    notes: list[str] = []
+    violation_set = set(violations)
+    if actual_size < target_size:
+        notes.append(
+            f"Evidence pack selected {actual_size} item(s) out of requested {target_size} after diversity filtering."
         )
-    )
-
-    pack_rows: list[dict[str, Any]] = []
-    for index, row in enumerate(scored_rows[:pack_size], start=1):
-        pack_rows.append(
-            {
-                "chunk_id": row["chunk_id"],
-                "source_id": row["source_id"],
-                "publisher": row["publisher"],
-                "credibility_tier": row["credibility_tier"],
-                "retrieval_score": row["retrieval_score"],
-                "semantic_score": row["semantic_score"],
-                "recency_score": row["recency_score"],
-                "credibility_score": row["credibility_score"],
-                "rank_in_pack": index,
-            }
-        )
-
-    return pack_rows
+    if "publisher_dominance" in violation_set:
+        notes.append("Publisher dominance cap could not be satisfied with the available evidence pool.")
+    if "tier_1_2_minimum" in violation_set:
+        notes.append("Tier 1/2 minimum share could not be satisfied with the available evidence pool.")
+    if "tier_4_maximum" in violation_set:
+        notes.append("Tier 4 maximum share could not be satisfied with the available evidence pool.")
+    return notes
 
 
-def _tokenize(value: str) -> list[str]:
-    return re.findall(r"[a-z0-9]+", value.lower())
-
-
-def _keyword_score(*, text: str, query_terms: list[str]) -> float:
-    tokens = _tokenize(text)
-    return float(sum(tokens.count(term) for term in query_terms))
+def _diversity_level(*, violations: Iterable[str], items: list[dict[str, Any]]) -> str:
+    violation_list = list(violations)
+    if not items:
+        return "fail"
+    if len(violation_list) >= 1:
+        return "fail"
+    return "pass"
 
 
 def _published_timestamp(row: Mapping[str, Any]) -> float:

--- a/tests/agent/daily_brief/test_runner.py
+++ b/tests/agent/daily_brief/test_runner.py
@@ -34,6 +34,8 @@ from apps.agent.pipeline.types import (
     SourceRegistryEntry,
     SourceRow,
 )
+from apps.agent.runtime.budget_guard import BudgetCaps
+from apps.agent.runtime.cost_ledger import BudgetWindowSnapshot
 
 
 class DailyBriefRunnerTests(unittest.TestCase):
@@ -193,10 +195,136 @@ class DailyBriefRunnerTests(unittest.TestCase):
             citation_rows = json.loads((artifact_dir / "citations.json").read_text(encoding="utf-8"))
             synthesis_bullets = json.loads((artifact_dir / "synthesis_bullets.json").read_text(encoding="utf-8"))
             bullet_citations = json.loads((artifact_dir / "bullet_citations.json").read_text(encoding="utf-8"))
+            run_summary = json.loads((artifact_dir / "run_summary.json").read_text(encoding="utf-8"))
             self.assertIsInstance(citation_rows, list)
             self.assertEqual(citation_rows[0]["citation_id"], "cite_001")
             self.assertEqual(synthesis_bullets[0]["section"], "prevailing")
             self.assertEqual(bullet_citations[0]["citation_id"], "cite_001")
+            self.assertEqual(run_summary["guardrail_checks"]["budget_check"], "pass")
+            self.assertIn(run_summary["guardrail_checks"]["diversity_check"], {"pass", "fail"})
+
+    def test_run_fixture_daily_brief_persists_budget_preflight_truthfully(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_fixture_daily_brief(
+                base_dir=Path(tmpdir),
+                run_id="run_fixture_budget_truth",
+                generated_at_utc="2026-03-10T16:00:00Z",
+                budget_preflight={
+                    "hourly_spend_usd": 0.02,
+                    "daily_spend_usd": 0.50,
+                    "monthly_spend_usd": 20.0,
+                    "next_estimated_cost_usd": 0.01,
+                    "caps": BudgetCaps(),
+                    "windows": {
+                        "hourly": BudgetWindowSnapshot(
+                            window_start="2026-03-10T16:00:00Z",
+                            window_end="2026-03-10T16:59:59Z",
+                            cost_usd=0.02,
+                        ),
+                        "daily": BudgetWindowSnapshot(
+                            window_start="2026-03-10T00:00:00Z",
+                            window_end="2026-03-10T23:59:59Z",
+                            cost_usd=0.50,
+                        ),
+                        "monthly": BudgetWindowSnapshot(
+                            window_start="2026-03-01T00:00:00Z",
+                            window_end="2026-03-31T23:59:59Z",
+                            cost_usd=20.0,
+                        ),
+                    },
+                },
+            )
+
+            decision_record = json.loads(Path(result["decision_record_path"]).read_text(encoding="utf-8"))
+            run_summary = json.loads((Path(result["artifact_dir"]) / "run_summary.json").read_text(encoding="utf-8"))
+            html = Path(result["html_path"]).read_text(encoding="utf-8")
+
+        self.assertEqual(decision_record["budget_snapshot"]["hourly_spend_usd"], 0.03)
+        self.assertEqual(decision_record["budget_snapshot"]["daily_spend_usd"], 0.51)
+        self.assertEqual(decision_record["budget_snapshot"]["monthly_spend_usd"], 20.01)
+        self.assertTrue(decision_record["budget_snapshot"]["allowed"])
+        self.assertEqual(decision_record["guardrail_checks"]["budget_check"], "pass")
+        self.assertEqual(run_summary["budget_snapshot"]["hourly_spend_usd"], 0.03)
+        self.assertEqual(run_summary["guardrail_checks"]["budget_check"], "pass")
+        self.assertIn("Budget: Pass", html)
+
+    def test_run_fixture_daily_brief_reports_diversity_failure_in_outputs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fixture_path = Path(tmpdir) / "fixture_payloads.json"
+            fixture_path.write_text(
+                json.dumps(
+                    {
+                        "wsj_markets": [
+                            {
+                                "url": "https://example.test/wsj-only",
+                                "title": "Cooling growth draws focus",
+                                "published_at": "2026-03-10T15:15:00Z",
+                                "fetched_at": "2026-03-10T15:20:00Z",
+                                "summary": "Cooling growth becomes the focus.",
+                                "doc_type": "news",
+                                "language": "en",
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = run_fixture_daily_brief(
+                base_dir=Path(tmpdir),
+                fixture_path=fixture_path,
+                run_id="run_fixture_diversity_fail",
+                generated_at_utc="2026-03-10T16:00:00Z",
+            )
+
+            decision_record = json.loads(Path(result["decision_record_path"]).read_text(encoding="utf-8"))
+            run_summary = json.loads((Path(result["artifact_dir"]) / "run_summary.json").read_text(encoding="utf-8"))
+            html = Path(result["html_path"]).read_text(encoding="utf-8")
+
+        self.assertEqual(result["status"], "abstained")
+        self.assertEqual(decision_record["guardrail_checks"]["diversity_check"], "fail")
+        self.assertEqual(run_summary["guardrail_checks"]["diversity_check"], "fail")
+        self.assertIn("Diversity: Fail", html)
+
+    def test_run_fixture_daily_brief_stops_before_stage_on_budget_preflight(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_fixture_daily_brief(
+                base_dir=Path(tmpdir),
+                run_id="run_fixture_budget_stop",
+                generated_at_utc="2026-03-10T16:00:00Z",
+                budget_preflight={
+                    "hourly_spend_usd": 0.09,
+                    "daily_spend_usd": 0.50,
+                    "monthly_spend_usd": 20.0,
+                    "next_estimated_cost_usd": 0.02,
+                    "caps": BudgetCaps(),
+                    "windows": {
+                        "hourly": BudgetWindowSnapshot(
+                            window_start="2026-03-10T16:00:00Z",
+                            window_end="2026-03-10T16:59:59Z",
+                            cost_usd=0.09,
+                        ),
+                        "daily": BudgetWindowSnapshot(
+                            window_start="2026-03-10T00:00:00Z",
+                            window_end="2026-03-10T23:59:59Z",
+                            cost_usd=0.50,
+                        ),
+                        "monthly": BudgetWindowSnapshot(
+                            window_start="2026-03-01T00:00:00Z",
+                            window_end="2026-03-31T23:59:59Z",
+                            cost_usd=20.0,
+                        ),
+                    },
+                },
+            )
+
+            decision_record = json.loads(Path(result["decision_record_path"]).read_text(encoding="utf-8"))
+
+        self.assertEqual(result["status"], "stopped_budget")
+        self.assertEqual(result["pipeline_status"], "stopped_budget")
+        self.assertEqual(decision_record["guardrail_checks"]["budget_check"], "fail")
+        self.assertFalse(decision_record["budget_snapshot"]["allowed"])
+        self.assertIsNone(result["html_path"])
 
     def test_run_fixture_daily_brief_abstains_when_evidence_is_insufficient(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/agent/retrieval/test_evidence_pack.py
+++ b/tests/agent/retrieval/test_evidence_pack.py
@@ -1,9 +1,102 @@
 import unittest
 
 from apps.agent.retrieval.evidence_pack import build_evidence_pack
+from apps.agent.retrieval.evidence_pack import build_evidence_pack_report
 
 
 class EvidencePackTests(unittest.TestCase):
+    def test_report_enforces_publisher_cap_when_alternatives_exist(self):
+        fts_rows = [
+            {
+                "chunk_id": "chunk_001",
+                "doc_id": "doc_001",
+                "text": "inflation inflation inflation",
+                "source_id": "src_reuters_a",
+                "publisher": "Reuters",
+                "published_at": "2026-03-10T10:00:00Z",
+                "credibility_tier": 2,
+            },
+            {
+                "chunk_id": "chunk_002",
+                "doc_id": "doc_002",
+                "text": "inflation inflation rates",
+                "source_id": "src_reuters_b",
+                "publisher": "Reuters",
+                "published_at": "2026-03-10T09:00:00Z",
+                "credibility_tier": 2,
+            },
+            {
+                "chunk_id": "chunk_003",
+                "doc_id": "doc_003",
+                "text": "inflation rates cooling",
+                "source_id": "src_reuters_c",
+                "publisher": "Reuters",
+                "published_at": "2026-03-10T08:00:00Z",
+                "credibility_tier": 2,
+            },
+            {
+                "chunk_id": "chunk_004",
+                "doc_id": "doc_004",
+                "text": "inflation update from fed",
+                "source_id": "src_fed",
+                "publisher": "Federal Reserve",
+                "published_at": "2026-03-10T07:00:00Z",
+                "credibility_tier": 1,
+            },
+            {
+                "chunk_id": "chunk_005",
+                "doc_id": "doc_005",
+                "text": "inflation update from bls",
+                "source_id": "src_bls",
+                "publisher": "BLS",
+                "published_at": "2026-03-10T06:00:00Z",
+                "credibility_tier": 1,
+            },
+            {
+                "chunk_id": "chunk_006",
+                "doc_id": "doc_006",
+                "text": "inflation update from ecb",
+                "source_id": "src_ecb",
+                "publisher": "ECB",
+                "published_at": "2026-03-10T05:00:00Z",
+                "credibility_tier": 1,
+            },
+        ]
+
+        report = build_evidence_pack_report(fts_rows=fts_rows, query_text="inflation", pack_size=5)
+
+        self.assertEqual(report["diversity_check"], "pass")
+        self.assertEqual(report["diversity_stats"]["max_publisher_pct"], 40.0)
+        self.assertEqual(sum(1 for item in report["items"] if item["publisher"] == "Reuters"), 2)
+
+    def test_report_flags_fail_when_candidate_pool_cannot_meet_diversity_rules(self):
+        fts_rows = [
+            {
+                "chunk_id": "chunk_001",
+                "doc_id": "doc_001",
+                "text": "inflation inflation inflation",
+                "source_id": "src_only_a",
+                "publisher": "Single Publisher",
+                "published_at": "2026-03-10T10:00:00Z",
+                "credibility_tier": 2,
+            },
+            {
+                "chunk_id": "chunk_002",
+                "doc_id": "doc_002",
+                "text": "inflation rates stay high",
+                "source_id": "src_only_b",
+                "publisher": "Single Publisher",
+                "published_at": "2026-03-10T09:00:00Z",
+                "credibility_tier": 2,
+            },
+        ]
+
+        report = build_evidence_pack_report(fts_rows=fts_rows, query_text="inflation", pack_size=2)
+
+        self.assertEqual(report["diversity_check"], "fail")
+        self.assertGreater(report["diversity_stats"]["max_publisher_pct"], 40.0)
+        self.assertTrue(any("publisher dominance" in note.lower() for note in report["notes"]))
+
     def test_orders_results_by_retrieval_score(self):
         fts_rows = [
             {

--- a/tests/agent/test_orchestrator.py
+++ b/tests/agent/test_orchestrator.py
@@ -185,6 +185,45 @@ class OrchestratorTests(unittest.TestCase):
         self.assertEqual(lifecycle_events[-1]["status"], "stopped_budget")
         self.assertEqual(len(result["budget_ledger_rows"]), 3)
 
+    def test_budget_preflight_surfaces_decision_on_allowed_run(self):
+        result = run_pipeline(
+            run_id="run_preflight_allowed",
+            run_type=RunType.DAILY_BRIEF,
+            stages=[lambda context: StageResult(status=RunStatus.OK)],
+            recorder=lambda snapshot: None,
+            budget_preflight={
+                "hourly_spend_usd": 0.02,
+                "daily_spend_usd": 0.50,
+                "monthly_spend_usd": 20.0,
+                "next_estimated_cost_usd": 0.01,
+                "caps": BudgetCaps(),
+                "windows": {
+                    "hourly": BudgetWindowSnapshot(
+                        window_start="2026-03-10T09:00:00Z",
+                        window_end="2026-03-10T09:59:59Z",
+                        cost_usd=0.02,
+                    ),
+                    "daily": BudgetWindowSnapshot(
+                        window_start="2026-03-10T00:00:00Z",
+                        window_end="2026-03-10T23:59:59Z",
+                        cost_usd=0.50,
+                    ),
+                    "monthly": BudgetWindowSnapshot(
+                        window_start="2026-03-01T00:00:00Z",
+                        window_end="2026-03-31T23:59:59Z",
+                        cost_usd=20.0,
+                    ),
+                },
+            },
+        )
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["budget_snapshot"]["hourly_spend_usd"], 0.03)
+        self.assertEqual(result["budget_snapshot"]["daily_spend_usd"], 0.51)
+        self.assertEqual(result["budget_snapshot"]["monthly_spend_usd"], 20.01)
+        self.assertTrue(result["budget_snapshot"]["allowed"])
+        self.assertEqual(len(result["budget_ledger_rows"]), 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- pass budget preflight through the daily-brief runtime and persist the real budget snapshot/ledger state
- enforce evidence-pack diversity where possible and record explicit diversity failures when the candidate pool cannot satisfy the guardrails
- render truthful budget/diversity guardrail outcomes in the daily-brief HTML, run summary, and decision record, including stopped-budget runs

## Verification
- python scripts/validate_artifacts.py
- python scripts/validate_decision_record_schema.py
- python -m compileall -q apps tests scripts
- python -m unittest discover -s tests -p "test_*.py" -v

Closes #48
