### PR TITLE
fix(daily-brief): honor validation retry policy

### DIFF
--- a/apps/agent/daily_brief/runner.py
+++ b/apps/agent/daily_brief/runner.py
@@ -19,6 +19,7 @@ from apps.agent.pipeline.stage8_validation import run_stage8_citation_validation
 from apps.agent.pipeline.types import (
     DAILY_BRIEF_OUTPUT_SECTIONS,
     BulletCitationRow,
+    CitationValidationResult,
     DailyBriefSectionBulletRow,
     DailyBriefSynthesis,
     DailyBriefCorpusStageData,
@@ -41,11 +42,13 @@ from apps.agent.runtime.cost_ledger import BudgetWindowSnapshot
 from apps.agent.runtime.source_scope import load_active_source_subset
 from apps.agent.runtime.source_scope import load_source_registry
 from apps.agent.synthesis.postprocess import finalize_validation_outcome
-from apps.agent.daily_brief.synthesis import build_citation_store, build_synthesis
+from apps.agent.daily_brief.synthesis import SynthesisRetryPlan, build_citation_store, build_synthesis
 
 
 ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_FIXTURE_PATH = ROOT / "artifacts" / "runtime" / "daily_brief_fixture_payloads.json"
+MAX_VALIDATION_RETRIES = 1
+MAX_VALIDATION_ATTEMPTS = MAX_VALIDATION_RETRIES + 1
 STOPWORDS = {
     "a",
     "and",
@@ -231,6 +234,9 @@ def _execute_daily_brief_slice(
             "chunks_indexed": context.counters.chunks_indexed,
             "stage8_status": synthesis_data.stage8_result["status"],
             "final_status": synthesis_data.final_result["status"],
+            "validation_attempts": synthesis_data.stage8_result["validation_attempts"],
+            "max_validation_attempts": synthesis_data.stage8_result["max_validation_attempts"],
+            "validation_retry_exhausted": synthesis_data.stage8_result["retry_exhausted"],
             "budget_snapshot": budget_snapshot,
             "budget_ledger_rows": list(context.budget_ledger_rows),
             "guardrail_checks": guardrail_checks,
@@ -339,22 +345,47 @@ def build_daily_brief_synthesis(
         documents_by_id=documents_by_id,
         chunks_by_id=chunks_by_id,
     )
-    synthesis = build_synthesis(
-        evidence_items=evidence_pack_items,
-        documents_by_id=documents_by_id,
-        citation_store=citation_store,
-    )
-
     validation_registry = _build_validation_registry(
         registry=registry,
         documents=stage_data.documents,
     )
-    stage8_result = run_stage8_citation_validation(
-        synthesis,
-        citation_store,
-        source_registry=validation_registry,
-        available_source_ids={str(item["source_id"]) for item in evidence_pack_items},
-    )
+    available_source_ids = {str(item["source_id"]) for item in evidence_pack_items}
+    stage8_result: CitationValidationResult | None = None
+    retry_plan: SynthesisRetryPlan | None = None
+    for validation_attempt in range(1, MAX_VALIDATION_ATTEMPTS + 1):
+        synthesis = build_synthesis(
+            evidence_items=evidence_pack_items,
+            documents_by_id=documents_by_id,
+            citation_store=citation_store,
+            retry_plan=retry_plan,
+        )
+        current_result = run_stage8_citation_validation(
+            synthesis,
+            citation_store,
+            source_registry=validation_registry,
+            available_source_ids=available_source_ids,
+        )
+        retry_exhausted = (
+            current_result["status"] == "retry"
+            and validation_attempt >= MAX_VALIDATION_ATTEMPTS
+        )
+        stage8_result = {
+            **current_result,
+            "validation_attempts": validation_attempt,
+            "max_validation_attempts": MAX_VALIDATION_ATTEMPTS,
+            "retry_exhausted": retry_exhausted,
+        }
+        if current_result["status"] != "retry" or retry_exhausted:
+            break
+        retry_plan = _build_retry_plan(
+            synthesis=synthesis,
+            validation_result=current_result,
+            citation_store=citation_store,
+        )
+
+    if stage8_result is None:
+        raise ValueError("Daily brief synthesis did not produce a validation result.")
+
     final_result = finalize_validation_outcome(validation_result=stage8_result)
     synthesis_id = f"syn_{run_id}"
     return DailyBriefSynthesisStageData(
@@ -374,6 +405,84 @@ def build_daily_brief_synthesis(
             synthesis_id=synthesis_id,
         ),
     )
+
+
+def _build_retry_plan(
+    *,
+    synthesis: DailyBriefSynthesis,
+    validation_result: CitationValidationResult,
+    citation_store: Mapping[str, Mapping[str, Any]],
+) -> SynthesisRetryPlan:
+    target_sections = tuple(
+        section
+        for section in validation_result["report"].get("empty_core_sections", [])
+        if section in {"prevailing", "counter", "minority", "watch"}
+    )
+    validated_synthesis = validation_result["synthesis"]
+    pinned_chunk_ids_by_section: dict[str, str] = {}
+    blocked_chunk_ids: set[str] = set()
+
+    for section in ("prevailing", "counter", "minority", "watch"):
+        validated_chunk_ids = _chunk_ids_for_section(
+            synthesis=validated_synthesis,
+            section=section,
+            citation_store=citation_store,
+        )
+        if section in target_sections or not validated_chunk_ids:
+            blocked_chunk_ids.update(
+                _chunk_ids_for_section(
+                    synthesis=synthesis,
+                    section=section,
+                    citation_store=citation_store,
+                )
+            )
+            continue
+        pinned_chunk_ids_by_section[section] = validated_chunk_ids[0]
+
+    if not target_sections:
+        target_sections = tuple(
+            section
+            for section in ("prevailing", "counter", "minority", "watch")
+            if section not in pinned_chunk_ids_by_section
+        )
+        for section in target_sections:
+            blocked_chunk_ids.update(
+                _chunk_ids_for_section(
+                    synthesis=synthesis,
+                    section=section,
+                    citation_store=citation_store,
+                )
+            )
+
+    return SynthesisRetryPlan(
+        pinned_chunk_ids_by_section=pinned_chunk_ids_by_section,
+        target_sections=target_sections,
+        blocked_chunk_ids=frozenset(blocked_chunk_ids),
+    )
+
+
+def _chunk_ids_for_section(
+    *,
+    synthesis: Mapping[str, Any],
+    section: str,
+    citation_store: Mapping[str, Mapping[str, Any]],
+) -> list[str]:
+    bullets = synthesis.get(section, [])
+    if not isinstance(bullets, list):
+        return []
+
+    chunk_ids: list[str] = []
+    for bullet in bullets:
+        if not isinstance(bullet, Mapping):
+            continue
+        citation_ids = bullet.get("citation_ids", [])
+        if not isinstance(citation_ids, list):
+            continue
+        for citation_id in citation_ids:
+            citation = citation_store.get(str(citation_id))
+            if isinstance(citation, Mapping) and citation.get("chunk_id") is not None:
+                chunk_ids.append(str(citation["chunk_id"]))
+    return chunk_ids
 
 
 def _build_source_row(*, source: SourceRegistryEntry, generated_at_utc: str) -> SourceRow:
@@ -527,6 +636,11 @@ def _guardrail_checks(
         notes.append("Citation validation did not run because budget preflight stopped the run.")
     if final_status == "abstained":
         notes.append("Daily brief downgraded to abstain after citation validation.")
+    validation_attempts = 0
+    if stage8_result is not None:
+        validation_attempts = int(stage8_result.get("validation_attempts", 1))
+    if validation_attempts > 1:
+        notes.append(f"Citation validation required {validation_attempts} synthesis attempt(s).")
     removed_bullets = 0
     if stage8_result is not None:
         removed_bullets = int(stage8_result["report"]["removed_bullets"])

--- a/apps/agent/daily_brief/synthesis.py
+++ b/apps/agent/daily_brief/synthesis.py
@@ -50,6 +50,13 @@ class _SectionCandidate:
     scores: dict[DailyBriefOutputSection, int]
 
 
+@dataclass(frozen=True)
+class SynthesisRetryPlan:
+    pinned_chunk_ids_by_section: Mapping[DailyBriefOutputSection, str]
+    target_sections: tuple[DailyBriefOutputSection, ...]
+    blocked_chunk_ids: frozenset[str]
+
+
 def build_citation_store(
     *,
     evidence_items: Iterable[Mapping[str, Any]],
@@ -86,6 +93,7 @@ def build_synthesis(
     evidence_items: Iterable[Mapping[str, Any]],
     documents_by_id: Mapping[str, Mapping[str, Any]],
     citation_store: Mapping[str, Mapping[str, Any]],
+    retry_plan: SynthesisRetryPlan | None = None,
 ) -> DailyBriefSynthesis:
     synthesis = {section: [] for section in DAILY_BRIEF_CORE_OUTPUT_SECTIONS}
     candidates = _build_section_candidates(
@@ -93,7 +101,7 @@ def build_synthesis(
         documents_by_id=documents_by_id,
         citation_store=citation_store,
     )
-    assignments = _assign_sections(candidates)
+    assignments = _assign_sections(candidates, retry_plan=retry_plan)
 
     for section in DAILY_BRIEF_CORE_OUTPUT_SECTIONS:
         candidate = assignments.get(section)
@@ -154,11 +162,39 @@ def _build_section_candidates(
 
 def _assign_sections(
     candidates: Iterable[_SectionCandidate],
+    *,
+    retry_plan: SynthesisRetryPlan | None = None,
 ) -> dict[DailyBriefOutputSection, _SectionCandidate]:
     ordered_candidates = list(candidates)
+    candidates_by_chunk_id = {candidate.chunk_id: candidate for candidate in ordered_candidates}
     best_assignment: dict[DailyBriefOutputSection, _SectionCandidate] = {}
     best_key: tuple[int, tuple[tuple[int, int, str], ...]] | None = None
+    blocked_chunk_ids = frozenset()
+    seeded_assignment: dict[DailyBriefOutputSection, _SectionCandidate] = {}
+    used_chunk_ids = frozenset()
     search_order: tuple[DailyBriefOutputSection, ...] = ("watch", "counter", "minority", "prevailing")
+
+    if retry_plan is not None:
+        blocked_chunk_ids = frozenset(retry_plan.blocked_chunk_ids)
+        used_chunk_ids_mutable: set[str] = set()
+        for section, chunk_id in retry_plan.pinned_chunk_ids_by_section.items():
+            candidate = candidates_by_chunk_id.get(chunk_id)
+            if candidate is None or candidate.chunk_id in blocked_chunk_ids:
+                continue
+            seeded_assignment[section] = candidate
+            used_chunk_ids_mutable.add(candidate.chunk_id)
+        used_chunk_ids = frozenset(used_chunk_ids_mutable)
+        prioritized_targets = tuple(
+            section
+            for section in retry_plan.target_sections
+            if section not in seeded_assignment
+        )
+        remaining_sections = tuple(
+            section
+            for section in search_order
+            if section not in seeded_assignment and section not in prioritized_targets
+        )
+        search_order = prioritized_targets + remaining_sections
 
     def search(
         section_index: int,
@@ -176,7 +212,7 @@ def _assign_sections(
         section = search_order[section_index]
         assigned_any = False
         for candidate in ordered_candidates:
-            if candidate.chunk_id in used_chunk_ids:
+            if candidate.chunk_id in used_chunk_ids or candidate.chunk_id in blocked_chunk_ids:
                 continue
             assigned_any = True
             assignment[section] = candidate
@@ -190,7 +226,7 @@ def _assign_sections(
         if not assigned_any:
             search(section_index + 1, used_chunk_ids, assignment)
 
-    search(0, frozenset(), {})
+    search(0, used_chunk_ids, dict(seeded_assignment))
     return best_assignment
 
 

--- a/apps/agent/orchestrator.py
+++ b/apps/agent/orchestrator.py
@@ -31,6 +31,9 @@ def run_pipeline(
     max_stage_attempts: int = 1,
     budget_preflight: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
+    if max_stage_attempts < 1:
+        raise ValueError("max_stage_attempts must be at least 1")
+
     started_at = _utc_now_iso()
     normalized_run_type = _normalize_run_type(run_type)
     context = RunContext(

--- a/apps/agent/pipeline/stage8_validation.py
+++ b/apps/agent/pipeline/stage8_validation.py
@@ -36,4 +36,7 @@ def run_stage8_citation_validation(
         "synthesis": report.synthesis,
         "citation_store": report.citation_store,
         "report": report.to_dict(),
+        "validation_attempts": 1,
+        "max_validation_attempts": 1,
+        "retry_exhausted": status == "retry",
     }

--- a/apps/agent/pipeline/types.py
+++ b/apps/agent/pipeline/types.py
@@ -189,6 +189,9 @@ class CitationValidationResult(TypedDict):
     synthesis: DailyBriefSynthesis
     citation_store: dict[str, CitationStoreEntry]
     report: CitationValidationReport
+    validation_attempts: int
+    max_validation_attempts: int
+    retry_exhausted: bool
 
 
 class FinalSynthesisResult(TypedDict):

--- a/apps/agent/synthesis/postprocess.py
+++ b/apps/agent/synthesis/postprocess.py
@@ -31,6 +31,9 @@ def finalize_validation_outcome(*, validation_result: dict[str, object]) -> Fina
             "abstain_reason": None,
         }
 
+    if not bool(validation_result.get("retry_exhausted", False)):
+        raise ValueError("Validation retry policy must be exhausted before abstaining.")
+
     abstain_reason = "validation_retry_exhausted"
     return {
         "status": "abstained",

--- a/artifacts/modelling/citation_contract.md
+++ b/artifacts/modelling/citation_contract.md
@@ -250,7 +250,10 @@ We were unable to generate a complete daily brief for [date] due to insufficient
 ### Retry Cost Guards
 
 - **Max retries:** 1 (total 2 synthesis attempts per daily brief)
+- **Attempt contract:** attempt 1 may return `retry`; attempt 2 is the terminal attempt and MUST set `retry_exhausted: true` if validation still returns `retry`
+- **Postprocess rule:** only convert a `retry` validation result into an abstaining output after the retry budget is exhausted
 - **Retry triggers logging:** Record retry reason, removed bullets count, evidence pack diversity stats
+- **Runtime reporting:** persist `validation_attempts`, `max_validation_attempts`, and `validation_retry_exhausted` beside the normal budget snapshot so retry work is visible without fabricating extra spend
 - **Abort after 2nd failure:** Do not loop indefinitely; deliver abstaining report
 
 **Rationale:** This prevents scenarios where poor evidence packs cause repeated expensive synthesis calls. Better to abstain explicitly than burn budget retrying.

--- a/tests/agent/daily_brief/test_runner.py
+++ b/tests/agent/daily_brief/test_runner.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import get_args, get_type_hints
+from unittest.mock import patch
 
 from apps.agent.daily_brief.runner import (
     build_daily_brief_query,
@@ -14,6 +15,7 @@ from apps.agent.daily_brief.runner import (
     load_active_fixture_payloads,
     run_fixture_daily_brief,
 )
+from apps.agent.daily_brief.synthesis import build_citation_store
 from apps.agent.pipeline.types import (
     BulletCitationRow,
     CitationStoreEntry,
@@ -39,6 +41,330 @@ from apps.agent.runtime.cost_ledger import BudgetWindowSnapshot
 
 
 class DailyBriefRunnerTests(unittest.TestCase):
+    def test_build_daily_brief_synthesis_retry_reassigns_failed_section_without_retry_metadata(self):
+        stage_data = DailyBriefCorpusStageData(
+            source_rows=[],
+            documents=[
+                {
+                    "source_id": "bls_preview",
+                    "publisher": "BLS Preview Desk",
+                    "canonical_url": "https://example.test/watch",
+                    "title": "Watch Friday CPI for shelter inflation",
+                    "author": None,
+                    "language": "en",
+                    "doc_type": "analysis",
+                    "published_at": "2026-03-10T16:00:00Z",
+                    "fetched_at": "2026-03-10T16:05:00Z",
+                    "paywall_policy": "full",
+                    "metadata_only": 0,
+                    "rss_snippet": "Markets are watching Friday CPI for shelter inflation surprises.",
+                    "body_text": "Watch Friday CPI for shelter inflation surprises.",
+                    "content_hash": "hash_watch",
+                    "status": "active",
+                    "created_at": "2026-03-10T16:05:00Z",
+                    "updated_at": "2026-03-10T16:05:00Z",
+                    "doc_id": "doc_watch",
+                    "credibility_tier": 1,
+                    "ingestion_run_id": "run_retry_real",
+                },
+                {
+                    "source_id": "market_commentary",
+                    "publisher": "Market Commentary",
+                    "canonical_url": "https://example.test/minority",
+                    "title": "Minority view still expects a hard landing",
+                    "author": None,
+                    "language": "en",
+                    "doc_type": "analysis",
+                    "published_at": "2026-03-10T15:30:00Z",
+                    "fetched_at": "2026-03-10T15:35:00Z",
+                    "paywall_policy": "full",
+                    "metadata_only": 0,
+                    "rss_snippet": "A minority of investors still expects a hard landing.",
+                    "body_text": "A minority of investors still expects a hard landing.",
+                    "content_hash": "hash_minority",
+                    "status": "active",
+                    "created_at": "2026-03-10T15:35:00Z",
+                    "updated_at": "2026-03-10T15:35:00Z",
+                    "doc_id": "doc_minority",
+                    "credibility_tier": 3,
+                    "ingestion_run_id": "run_retry_real",
+                },
+                {
+                    "source_id": "fed_press_releases",
+                    "publisher": "Federal Reserve",
+                    "canonical_url": "https://example.test/prevailing",
+                    "title": "Fed keeps policy steady",
+                    "author": None,
+                    "language": "en",
+                    "doc_type": "statement",
+                    "published_at": "2026-03-10T14:00:00Z",
+                    "fetched_at": "2026-03-10T14:05:00Z",
+                    "paywall_policy": "full",
+                    "metadata_only": 0,
+                    "rss_snippet": "Fed officials kept policy steady while inflation progress remained uneven.",
+                    "body_text": "Fed officials kept policy steady while inflation progress remained uneven.",
+                    "content_hash": "hash_prevailing",
+                    "status": "active",
+                    "created_at": "2026-03-10T14:05:00Z",
+                    "updated_at": "2026-03-10T14:05:00Z",
+                    "doc_id": "doc_prevailing",
+                    "credibility_tier": 1,
+                    "ingestion_run_id": "run_retry_real",
+                },
+                {
+                    "source_id": "reuters_business",
+                    "publisher": "Reuters",
+                    "canonical_url": "https://example.test/counter-invalid",
+                    "title": "Bond traders push back on soft-landing consensus",
+                    "author": None,
+                    "language": "en",
+                    "doc_type": "news",
+                    "published_at": None,
+                    "fetched_at": "2026-03-10T14:35:00Z",
+                    "paywall_policy": "full",
+                    "metadata_only": 0,
+                    "rss_snippet": "Bond traders push back on the soft-landing consensus as growth cools.",
+                    "body_text": "Bond traders push back on the soft-landing consensus as growth cools.",
+                    "content_hash": "hash_counter_invalid",
+                    "status": "active",
+                    "created_at": "2026-03-10T14:35:00Z",
+                    "updated_at": "2026-03-10T14:35:00Z",
+                    "doc_id": "doc_counter_invalid",
+                    "credibility_tier": 2,
+                    "ingestion_run_id": "run_retry_real",
+                },
+                {
+                    "source_id": "wsj_markets",
+                    "publisher": "Wall Street Journal",
+                    "canonical_url": "https://example.test/counter-retry",
+                    "title": "Investors question the soft-landing narrative",
+                    "author": None,
+                    "language": "en",
+                    "doc_type": "news",
+                    "published_at": "2026-03-10T14:20:00Z",
+                    "fetched_at": "2026-03-10T14:25:00Z",
+                    "paywall_policy": "full",
+                    "metadata_only": 0,
+                    "rss_snippet": "Investors question the soft-landing narrative as growth data weakens.",
+                    "body_text": "Investors question the soft-landing narrative as growth data weakens.",
+                    "content_hash": "hash_counter_retry",
+                    "status": "active",
+                    "created_at": "2026-03-10T14:25:00Z",
+                    "updated_at": "2026-03-10T14:25:00Z",
+                    "doc_id": "doc_counter_retry",
+                    "credibility_tier": 2,
+                    "ingestion_run_id": "run_retry_real",
+                },
+            ],
+            chunks=[
+                {"chunk_id": "doc_watch_chunk_000", "doc_id": "doc_watch", "chunk_index": 0, "text": "Watch Friday CPI for shelter inflation surprises.", "token_count": 6, "char_start": 0, "char_end": 43, "created_at": "2026-03-10T16:05:00Z"},
+                {"chunk_id": "doc_minority_chunk_000", "doc_id": "doc_minority", "chunk_index": 0, "text": "A minority of investors still expects a hard landing.", "token_count": 9, "char_start": 0, "char_end": 55, "created_at": "2026-03-10T15:35:00Z"},
+                {"chunk_id": "doc_prevailing_chunk_000", "doc_id": "doc_prevailing", "chunk_index": 0, "text": "Fed officials kept policy steady while inflation progress remained uneven.", "token_count": 10, "char_start": 0, "char_end": 71, "created_at": "2026-03-10T14:05:00Z"},
+                {"chunk_id": "doc_counter_invalid_chunk_000", "doc_id": "doc_counter_invalid", "chunk_index": 0, "text": "Bond traders push back on the soft-landing consensus as growth cools.", "token_count": 10, "char_start": 0, "char_end": 70, "created_at": "2026-03-10T14:35:00Z"},
+                {"chunk_id": "doc_counter_retry_chunk_000", "doc_id": "doc_counter_retry", "chunk_index": 0, "text": "Investors question the soft-landing narrative as growth data weakens.", "token_count": 9, "char_start": 0, "char_end": 68, "created_at": "2026-03-10T14:25:00Z"},
+            ],
+            fts_rows=[
+                {"text": "Watch Friday CPI for shelter inflation surprises.", "doc_id": "doc_watch", "chunk_id": "doc_watch_chunk_000", "publisher": "BLS Preview Desk", "source_id": "bls_preview", "published_at": "2026-03-10T16:00:00Z", "credibility_tier": 1},
+                {"text": "A minority of investors still expects a hard landing.", "doc_id": "doc_minority", "chunk_id": "doc_minority_chunk_000", "publisher": "Market Commentary", "source_id": "market_commentary", "published_at": "2026-03-10T15:30:00Z", "credibility_tier": 3},
+                {"text": "Fed officials kept policy steady while inflation progress remained uneven.", "doc_id": "doc_prevailing", "chunk_id": "doc_prevailing_chunk_000", "publisher": "Federal Reserve", "source_id": "fed_press_releases", "published_at": "2026-03-10T14:00:00Z", "credibility_tier": 1},
+                {"text": "Bond traders push back on the soft-landing consensus as growth cools.", "doc_id": "doc_counter_invalid", "chunk_id": "doc_counter_invalid_chunk_000", "publisher": "Reuters", "source_id": "reuters_business", "published_at": None, "credibility_tier": 2},
+                {"text": "Investors question the soft-landing narrative as growth data weakens.", "doc_id": "doc_counter_retry", "chunk_id": "doc_counter_retry_chunk_000", "publisher": "Wall Street Journal", "source_id": "wsj_markets", "published_at": "2026-03-10T14:20:00Z", "credibility_tier": 2},
+            ],
+        )
+        registry = {
+            "bls_preview": {"id": "bls_preview", "name": "BLS Preview Desk", "url": "https://example.test/watch", "type": "rss", "credibility_tier": 1, "paywall_policy": "full", "fetch_interval": "daily", "tags": ["macro_data"]},
+            "market_commentary": {"id": "market_commentary", "name": "Market Commentary", "url": "https://example.test/minority", "type": "rss", "credibility_tier": 3, "paywall_policy": "full", "fetch_interval": "daily", "tags": ["market_narrative"]},
+            "fed_press_releases": {"id": "fed_press_releases", "name": "Federal Reserve", "url": "https://example.test/prevailing", "type": "rss", "credibility_tier": 1, "paywall_policy": "full", "fetch_interval": "daily", "tags": ["policy_centralbank"]},
+            "reuters_business": {"id": "reuters_business", "name": "Reuters", "url": "https://example.test/counter-invalid", "type": "rss", "credibility_tier": 2, "paywall_policy": "full", "fetch_interval": "daily", "tags": ["market_narrative"]},
+            "wsj_markets": {"id": "wsj_markets", "name": "Wall Street Journal", "url": "https://example.test/counter-retry", "type": "rss", "credibility_tier": 2, "paywall_policy": "full", "fetch_interval": "daily", "tags": ["market_narrative"]},
+        }
+
+        with patch("apps.agent.daily_brief.runner.build_evidence_pack_report") as evidence_pack_report_mock:
+            evidence_pack_report_mock.return_value = {
+                "items": [
+                    {"chunk_id": "doc_watch_chunk_000", "source_id": "bls_preview", "publisher": "BLS Preview Desk", "credibility_tier": 1, "retrieval_score": 0.95, "semantic_score": 0.95, "recency_score": 0.90, "credibility_score": 1.0, "rank_in_pack": 1},
+                    {"chunk_id": "doc_minority_chunk_000", "source_id": "market_commentary", "publisher": "Market Commentary", "credibility_tier": 3, "retrieval_score": 0.90, "semantic_score": 0.90, "recency_score": 0.80, "credibility_score": 0.6, "rank_in_pack": 2},
+                    {"chunk_id": "doc_prevailing_chunk_000", "source_id": "fed_press_releases", "publisher": "Federal Reserve", "credibility_tier": 1, "retrieval_score": 0.88, "semantic_score": 0.88, "recency_score": 0.70, "credibility_score": 1.0, "rank_in_pack": 3},
+                    {"chunk_id": "doc_counter_invalid_chunk_000", "source_id": "reuters_business", "publisher": "Reuters", "credibility_tier": 2, "retrieval_score": 0.86, "semantic_score": 0.86, "recency_score": 0.68, "credibility_score": 0.8, "rank_in_pack": 4},
+                    {"chunk_id": "doc_counter_retry_chunk_000", "source_id": "wsj_markets", "publisher": "Wall Street Journal", "credibility_tier": 2, "retrieval_score": 0.84, "semantic_score": 0.84, "recency_score": 0.66, "credibility_score": 0.8, "rank_in_pack": 5},
+                ],
+                "diversity_stats": {"unique_publishers": 5},
+                "diversity_check": "pass",
+                "notes": [],
+            }
+
+            synthesis = build_daily_brief_synthesis(
+                stage_data=stage_data,
+                registry=registry,
+                run_id="run_retry_real",
+            )
+
+        self.assertEqual(synthesis.stage8_result["status"], "ok")
+        self.assertEqual(synthesis.stage8_result["validation_attempts"], 2)
+        self.assertFalse(synthesis.stage8_result["retry_exhausted"])
+        self.assertEqual(synthesis.final_result["synthesis"]["counter"][0]["citation_ids"], ["cite_005"])
+        self.assertNotIn("meta", synthesis.final_result["synthesis"])
+
+    def test_build_daily_brief_synthesis_retries_once_before_returning_validated_output(self):
+        stage_inputs = prepare_daily_brief_inputs(generated_at_utc="2026-03-10T16:00:00Z")
+        context = RunContext(
+            run_id="run_daily_fixture",
+            run_type=RunType.DAILY_BRIEF,
+            started_at="2026-03-10T16:00:00Z",
+            status=RunStatus.RUNNING,
+        )
+        corpus = build_daily_brief_corpus(
+            stage_data=stage_inputs,
+            run_id="run_daily_fixture",
+            context=context,
+        )
+        first_attempt = {
+            "prevailing": [{"text": "First attempt prevailing.", "citation_ids": ["cite_001"]}],
+            "counter": [],
+            "minority": [],
+            "watch": [],
+        }
+        retried_attempt = {
+            "prevailing": [{"text": "Retried prevailing.", "citation_ids": ["cite_001"]}],
+            "counter": [{"text": "Retried counter.", "citation_ids": ["cite_002"]}],
+            "minority": [{"text": "Retried minority.", "citation_ids": ["cite_003"]}],
+            "watch": [{"text": "Retried watch.", "citation_ids": ["cite_004"]}],
+        }
+        citation_store = {
+            "cite_001": {"citation_id": "cite_001", "source_id": "src1", "publisher": "Pub 1", "doc_id": "doc_001", "chunk_id": "chunk_001", "url": "https://example.test/1", "title": "Doc 1", "published_at": "2026-03-10T10:00:00Z", "fetched_at": "2026-03-10T10:05:00Z", "paywall_policy": "full", "quote_text": "Quote 1", "snippet_text": "Snippet 1"},
+            "cite_002": {"citation_id": "cite_002", "source_id": "src2", "publisher": "Pub 2", "doc_id": "doc_002", "chunk_id": "chunk_002", "url": "https://example.test/2", "title": "Doc 2", "published_at": "2026-03-10T11:00:00Z", "fetched_at": "2026-03-10T11:05:00Z", "paywall_policy": "full", "quote_text": "Quote 2", "snippet_text": "Snippet 2"},
+            "cite_003": {"citation_id": "cite_003", "source_id": "src3", "publisher": "Pub 3", "doc_id": "doc_003", "chunk_id": "chunk_003", "url": "https://example.test/3", "title": "Doc 3", "published_at": "2026-03-10T12:00:00Z", "fetched_at": "2026-03-10T12:05:00Z", "paywall_policy": "full", "quote_text": "Quote 3", "snippet_text": "Snippet 3"},
+            "cite_004": {"citation_id": "cite_004", "source_id": "src4", "publisher": "Pub 4", "doc_id": "doc_004", "chunk_id": "chunk_004", "url": "https://example.test/4", "title": "Doc 4", "published_at": "2026-03-10T13:00:00Z", "fetched_at": "2026-03-10T13:05:00Z", "paywall_policy": "full", "quote_text": "Quote 4", "snippet_text": "Snippet 4"},
+        }
+
+        with patch("apps.agent.daily_brief.runner.build_synthesis") as build_synthesis_mock, patch(
+            "apps.agent.daily_brief.runner.run_stage8_citation_validation"
+        ) as validation_mock:
+            build_synthesis_mock.side_effect = [first_attempt, retried_attempt]
+            validation_mock.side_effect = [
+                {
+                    "status": "retry",
+                    "synthesis": first_attempt,
+                    "citation_store": citation_store,
+                    "report": {
+                        "removed_bullets": 4,
+                        "empty_core_sections": ["counter", "minority", "watch"],
+                        "total_bullets": 1,
+                        "cited_bullets": 1,
+                        "validation_passed": False,
+                        "should_retry": True,
+                        "synthesis": first_attempt,
+                        "citation_store": citation_store,
+                    },
+                },
+                {
+                    "status": "ok",
+                    "synthesis": retried_attempt,
+                    "citation_store": citation_store,
+                    "report": {
+                        "removed_bullets": 0,
+                        "empty_core_sections": [],
+                        "total_bullets": 4,
+                        "cited_bullets": 4,
+                        "validation_passed": True,
+                        "should_retry": False,
+                        "synthesis": retried_attempt,
+                        "citation_store": citation_store,
+                    },
+                },
+            ]
+
+            synthesis = build_daily_brief_synthesis(
+                stage_data=corpus,
+                registry=stage_inputs.registry,
+                run_id="run_daily_fixture",
+            )
+
+        self.assertEqual(validation_mock.call_count, 2)
+        self.assertIsNone(build_synthesis_mock.call_args_list[0].kwargs["retry_plan"])
+        self.assertIsNotNone(build_synthesis_mock.call_args_list[1].kwargs["retry_plan"])
+        self.assertEqual(synthesis.stage8_result["validation_attempts"], 2)
+        self.assertEqual(synthesis.stage8_result["max_validation_attempts"], 2)
+        self.assertFalse(synthesis.stage8_result["retry_exhausted"])
+        self.assertEqual(synthesis.final_result["status"], "ok")
+
+    def test_build_daily_brief_synthesis_abstains_after_retry_exhaustion(self):
+        stage_inputs = prepare_daily_brief_inputs(generated_at_utc="2026-03-10T16:00:00Z")
+        context = RunContext(
+            run_id="run_daily_fixture",
+            run_type=RunType.DAILY_BRIEF,
+            started_at="2026-03-10T16:00:00Z",
+            status=RunStatus.RUNNING,
+        )
+        corpus = build_daily_brief_corpus(
+            stage_data=stage_inputs,
+            run_id="run_daily_fixture",
+            context=context,
+        )
+        first_attempt = {
+            "prevailing": [{"text": "First attempt prevailing.", "citation_ids": ["cite_001"]}],
+            "counter": [],
+            "minority": [],
+            "watch": [],
+        }
+        second_attempt = {
+            "prevailing": [],
+            "counter": [],
+            "minority": [],
+            "watch": [],
+        }
+
+        with patch("apps.agent.daily_brief.runner.build_synthesis") as build_synthesis_mock, patch(
+            "apps.agent.daily_brief.runner.run_stage8_citation_validation"
+        ) as validation_mock:
+            build_synthesis_mock.side_effect = [first_attempt, second_attempt]
+            validation_mock.side_effect = [
+                {
+                    "status": "retry",
+                    "synthesis": first_attempt,
+                    "citation_store": {},
+                    "report": {
+                        "removed_bullets": 4,
+                        "empty_core_sections": ["counter", "minority", "watch"],
+                        "total_bullets": 1,
+                        "cited_bullets": 1,
+                        "validation_passed": False,
+                        "should_retry": True,
+                        "synthesis": first_attempt,
+                        "citation_store": {},
+                    },
+                },
+                {
+                    "status": "retry",
+                    "synthesis": second_attempt,
+                    "citation_store": {},
+                    "report": {
+                        "removed_bullets": 4,
+                        "empty_core_sections": ["prevailing", "counter", "minority", "watch"],
+                        "total_bullets": 0,
+                        "cited_bullets": 0,
+                        "validation_passed": False,
+                        "should_retry": True,
+                        "synthesis": second_attempt,
+                        "citation_store": {},
+                    },
+                },
+            ]
+
+            synthesis = build_daily_brief_synthesis(
+                stage_data=corpus,
+                registry=stage_inputs.registry,
+                run_id="run_daily_fixture",
+            )
+
+        self.assertEqual(validation_mock.call_count, 2)
+        self.assertEqual(synthesis.stage8_result["status"], "retry")
+        self.assertEqual(synthesis.stage8_result["validation_attempts"], 2)
+        self.assertEqual(synthesis.stage8_result["max_validation_attempts"], 2)
+        self.assertTrue(synthesis.stage8_result["retry_exhausted"])
+        self.assertEqual(synthesis.final_result["status"], "abstained")
+        self.assertEqual(synthesis.final_result["abstain_reason"], "validation_retry_exhausted")
+
     def test_stage_payload_annotations_use_named_contract_types(self):
         input_hints = get_type_hints(DailyBriefInputStageData)
         corpus_hints = get_type_hints(DailyBriefCorpusStageData)
@@ -251,6 +577,100 @@ class DailyBriefRunnerTests(unittest.TestCase):
         self.assertEqual(run_summary["budget_snapshot"]["hourly_spend_usd"], 0.03)
         self.assertEqual(run_summary["guardrail_checks"]["budget_check"], "pass")
         self.assertIn("Budget: Pass", html)
+
+    def test_run_fixture_daily_brief_reports_retry_attempts_without_double_counting_budget(self):
+        first_attempt = {
+            "prevailing": [{"text": "First attempt prevailing.", "citation_ids": ["cite_001"]}],
+            "counter": [],
+            "minority": [],
+            "watch": [],
+        }
+        retried_attempt = {
+            "prevailing": [{"text": "Retried prevailing.", "citation_ids": ["cite_001"]}],
+            "counter": [{"text": "Retried counter.", "citation_ids": ["cite_002"]}],
+            "minority": [{"text": "Retried minority.", "citation_ids": ["cite_003"]}],
+            "watch": [{"text": "Retried watch.", "citation_ids": ["cite_004"]}],
+        }
+        citation_store = {
+            "cite_001": {"citation_id": "cite_001", "source_id": "src1", "publisher": "Pub 1", "doc_id": "doc_001", "chunk_id": "chunk_001", "url": "https://example.test/1", "title": "Doc 1", "published_at": "2026-03-10T10:00:00Z", "fetched_at": "2026-03-10T10:05:00Z", "paywall_policy": "full", "quote_text": "Quote 1", "snippet_text": "Snippet 1"},
+            "cite_002": {"citation_id": "cite_002", "source_id": "src2", "publisher": "Pub 2", "doc_id": "doc_002", "chunk_id": "chunk_002", "url": "https://example.test/2", "title": "Doc 2", "published_at": "2026-03-10T11:00:00Z", "fetched_at": "2026-03-10T11:05:00Z", "paywall_policy": "full", "quote_text": "Quote 2", "snippet_text": "Snippet 2"},
+            "cite_003": {"citation_id": "cite_003", "source_id": "src3", "publisher": "Pub 3", "doc_id": "doc_003", "chunk_id": "chunk_003", "url": "https://example.test/3", "title": "Doc 3", "published_at": "2026-03-10T12:00:00Z", "fetched_at": "2026-03-10T12:05:00Z", "paywall_policy": "full", "quote_text": "Quote 3", "snippet_text": "Snippet 3"},
+            "cite_004": {"citation_id": "cite_004", "source_id": "src4", "publisher": "Pub 4", "doc_id": "doc_004", "chunk_id": "chunk_004", "url": "https://example.test/4", "title": "Doc 4", "published_at": "2026-03-10T13:00:00Z", "fetched_at": "2026-03-10T13:05:00Z", "paywall_policy": "full", "quote_text": "Quote 4", "snippet_text": "Snippet 4"},
+        }
+
+        with patch("apps.agent.daily_brief.runner.build_synthesis") as build_synthesis_mock, patch(
+            "apps.agent.daily_brief.runner.run_stage8_citation_validation"
+        ) as validation_mock, tempfile.TemporaryDirectory() as tmpdir:
+            build_synthesis_mock.side_effect = [first_attempt, retried_attempt]
+            validation_mock.side_effect = [
+                {
+                    "status": "retry",
+                    "synthesis": first_attempt,
+                    "citation_store": citation_store,
+                    "report": {
+                        "removed_bullets": 4,
+                        "empty_core_sections": ["counter", "minority", "watch"],
+                        "total_bullets": 1,
+                        "cited_bullets": 1,
+                        "validation_passed": False,
+                        "should_retry": True,
+                        "synthesis": first_attempt,
+                        "citation_store": citation_store,
+                    },
+                },
+                {
+                    "status": "ok",
+                    "synthesis": retried_attempt,
+                    "citation_store": citation_store,
+                    "report": {
+                        "removed_bullets": 0,
+                        "empty_core_sections": [],
+                        "total_bullets": 4,
+                        "cited_bullets": 4,
+                        "validation_passed": True,
+                        "should_retry": False,
+                        "synthesis": retried_attempt,
+                        "citation_store": citation_store,
+                    },
+                },
+            ]
+            result = run_fixture_daily_brief(
+                base_dir=Path(tmpdir),
+                run_id="run_fixture_retry_truth",
+                generated_at_utc="2026-03-10T16:00:00Z",
+                budget_preflight={
+                    "hourly_spend_usd": 0.02,
+                    "daily_spend_usd": 0.50,
+                    "monthly_spend_usd": 20.0,
+                    "next_estimated_cost_usd": 0.01,
+                    "caps": BudgetCaps(),
+                    "windows": {
+                        "hourly": BudgetWindowSnapshot(
+                            window_start="2026-03-10T16:00:00Z",
+                            window_end="2026-03-10T16:59:59Z",
+                            cost_usd=0.02,
+                        ),
+                        "daily": BudgetWindowSnapshot(
+                            window_start="2026-03-10T00:00:00Z",
+                            window_end="2026-03-10T23:59:59Z",
+                            cost_usd=0.50,
+                        ),
+                        "monthly": BudgetWindowSnapshot(
+                            window_start="2026-03-01T00:00:00Z",
+                            window_end="2026-03-31T23:59:59Z",
+                            cost_usd=20.0,
+                        ),
+                    },
+                },
+            )
+            run_summary = json.loads((Path(result["artifact_dir"]) / "run_summary.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(run_summary["validation_attempts"], 2)
+        self.assertEqual(run_summary["max_validation_attempts"], 2)
+        self.assertFalse(run_summary["validation_retry_exhausted"])
+        self.assertEqual(run_summary["budget_snapshot"]["hourly_spend_usd"], 0.03)
+        self.assertEqual(run_summary["budget_snapshot"]["daily_spend_usd"], 0.51)
+        self.assertEqual(run_summary["budget_snapshot"]["monthly_spend_usd"], 20.01)
 
     def test_run_fixture_daily_brief_reports_diversity_failure_in_outputs(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/agent/daily_brief/test_synthesis.py
+++ b/tests/agent/daily_brief/test_synthesis.py
@@ -1,9 +1,134 @@
 import unittest
 
-from apps.agent.daily_brief.synthesis import build_citation_store, build_synthesis
+from apps.agent.daily_brief.synthesis import SynthesisRetryPlan, build_citation_store, build_synthesis
 
 
 class DailyBriefSynthesisTests(unittest.TestCase):
+    def test_build_synthesis_retry_plan_reassigns_failed_section_with_alternate_evidence(self):
+        evidence_items = [
+            {
+                "chunk_id": "doc_watch_chunk_000",
+                "doc_id": "doc_watch",
+                "source_id": "bls_preview",
+                "publisher": "BLS Preview Desk",
+                "credibility_tier": 1,
+                "rank_in_pack": 1,
+            },
+            {
+                "chunk_id": "doc_minority_chunk_000",
+                "doc_id": "doc_minority",
+                "source_id": "market_commentary",
+                "publisher": "Market Commentary",
+                "credibility_tier": 3,
+                "rank_in_pack": 2,
+            },
+            {
+                "chunk_id": "doc_prevailing_chunk_000",
+                "doc_id": "doc_prevailing",
+                "source_id": "fed_press_releases",
+                "publisher": "Federal Reserve",
+                "credibility_tier": 1,
+                "rank_in_pack": 3,
+            },
+            {
+                "chunk_id": "doc_counter_invalid_chunk_000",
+                "doc_id": "doc_counter_invalid",
+                "source_id": "reuters_business",
+                "publisher": "Reuters",
+                "credibility_tier": 2,
+                "rank_in_pack": 4,
+            },
+            {
+                "chunk_id": "doc_counter_retry_chunk_000",
+                "doc_id": "doc_counter_retry",
+                "source_id": "wsj_markets",
+                "publisher": "Wall Street Journal",
+                "credibility_tier": 2,
+                "rank_in_pack": 5,
+            },
+        ]
+        documents_by_id = {
+            "doc_watch": {
+                "canonical_url": "https://example.test/watch",
+                "title": "Watch Friday CPI for shelter inflation",
+                "published_at": "2026-03-10T16:00:00Z",
+                "fetched_at": "2026-03-10T16:05:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Markets are watching Friday CPI for shelter inflation surprises.",
+            },
+            "doc_minority": {
+                "canonical_url": "https://example.test/minority",
+                "title": "Minority view warns inflation could reaccelerate",
+                "published_at": "2026-03-10T15:30:00Z",
+                "fetched_at": "2026-03-10T15:35:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "A minority of investors still expects inflation to reaccelerate.",
+            },
+            "doc_prevailing": {
+                "canonical_url": "https://example.test/prevailing",
+                "title": "Fed keeps policy steady",
+                "published_at": "2026-03-10T14:00:00Z",
+                "fetched_at": "2026-03-10T14:05:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Fed officials kept policy steady while inflation progress remained uneven.",
+            },
+            "doc_counter_invalid": {
+                "canonical_url": "https://example.test/counter-invalid",
+                "title": "Bond traders push back on soft-landing consensus",
+                "published_at": None,
+                "fetched_at": "2026-03-10T14:35:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Bond traders push back on the soft-landing consensus as growth cools.",
+            },
+            "doc_counter_retry": {
+                "canonical_url": "https://example.test/counter-retry",
+                "title": "Investors question the soft-landing narrative",
+                "published_at": "2026-03-10T14:20:00Z",
+                "fetched_at": "2026-03-10T14:25:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Investors question the soft-landing narrative as growth data weakens.",
+            },
+        }
+        chunks_by_id = {
+            "doc_watch_chunk_000": {"text": "Watch Friday CPI for shelter inflation surprises."},
+            "doc_minority_chunk_000": {"text": "A minority of investors still expects inflation to reaccelerate."},
+            "doc_prevailing_chunk_000": {"text": "Fed officials kept policy steady while inflation progress remained uneven."},
+            "doc_counter_invalid_chunk_000": {"text": "Bond traders push back on the soft-landing consensus as growth cools."},
+            "doc_counter_retry_chunk_000": {"text": "Investors question the soft-landing narrative as growth data weakens."},
+        }
+
+        citations = build_citation_store(
+            evidence_items=evidence_items,
+            documents_by_id=documents_by_id,
+            chunks_by_id=chunks_by_id,
+        )
+        first_attempt = build_synthesis(
+            evidence_items=evidence_items,
+            documents_by_id=documents_by_id,
+            citation_store=citations,
+        )
+        retry_attempt = build_synthesis(
+            evidence_items=evidence_items,
+            documents_by_id=documents_by_id,
+            citation_store=citations,
+            retry_plan=SynthesisRetryPlan(
+                pinned_chunk_ids_by_section={
+                    "prevailing": "doc_prevailing_chunk_000",
+                    "minority": "doc_minority_chunk_000",
+                    "watch": "doc_watch_chunk_000",
+                },
+                target_sections=("counter",),
+                blocked_chunk_ids=frozenset({"doc_counter_invalid_chunk_000"}),
+            ),
+        )
+
+        self.assertEqual(first_attempt["counter"][0]["citation_ids"], ["cite_004"])
+        self.assertEqual(retry_attempt["counter"][0]["citation_ids"], ["cite_005"])
+        self.assertEqual(retry_attempt["prevailing"][0]["citation_ids"], ["cite_003"])
+        self.assertEqual(retry_attempt["minority"][0]["citation_ids"], ["cite_002"])
+        self.assertEqual(retry_attempt["watch"][0]["citation_ids"], ["cite_001"])
+        self.assertNotIn("meta", retry_attempt)
+
     def test_build_synthesis_assigns_sections_from_evidence_signals_not_rank(self):
         evidence_items = [
             {

--- a/tests/agent/synthesis/test_postprocess.py
+++ b/tests/agent/synthesis/test_postprocess.py
@@ -75,7 +75,7 @@ class SynthesisPostprocessTests(unittest.TestCase):
         self.assertEqual(result["synthesis"], validation_result["synthesis"])
         self.assertIsNone(result["abstain_reason"])
 
-    def test_finalize_validation_outcome_maps_retry_to_abstained_output(self):
+    def test_finalize_validation_outcome_requires_retry_exhaustion_before_abstaining(self):
         validation_result = {
             "status": "retry",
             "synthesis": {
@@ -85,6 +85,27 @@ class SynthesisPostprocessTests(unittest.TestCase):
                 "removed_bullets": 4,
                 "empty_core_sections": ["prevailing", "counter"],
             },
+            "validation_attempts": 1,
+            "max_validation_attempts": 2,
+            "retry_exhausted": False,
+        }
+
+        with self.assertRaises(ValueError):
+            finalize_validation_outcome(validation_result=validation_result)
+
+    def test_finalize_validation_outcome_maps_exhausted_retry_to_abstained_output(self):
+        validation_result = {
+            "status": "retry",
+            "synthesis": {
+                "prevailing": [{"text": "[Insufficient evidence to support this claim]", "citation_ids": []}]
+            },
+            "report": {
+                "removed_bullets": 4,
+                "empty_core_sections": ["prevailing", "counter"],
+            },
+            "validation_attempts": 2,
+            "max_validation_attempts": 2,
+            "retry_exhausted": True,
         }
 
         result = finalize_validation_outcome(validation_result=validation_result)

--- a/tests/agent/test_orchestrator.py
+++ b/tests/agent/test_orchestrator.py
@@ -49,6 +49,16 @@ class OrchestratorTests(unittest.TestCase):
 
         self.assertEqual(result["run_type"], "daily_brief")
 
+    def test_rejects_non_positive_stage_attempt_limit(self):
+        with self.assertRaises(ValueError):
+            run_pipeline(
+                run_id="run_bad_attempt_limit",
+                run_type=RunType.DAILY_BRIEF,
+                stages=[],
+                recorder=lambda snapshot: None,
+                max_stage_attempts=0,
+            )
+
     def test_retries_retryable_stage_until_success(self):
         attempts = {"count": 0}
 


### PR DESCRIPTION
## Summary
- implement the documented daily-brief retry-on-validation-failure policy with one explicit retry and terminal exhaustion metadata
- keep postprocess abstention gated on retry exhaustion and persist truthful retry attempt accounting alongside the existing budget snapshot
- document the explicit retry/stop contract and cover success, exhaustion, and attempt-limit behavior with tests

## Verification
- python scripts/validate_artifacts.py
- python scripts/validate_decision_record_schema.py
- python -m compileall -q apps tests scripts
- python -m unittest discover -s tests -p "test_*.py" -v

Closes #51
