### PR TITLE
feat: evidence-aware daily brief section assignment

### DIFF
--- a/apps/agent/daily_brief/synthesis.py
+++ b/apps/agent/daily_brief/synthesis.py
@@ -1,12 +1,53 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from collections.abc import Iterable, Mapping
 from typing import Any
 
-from apps.agent.pipeline.types import CitationStoreEntry, DailyBriefBullet, DailyBriefSynthesis
+from apps.agent.pipeline.types import (
+    DAILY_BRIEF_CORE_OUTPUT_SECTIONS,
+    CitationStoreEntry,
+    DailyBriefBullet,
+    DailyBriefOutputSection,
+    DailyBriefSynthesis,
+)
 
 
-SECTION_SEQUENCE = ("prevailing", "counter", "minority", "watch")
+WATCH_KEYWORDS = (
+    "ahead",
+    "could",
+    "if ",
+    "monitor",
+    "next",
+    "risk",
+    "watch",
+)
+COUNTER_KEYWORDS = (
+    "against",
+    "challenge",
+    "contrary",
+    "doubt",
+    "however",
+    "push back",
+    "question",
+    "skeptic",
+)
+MINORITY_KEYWORDS = (
+    "contrarian",
+    "dissent",
+    "few",
+    "minority",
+    "outlier",
+)
+
+
+@dataclass(frozen=True)
+class _SectionCandidate:
+    chunk_id: str
+    item: Mapping[str, Any]
+    document: Mapping[str, Any]
+    citation_id: str
+    scores: dict[DailyBriefOutputSection, int]
 
 
 def build_citation_store(
@@ -46,26 +87,28 @@ def build_synthesis(
     documents_by_id: Mapping[str, Mapping[str, Any]],
     citation_store: Mapping[str, Mapping[str, Any]],
 ) -> DailyBriefSynthesis:
-    synthesis = {section: [] for section in SECTION_SEQUENCE}
-    citation_ids = list(citation_store.keys())
+    synthesis = {section: [] for section in DAILY_BRIEF_CORE_OUTPUT_SECTIONS}
+    candidates = _build_section_candidates(
+        evidence_items=evidence_items,
+        documents_by_id=documents_by_id,
+        citation_store=citation_store,
+    )
+    assignments = _assign_sections(candidates)
 
-    for index, item in enumerate(_sorted_evidence_items(evidence_items)):
-        if index >= len(SECTION_SEQUENCE) or index >= len(citation_ids):
-            break
-
-        section = SECTION_SEQUENCE[index]
-        doc = documents_by_id[str(item["doc_id"])]
+    for section in DAILY_BRIEF_CORE_OUTPUT_SECTIONS:
+        candidate = assignments.get(section)
+        if candidate is None:
+            continue
         bullet: DailyBriefBullet = {
-            "text": _build_bullet_text(section=section, document=doc, publisher=str(item["publisher"])),
-            "citation_ids": [citation_ids[index]],
-            "confidence_label": _confidence_label(int(item["credibility_tier"])),
+            "text": _build_bullet_text(
+                section=section,
+                document=candidate.document,
+                publisher=str(candidate.item["publisher"]),
+            ),
+            "citation_ids": [candidate.citation_id],
+            "confidence_label": _confidence_label(int(candidate.item["credibility_tier"])),
         }
-        synthesis[section].append(
-            {
-                **bullet,
-            }
-        )
-
+        synthesis[section].append(dict(bullet))
     return synthesis
 
 
@@ -79,11 +122,153 @@ def _sorted_evidence_items(evidence_items: Iterable[Mapping[str, Any]]) -> list[
     )
 
 
+def _build_section_candidates(
+    *,
+    evidence_items: Iterable[Mapping[str, Any]],
+    documents_by_id: Mapping[str, Mapping[str, Any]],
+    citation_store: Mapping[str, Mapping[str, Any]],
+) -> list[_SectionCandidate]:
+    citation_ids_by_chunk_id = {
+        str(entry["chunk_id"]): str(citation_id)
+        for citation_id, entry in citation_store.items()
+        if isinstance(entry, Mapping) and entry.get("chunk_id") is not None
+    }
+    candidates: list[_SectionCandidate] = []
+    for item in _sorted_evidence_items(evidence_items):
+        chunk_id = str(item["chunk_id"])
+        citation_id = citation_ids_by_chunk_id.get(chunk_id)
+        if citation_id is None:
+            continue
+        document = documents_by_id[str(item["doc_id"])]
+        candidates.append(
+            _SectionCandidate(
+                chunk_id=chunk_id,
+                item=item,
+                document=document,
+                citation_id=citation_id,
+                scores=_section_scores(item=item, document=document),
+            )
+        )
+    return candidates
+
+
+def _assign_sections(
+    candidates: Iterable[_SectionCandidate],
+) -> dict[DailyBriefOutputSection, _SectionCandidate]:
+    ordered_candidates = list(candidates)
+    best_assignment: dict[DailyBriefOutputSection, _SectionCandidate] = {}
+    best_key: tuple[int, tuple[tuple[int, int, str], ...]] | None = None
+    search_order: tuple[DailyBriefOutputSection, ...] = ("watch", "counter", "minority", "prevailing")
+
+    def search(
+        section_index: int,
+        used_chunk_ids: frozenset[str],
+        assignment: dict[DailyBriefOutputSection, _SectionCandidate],
+    ) -> None:
+        nonlocal best_assignment, best_key
+        if section_index >= len(search_order):
+            ranking = _assignment_key(assignment=assignment, search_order=search_order)
+            if best_key is None or ranking > best_key:
+                best_key = ranking
+                best_assignment = dict(assignment)
+            return
+
+        section = search_order[section_index]
+        assigned_any = False
+        for candidate in ordered_candidates:
+            if candidate.chunk_id in used_chunk_ids:
+                continue
+            assigned_any = True
+            assignment[section] = candidate
+            search(
+                section_index + 1,
+                used_chunk_ids | {candidate.chunk_id},
+                assignment,
+            )
+            assignment.pop(section, None)
+
+        if not assigned_any:
+            search(section_index + 1, used_chunk_ids, assignment)
+
+    search(0, frozenset(), {})
+    return best_assignment
+
+
+def _assignment_key(
+    *,
+    assignment: Mapping[DailyBriefOutputSection, _SectionCandidate],
+    search_order: tuple[DailyBriefOutputSection, ...],
+) -> tuple[int, tuple[tuple[int, int, str], ...]]:
+    total_score = 0
+    tie_breakers: list[tuple[int, int, str]] = []
+    for section in search_order:
+        candidate = assignment.get(section)
+        if candidate is None:
+            tie_breakers.append((-1, -9999, ""))
+            continue
+        score = candidate.scores[section]
+        rank_in_pack = int(candidate.item.get("rank_in_pack", 9999))
+        total_score += score
+        tie_breakers.append((score, -rank_in_pack, candidate.chunk_id))
+    return total_score, tuple(tie_breakers)
+
+
+def _section_scores(
+    *,
+    item: Mapping[str, Any],
+    document: Mapping[str, Any],
+) -> dict[DailyBriefOutputSection, int]:
+    text = _normalized_document_text(document)
+    credibility_tier = int(item.get("credibility_tier", 4))
+    rank_in_pack = int(item.get("rank_in_pack", 9999))
+    rank_bonus = max(0, 50 - rank_in_pack)
+    credibility_bonus = max(0, 5 - credibility_tier) * 8
+    lower_consensus_bonus = max(0, credibility_tier - 1) * 8
+    watch_hits = _keyword_hits(text, WATCH_KEYWORDS)
+    counter_hits = _keyword_hits(text, COUNTER_KEYWORDS)
+    minority_hits = _keyword_hits(text, MINORITY_KEYWORDS)
+    recency_bonus = _recency_bonus(document)
+
+    return {
+        "prevailing": 90 + credibility_bonus + rank_bonus - (watch_hits + counter_hits + minority_hits) * 20,
+        "counter": 20 + counter_hits * 70 + credibility_bonus + rank_bonus // 2 - watch_hits * 10,
+        "minority": 15 + minority_hits * 70 + lower_consensus_bonus + rank_bonus // 3,
+        "watch": 20 + watch_hits * 70 + recency_bonus + rank_bonus // 4,
+        "changed": 0,
+    }
+
+
+def _normalized_document_text(document: Mapping[str, Any]) -> str:
+    return " ".join(
+        str(document.get(field, "")).lower()
+        for field in ("title", "rss_snippet", "doc_type")
+        if document.get(field)
+    )
+
+
+def _keyword_hits(text: str, keywords: Iterable[str]) -> int:
+    return sum(1 for keyword in keywords if keyword in text)
+
+
+def _recency_bonus(document: Mapping[str, Any]) -> int:
+    timestamp = str(document.get("published_at") or document.get("fetched_at") or "")
+    digits = "".join(character for character in timestamp if character.isdigit())
+    if len(digits) < 6:
+        return 0
+    hhmmss = digits[-6:]
+    hours = int(hhmmss[:2])
+    minutes = int(hhmmss[2:4])
+    return hours * 2 + minutes // 15
+
+
 def _build_bullet_text(*, section: str, document: Mapping[str, Any], publisher: str) -> str:
-    title = str(document.get("title") or document.get("rss_snippet") or publisher)
+    title = str(document.get("title") or document.get("rss_snippet") or publisher).strip()
+    normalized_title = title.rstrip(".")
     if section == "watch":
-        return f"Watch {title.lower()}."
-    return f"{title} ({publisher})."
+        if normalized_title.lower().startswith("watch "):
+            return f"{normalized_title}."
+        return f"Watch {normalized_title.lower()}."
+    return f"{normalized_title} ({publisher})."
 
 
 def _confidence_label(credibility_tier: int) -> str:

--- a/apps/agent/pipeline/types.py
+++ b/apps/agent/pipeline/types.py
@@ -33,6 +33,13 @@ DAILY_BRIEF_OUTPUT_SECTIONS: tuple[DailyBriefOutputSection, ...] = (
     "watch",
     "changed",
 )
+DAILY_BRIEF_CORE_OUTPUT_SECTIONS: tuple[DailyBriefOutputSection, ...] = (
+    "prevailing",
+    "counter",
+    "minority",
+    "watch",
+)
+DAILY_BRIEF_OPTIONAL_OUTPUT_SECTIONS: tuple[DailyBriefOutputSection, ...] = ("changed",)
 DAILY_BRIEF_CLAIM_SECTIONS: frozenset[DailyBriefOutputSection] = frozenset(DAILY_BRIEF_OUTPUT_SECTIONS)
 DAILY_BRIEF_SECTION_ALIASES: dict[str, DailyBriefOutputSection] = {
     "counterarguments": "counter",

--- a/tests/agent/daily_brief/test_runner.py
+++ b/tests/agent/daily_brief/test_runner.py
@@ -193,13 +193,17 @@ class DailyBriefRunnerTests(unittest.TestCase):
             self.assertEqual(result["lifecycle"][-1]["status"], "ok")
             self.assertIn("Daily Brief", html_path.read_text(encoding="utf-8"))
             citation_rows = json.loads((artifact_dir / "citations.json").read_text(encoding="utf-8"))
+            synthesis_payload = json.loads((artifact_dir / "synthesis.json").read_text(encoding="utf-8"))
             synthesis_bullets = json.loads((artifact_dir / "synthesis_bullets.json").read_text(encoding="utf-8"))
             bullet_citations = json.loads((artifact_dir / "bullet_citations.json").read_text(encoding="utf-8"))
             run_summary = json.loads((artifact_dir / "run_summary.json").read_text(encoding="utf-8"))
             self.assertIsInstance(citation_rows, list)
             self.assertEqual(citation_rows[0]["citation_id"], "cite_001")
             self.assertEqual(synthesis_bullets[0]["section"], "prevailing")
-            self.assertEqual(bullet_citations[0]["citation_id"], "cite_001")
+            self.assertEqual(
+                bullet_citations[0]["citation_id"],
+                synthesis_payload["prevailing"][0]["citation_ids"][0],
+            )
             self.assertEqual(run_summary["guardrail_checks"]["budget_check"], "pass")
             self.assertIn(run_summary["guardrail_checks"]["diversity_check"], {"pass", "fail"})
 

--- a/tests/agent/daily_brief/test_synthesis.py
+++ b/tests/agent/daily_brief/test_synthesis.py
@@ -4,7 +4,100 @@ from apps.agent.daily_brief.synthesis import build_citation_store, build_synthes
 
 
 class DailyBriefSynthesisTests(unittest.TestCase):
-    def test_build_synthesis_assigns_core_sections_with_stable_citation_ids(self):
+    def test_build_synthesis_assigns_sections_from_evidence_signals_not_rank(self):
+        evidence_items = [
+            {
+                "chunk_id": "doc_watch_chunk_000",
+                "doc_id": "doc_watch",
+                "source_id": "bls_preview",
+                "publisher": "BLS Preview Desk",
+                "credibility_tier": 1,
+                "rank_in_pack": 1,
+            },
+            {
+                "chunk_id": "doc_minority_chunk_000",
+                "doc_id": "doc_minority",
+                "source_id": "market_commentary",
+                "publisher": "Market Commentary",
+                "credibility_tier": 3,
+                "rank_in_pack": 2,
+            },
+            {
+                "chunk_id": "doc_prevailing_chunk_000",
+                "doc_id": "doc_prevailing",
+                "source_id": "fed_press_releases",
+                "publisher": "Federal Reserve",
+                "credibility_tier": 1,
+                "rank_in_pack": 3,
+            },
+            {
+                "chunk_id": "doc_counter_chunk_000",
+                "doc_id": "doc_counter",
+                "source_id": "reuters_business",
+                "publisher": "Reuters",
+                "credibility_tier": 2,
+                "rank_in_pack": 4,
+            },
+        ]
+        documents_by_id = {
+            "doc_watch": {
+                "canonical_url": "https://example.test/watch",
+                "title": "Watch Friday CPI for shelter inflation",
+                "published_at": "2026-03-10T16:00:00Z",
+                "fetched_at": "2026-03-10T16:05:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Markets are watching Friday CPI for shelter inflation surprises.",
+            },
+            "doc_minority": {
+                "canonical_url": "https://example.test/minority",
+                "title": "Minority view warns inflation could reaccelerate",
+                "published_at": "2026-03-10T15:30:00Z",
+                "fetched_at": "2026-03-10T15:35:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "A minority of investors still expects inflation to reaccelerate.",
+            },
+            "doc_prevailing": {
+                "canonical_url": "https://example.test/prevailing",
+                "title": "Fed keeps policy steady",
+                "published_at": "2026-03-10T14:00:00Z",
+                "fetched_at": "2026-03-10T14:05:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Fed officials kept policy steady while inflation progress remained uneven.",
+            },
+            "doc_counter": {
+                "canonical_url": "https://example.test/counter",
+                "title": "Bond traders push back on soft-landing consensus",
+                "published_at": "2026-03-10T14:30:00Z",
+                "fetched_at": "2026-03-10T14:35:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Bond traders push back on the soft-landing consensus as growth cools.",
+            },
+        }
+        chunks_by_id = {
+            "doc_watch_chunk_000": {"text": "Watch Friday CPI for shelter inflation surprises."},
+            "doc_minority_chunk_000": {"text": "A minority of investors still expects inflation to reaccelerate."},
+            "doc_prevailing_chunk_000": {"text": "Fed officials kept policy steady while inflation progress remained uneven."},
+            "doc_counter_chunk_000": {"text": "Bond traders push back on the soft-landing consensus as growth cools."},
+        }
+
+        citations = build_citation_store(
+            evidence_items=evidence_items,
+            documents_by_id=documents_by_id,
+            chunks_by_id=chunks_by_id,
+        )
+        synthesis = build_synthesis(
+            evidence_items=evidence_items,
+            documents_by_id=documents_by_id,
+            citation_store=citations,
+        )
+
+        self.assertEqual(sorted(synthesis.keys()), ["counter", "minority", "prevailing", "watch"])
+        self.assertEqual(synthesis["prevailing"][0]["citation_ids"], ["cite_003"])
+        self.assertEqual(synthesis["counter"][0]["citation_ids"], ["cite_004"])
+        self.assertEqual(synthesis["minority"][0]["citation_ids"], ["cite_002"])
+        self.assertEqual(synthesis["watch"][0]["citation_ids"], ["cite_001"])
+
+    def test_build_synthesis_uses_distinct_counter_and_minority_criteria(self):
         evidence_items = [
             {
                 "chunk_id": "doc_001_chunk_000",
@@ -17,16 +110,16 @@ class DailyBriefSynthesisTests(unittest.TestCase):
             {
                 "chunk_id": "doc_002_chunk_000",
                 "doc_id": "doc_002",
-                "source_id": "reuters_business",
-                "publisher": "Reuters",
-                "credibility_tier": 2,
+                "source_id": "minority_macro_letter",
+                "publisher": "Macro Letter",
+                "credibility_tier": 3,
                 "rank_in_pack": 2,
             },
             {
                 "chunk_id": "doc_003_chunk_000",
                 "doc_id": "doc_003",
-                "source_id": "wsj_markets",
-                "publisher": "Wall Street Journal",
+                "source_id": "reuters_business",
+                "publisher": "Reuters",
                 "credibility_tier": 2,
                 "rank_in_pack": 3,
             },
@@ -49,35 +142,35 @@ class DailyBriefSynthesisTests(unittest.TestCase):
                 "rss_snippet": "Fed signals steady policy.",
             },
             "doc_002": {
-                "canonical_url": "https://example.test/reuters",
-                "title": "Markets digest slower growth",
+                "canonical_url": "https://example.test/minority",
+                "title": "Minority view still expects a hard landing",
                 "published_at": "2026-03-10T15:00:00Z",
                 "fetched_at": "2026-03-10T15:05:00Z",
                 "paywall_policy": "full",
-                "rss_snippet": "Investors weigh slower growth.",
+                "rss_snippet": "A minority of strategists still expects a hard landing.",
             },
             "doc_003": {
-                "canonical_url": "https://example.test/wsj",
-                "title": "Cooling growth draws focus",
+                "canonical_url": "https://example.test/counter",
+                "title": "Investors challenge the soft-landing narrative",
                 "published_at": "2026-03-10T15:15:00Z",
                 "fetched_at": "2026-03-10T15:20:00Z",
-                "paywall_policy": "metadata_only",
-                "rss_snippet": "Cooling growth becomes the focus.",
+                "paywall_policy": "full",
+                "rss_snippet": "Investors challenge the soft-landing narrative as growth data weakens.",
             },
             "doc_004": {
                 "canonical_url": "https://example.test/bls",
-                "title": "Payroll growth moderates",
+                "title": "Watch payroll revisions next week",
                 "published_at": "2026-03-10T13:30:00Z",
                 "fetched_at": "2026-03-10T13:35:00Z",
                 "paywall_policy": "full",
-                "rss_snippet": "Payroll growth moderates.",
+                "rss_snippet": "Watch payroll revisions next week for confirmation.",
             },
         }
         chunks_by_id = {
             "doc_001_chunk_000": {"text": "Fed keeps policy steady while inflation progress is uneven."},
-            "doc_002_chunk_000": {"text": "Investors are weighing slower growth against steady policy."},
-            "doc_003_chunk_000": {"text": "Cooling growth is the new market focus."},
-            "doc_004_chunk_000": {"text": "Payroll growth moderates and wage gains cool."},
+            "doc_002_chunk_000": {"text": "A minority of strategists still expects a hard landing."},
+            "doc_003_chunk_000": {"text": "Investors challenge the soft-landing narrative as growth data weakens."},
+            "doc_004_chunk_000": {"text": "Watch payroll revisions next week for confirmation."},
         }
 
         citations = build_citation_store(
@@ -91,10 +184,9 @@ class DailyBriefSynthesisTests(unittest.TestCase):
             citation_store=citations,
         )
 
-        self.assertEqual(sorted(synthesis.keys()), ["counter", "minority", "prevailing", "watch"])
         self.assertEqual(synthesis["prevailing"][0]["citation_ids"], ["cite_001"])
-        self.assertEqual(synthesis["counter"][0]["citation_ids"], ["cite_002"])
-        self.assertEqual(synthesis["minority"][0]["citation_ids"], ["cite_003"])
+        self.assertEqual(synthesis["counter"][0]["citation_ids"], ["cite_003"])
+        self.assertEqual(synthesis["minority"][0]["citation_ids"], ["cite_002"])
         self.assertEqual(synthesis["watch"][0]["citation_ids"], ["cite_004"])
 
     def test_build_citation_store_omits_quote_text_for_metadata_only_sources(self):


### PR DESCRIPTION
## Summary
- replace positional daily brief section assignment with evidence-aware scoring and unique section assignment
- bind synthesis bullets to citation ids by evidence chunk instead of citation order
- add regression tests proving counter, minority, and watch semantics are not purely positional

## Testing
- python scripts/validate_artifacts.py
- python scripts/validate_decision_record_schema.py
- python -m compileall -q apps tests scripts
- python -m unittest discover -s tests -p "test_*.py" -v

Closes #53
