### PR TITLE
fix: reconcile artifact status truth and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,22 @@ Local-first financial news and macro literature-review assistant.
 
 This repository contains the modelling artifacts and early runtime components for an assistant that:
 - ingests financial/macro sources (RSS, HTML, PDF),
-- produces citation-grounded daily briefs and major-event alerts,
+- produces citation-grounded daily briefs,
+- keeps alert scoring and alert delivery as planned follow-on work,
 - enforces strict budget and safety guardrails.
 
 ## Current Phase
 
-This project is currently in the modelling + early implementation phase.
+This project is currently in early implementation with the modelling pack still serving as the planning source of truth.
+
+Implemented in-tree today:
+- daily-brief runtime, local HTML delivery, and citation/postprocess guardrails
+- eval harness with 12 golden cases
+
+Planned next:
+- alert scoring and policy gates
+- alert delivery
+- portfolio relevance mapping
 
 Completed modelling artifacts:
 - `artifacts/modelling/source_registry.yaml`
@@ -45,13 +55,18 @@ See:
 ```text
 apps/
   agent/
-    runtime/              # Early runtime modules (e.g., budget guard)
+    daily_brief/          # Daily-brief runtime stages
+    delivery/             # Local HTML delivery
+    runtime/              # Runtime modules (e.g., budget guard)
+evals/
+  golden/                # Golden cases for current runtime contracts
 artifacts/
   PRD.md                  # Product requirements
   PROJECT_FACT.md         # Hard constraints
   modelling/              # Modelling pack and planning docs
 tests/
-  agent/runtime/          # Unit tests
+  agent/                  # Runtime and tooling unit tests
+  evals/                  # Eval harness tests
 docs/plans/               # Planning notes
 ```
 

--- a/artifacts/modelling/backlog.json
+++ b/artifacts/modelling/backlog.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "generated_on": "2026-03-10",
-  "phase": "modelling",
+  "phase": "implementation",
   "tickets": [
     {
       "id": "M001",
@@ -105,7 +105,7 @@
     {
       "id": "M007",
       "title": "Implement daily brief delivery",
-      "status": "planned",
+      "status": "implemented",
       "priority": "P1",
       "depends_on": ["M004"],
       "files": [
@@ -121,7 +121,7 @@
     {
       "id": "M008",
       "title": "Add eval harness and 10 golden cases",
-      "status": "planned",
+      "status": "implemented",
       "priority": "P1",
       "depends_on": ["M004", "M005", "M007"],
       "files": [

--- a/docs/status-matrix.md
+++ b/docs/status-matrix.md
@@ -15,11 +15,11 @@ Definitions:
 | Retrieval and evidence-pack assembly | yes | yes | yes | `artifacts/modelling/pipeline.md`, `apps/agent/retrieval/`, `tests/agent/retrieval/` |
 | Citation validation and abstain shaping | yes | yes | yes | `artifacts/modelling/citation_contract.md`, `apps/agent/validators/citation_validator.py`, `apps/agent/synthesis/postprocess.py`, `tests/agent/validators/test_citation_validator.py`, `tests/agent/synthesis/test_postprocess.py` |
 | Budget guard and budget ledger | yes | yes | yes | `artifacts/PRD.md`, `artifacts/PROJECT_FACT.md`, `apps/agent/runtime/budget_guard.py`, `apps/agent/runtime/cost_ledger.py`, `tests/agent/runtime/test_budget_guard.py`, `tests/agent/runtime/test_cost_ledger.py` |
-| Daily-brief runtime and local HTML output | yes | yes | yes | `artifacts/PRD.md`, `apps/agent/daily_brief/runner.py`, `apps/agent/daily_brief/synthesis.py`, `apps/agent/delivery/html_report.py`, `tests/agent/daily_brief/test_runner.py`, `tests/agent/daily_brief/test_synthesis.py`, `tests/agent/delivery/test_html_report.py` |
+| Daily-brief runtime and local HTML output | yes | yes | yes | `artifacts/PRD.md`, `artifacts/modelling/backlog.json` (`M007`), `apps/agent/daily_brief/runner.py`, `apps/agent/daily_brief/synthesis.py`, `apps/agent/delivery/html_report.py`, `tests/agent/daily_brief/test_runner.py`, `tests/agent/daily_brief/test_synthesis.py`, `tests/agent/delivery/test_html_report.py` |
 | Alert scoring and policy gates | yes | no | no | `artifacts/modelling/alert_scoring.md`, `artifacts/modelling/backlog.json` (`M006`) |
 | Alert delivery runtime | yes | no | no | `artifacts/PRD.md`, `artifacts/modelling/backlog.json` (`M010`) |
-| Eval harness and golden cases | yes | yes | yes | `evals/run_eval_suite.py`, `evals/golden/`, `tests/evals/test_run_eval_suite.py` |
+| Eval harness and golden cases | yes | yes | yes | `artifacts/modelling/backlog.json` (`M008`), `evals/run_eval_suite.py`, `evals/golden/`, `tests/evals/test_run_eval_suite.py` |
 | Portfolio relevance mapping | yes | no | no | `artifacts/PRD.md`, `artifacts/modelling/backlog.json` (`M009`) |
 
 Priority note:
-- The working daily-brief path is ahead of alert delivery. Alert delivery remains modelled but is intentionally downstream of the daily-brief path in `artifacts/modelling/backlog.json`.
+- The daily-brief path and eval harness are implemented in-tree. Alert scoring, alert delivery, and portfolio relevance remain modelled-only and intentionally downstream in `artifacts/modelling/backlog.json`.

--- a/scripts/validate_artifacts.py
+++ b/scripts/validate_artifacts.py
@@ -1,46 +1,146 @@
 from __future__ import annotations
 
 import json
+import re
+import sys
 from pathlib import Path
+from typing import Any
 
 import yaml
 
+ROOT = Path(__file__).resolve().parents[1]
+TICKET_ID_PATTERN = re.compile(r"M\d{3}")
 
-def main() -> None:
+
+def _load_json(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            try:
+                return json.load(handle)
+            except json.JSONDecodeError as error:
+                raise json.JSONDecodeError(
+                    f"{error.msg} (while parsing {path})",
+                    error.doc,
+                    error.pos,
+                ) from error
+    except FileNotFoundError as error:
+        raise FileNotFoundError(f"Required JSON artifact file not found: {path}") from error
+
+
+def _load_yaml(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            try:
+                return yaml.safe_load(handle)
+            except yaml.YAMLError as error:
+                raise yaml.YAMLError(f"{error} (while parsing {path})") from error
+    except FileNotFoundError as error:
+        raise FileNotFoundError(f"Required YAML artifact file not found: {path}") from error
+
+
+def validate_backlog_ticket_paths(backlog: dict[str, Any], repo_root: Path) -> list[str]:
+    errors: list[str] = []
+
+    for ticket in backlog.get("tickets", []):
+        ticket_id = ticket.get("id", "<unknown>")
+        status = ticket.get("status")
+        files = ticket.get("files", [])
+        existing_paths = [(repo_root / relative_path).exists() for relative_path in files]
+
+        if status == "implemented" and not all(existing_paths):
+            missing_files = [path for path in files if not (repo_root / path).exists()]
+            errors.append(
+                f"Backlog ticket {ticket_id} is marked implemented but missing listed files: {', '.join(missing_files)}."
+            )
+        if status == "planned" and files and all(existing_paths):
+            errors.append(
+                f"Backlog ticket {ticket_id} is marked planned even though all listed files exist."
+            )
+
+    return errors
+
+
+def validate_status_matrix(status_matrix_text: str, backlog: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    ticket_statuses = {ticket["id"]: ticket["status"] for ticket in backlog.get("tickets", []) if "id" in ticket}
+
+    for raw_line in status_matrix_text.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("|") or "---" in line:
+            continue
+
+        columns = [column.strip() for column in line.strip("|").split("|")]
+        if len(columns) != 5:
+            continue
+
+        coded = columns[2].lower()
+        verified = columns[3].lower()
+        evidence = columns[4]
+
+        for ticket_id in TICKET_ID_PATTERN.findall(evidence):
+            status = ticket_statuses.get(ticket_id)
+            if status == "planned" and (coded != "no" or verified != "no"):
+                errors.append(
+                    f"docs/status-matrix.md row for ticket {ticket_id} must report coded=no and verified=no while backlog status is planned."
+                )
+            if status == "implemented" and (coded != "yes" or verified != "yes"):
+                errors.append(
+                    f"docs/status-matrix.md row for ticket {ticket_id} must report coded=yes and verified=yes while backlog status is implemented."
+                )
+
+    return errors
+
+
+def validate_readme_status(readme_text: str, backlog: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    ticket_statuses = {ticket["id"]: ticket["status"] for ticket in backlog.get("tickets", []) if "id" in ticket}
+    lower_text = readme_text.lower()
+
+    alerts_planned = any(ticket_statuses.get(ticket_id) != "implemented" for ticket_id in ("M006", "M010"))
+    if alerts_planned and "major-event alerts" in lower_text and "remain planned" not in lower_text:
+        errors.append("README.md must mark alerts as planned until backlog tickets M006 and M010 are implemented.")
+
+    return errors
+
+
+def validate_repo_artifacts(repo_root: Path = ROOT) -> list[str]:
     json_paths = [
-        Path("artifacts/modelling/backlog.json"),
+        repo_root / "artifacts/modelling/backlog.json",
     ]
     yaml_paths = [
-        Path("artifacts/modelling/source_registry.yaml"),
-        Path("artifacts/runtime/v1_active_sources.yaml"),
+        repo_root / "artifacts/modelling/source_registry.yaml",
+        repo_root / "artifacts/runtime/v1_active_sources.yaml",
     ]
 
+    loaded_json: dict[Path, Any] = {}
     for path in json_paths:
-        try:
-            with path.open("r", encoding="utf-8") as handle:
-                try:
-                    json.load(handle)
-                except json.JSONDecodeError as error:
-                    raise json.JSONDecodeError(
-                        f"{error.msg} (while parsing {path})",
-                        error.doc,
-                        error.pos,
-                    ) from error
-        except FileNotFoundError as error:
-            raise FileNotFoundError(f"Required JSON artifact file not found: {path}") from error
+        loaded_json[path] = _load_json(path)
 
     for path in yaml_paths:
-        try:
-            with path.open("r", encoding="utf-8") as handle:
-                try:
-                    yaml.safe_load(handle)
-                except yaml.YAMLError as error:
-                    raise yaml.YAMLError(f"{error} (while parsing {path})") from error
-        except FileNotFoundError as error:
-            raise FileNotFoundError(f"Required YAML artifact file not found: {path}") from error
+        _load_yaml(path)
+
+    backlog = loaded_json[repo_root / "artifacts/modelling/backlog.json"]
+    status_matrix_text = (repo_root / "docs/status-matrix.md").read_text(encoding="utf-8")
+    readme_text = (repo_root / "README.md").read_text(encoding="utf-8")
+
+    errors: list[str] = []
+    errors.extend(validate_backlog_ticket_paths(backlog, repo_root))
+    errors.extend(validate_status_matrix(status_matrix_text, backlog))
+    errors.extend(validate_readme_status(readme_text, backlog))
+    return errors
+
+
+def main() -> int:
+    errors = validate_repo_artifacts()
+    if errors:
+        print("FAIL")
+        for error in errors:
+            print(f"- {error}")
+        return 1
 
     print("Artifact validation passed.")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/agent/test_validate_artifacts.py
+++ b/tests/agent/test_validate_artifacts.py
@@ -1,0 +1,131 @@
+import json
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from scripts import validate_artifacts
+
+
+class ArtifactValidationTests(unittest.TestCase):
+    def test_planned_ticket_with_all_listed_files_present_fails_semantic_validation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "apps" / "agent" / "delivery").mkdir(parents=True)
+            (root / "scripts").mkdir(parents=True)
+            (root / "docs").mkdir(parents=True)
+            (root / "artifacts" / "modelling").mkdir(parents=True)
+            (root / "artifacts" / "runtime").mkdir(parents=True)
+
+            (root / "apps" / "agent" / "delivery" / "html_report.py").write_text("", encoding="utf-8")
+            (root / "scripts" / "run_daily_brief_fixture.py").write_text("", encoding="utf-8")
+            (root / "artifacts" / "modelling" / "backlog.json").write_text(
+                json.dumps(
+                    {
+                        "version": "1.0",
+                        "generated_on": "2026-03-10",
+                        "phase": "implementation",
+                        "tickets": [
+                            {
+                                "id": "M007",
+                                "title": "Implement daily brief delivery",
+                                "status": "planned",
+                                "priority": "P1",
+                                "depends_on": ["M004"],
+                                "files": [
+                                    "apps/agent/delivery/html_report.py",
+                                    "scripts/run_daily_brief_fixture.py",
+                                ],
+                                "acceptance_criteria": ["Daily brief local HTML output generated in stable structure"],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "artifacts" / "modelling" / "source_registry.yaml").write_text("sources: []\n", encoding="utf-8")
+            (root / "artifacts" / "runtime" / "v1_active_sources.yaml").write_text(
+                "active_source_ids: []\n", encoding="utf-8"
+            )
+            (root / "docs" / "status-matrix.md").write_text(
+                textwrap.dedent(
+                    """
+                    # Status Matrix
+
+                    | Area | Modelled | Coded | Verified | Evidence |
+                    |------|----------|-------|----------|----------|
+                    | Daily-brief runtime and local HTML output | yes | yes | yes | `apps/agent/delivery/html_report.py`, `scripts/run_daily_brief_fixture.py` |
+                    """
+                ).strip()
+                + "\n",
+                encoding="utf-8",
+            )
+            (root / "README.md").write_text(
+                "Implemented today: daily brief path.\nPlanned next: alert scoring, alert delivery, portfolio relevance.\n",
+                encoding="utf-8",
+            )
+
+            errors = validate_artifacts.validate_repo_artifacts(root)
+
+            self.assertTrue(any("M007" in error and "planned" in error for error in errors), errors)
+
+    def test_readme_requires_alerts_to_be_marked_planned_until_alert_tickets_are_implemented(self):
+        backlog = {
+            "tickets": [
+                {"id": "M006", "status": "planned", "files": ["apps/agent/alerts/scoring.py"]},
+                {"id": "M010", "status": "planned", "files": ["apps/agent/delivery/email_sender.py"]},
+            ]
+        }
+
+        errors = validate_artifacts.validate_readme_status(
+            "This repository produces citation-grounded daily briefs and major-event alerts.",
+            backlog,
+        )
+
+        self.assertEqual(
+            errors,
+            ["README.md must mark alerts as planned until backlog tickets M006 and M010 are implemented."],
+        )
+
+    def test_status_matrix_ticket_rows_must_match_backlog_ticket_status(self):
+        backlog = {
+            "tickets": [
+                {"id": "M010", "status": "planned", "files": ["apps/agent/delivery/email_sender.py"]},
+            ]
+        }
+        status_matrix_text = textwrap.dedent(
+            """
+            # Status Matrix
+
+            | Area | Modelled | Coded | Verified | Evidence |
+            |------|----------|-------|----------|----------|
+            | Alert delivery runtime | yes | yes | yes | `artifacts/modelling/backlog.json` (`M010`) |
+            """
+        )
+
+        errors = validate_artifacts.validate_status_matrix(status_matrix_text, backlog)
+
+        self.assertEqual(
+            errors,
+            ["docs/status-matrix.md row for ticket M010 must report coded=no and verified=no while backlog status is planned."],
+        )
+
+    def test_script_entrypoint_passes_for_repo_state(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        script_path = repo_root / "scripts" / "validate_artifacts.py"
+
+        completed = subprocess.run(
+            [sys.executable, str(script_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("Artifact validation passed.", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reconcile backlog, status matrix, and README language with the current daily-brief and eval implementation state
- add semantic artifact validation for backlog ticket status, status-matrix ticket rows, and README alert-state wording
- add regression tests for the new validator behavior and script entrypoint

## Verification
- python scripts/validate_artifacts.py
- python scripts/validate_decision_record_schema.py
- python -m compileall -q apps tests scripts
- python -m unittest discover -s tests -t . -p "test_*.py" -v

Closes #67
