### PR TITLE
feat(daily-brief): replace fixture-only path with live active-subset ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ Run tests:
 python -m unittest discover -s tests -t . -p "test_*.py" -v
 ```
 
+Run the active-subset daily brief against live feeds:
+
+```bash
+python scripts/run_daily_brief.py
+```
+
+Run the deterministic fixture-backed daily brief slice:
+
+```bash
+python scripts/run_daily_brief_fixture.py
+```
+
 Run repository validation:
 
 ```bash
@@ -121,3 +133,4 @@ python -m compileall -q apps tests scripts
 
 - This project is not a trading signal engine and should not produce buy/sell instructions.
 - Outputs are intended to provide evidence-grounded scenarios and risk flags.
+- The live daily-brief slice starts with the current RSS-backed active subset and skips sources that are temporarily blocked or unavailable.

--- a/apps/agent/daily_brief/runner.py
+++ b/apps/agent/daily_brief/runner.py
@@ -12,6 +12,7 @@ from apps.agent.delivery.html_report import render_daily_brief_html
 from apps.agent.ingest.dedup import classify_duplicate
 from apps.agent.ingest.extract import extract_payload
 from apps.agent.ingest.fetch import plan_fetch_items
+from apps.agent.ingest.live_fetch import fetch_live_payloads_for_source
 from apps.agent.ingest.normalize import build_document_record
 from apps.agent.orchestrator import run_pipeline
 from apps.agent.pipeline.stage10_decision_record import build_and_persist_decision_record
@@ -160,6 +161,63 @@ def run_fixture_daily_brief(
     return execution
 
 
+def run_daily_brief(
+    *,
+    base_dir: Path,
+    run_id: str = "run_daily_live",
+    generated_at_utc: str | None = None,
+    budget_preflight: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    lifecycle: list[dict[str, Any]] = []
+    execution: dict[str, Any] = {}
+    timestamp = generated_at_utc or _utc_now_iso()
+
+    def stage(context: Any) -> StageResult:
+        try:
+            result = _execute_daily_brief_slice(
+                base_dir=base_dir,
+                fixture_path=None,
+                run_id=run_id,
+                generated_at_utc=timestamp,
+                context=context,
+                use_live_sources=True,
+            )
+        except Exception as exc:
+            execution["status"] = "failed"
+            execution["error_summary"] = str(exc)
+            return StageResult(status=RunStatus.FAILED, error_summary=str(exc))
+
+        execution.update(result)
+        if result["status"] == "ok":
+            return StageResult(status=RunStatus.OK)
+        return StageResult(
+            status=RunStatus.PARTIAL,
+            error_summary=result.get("abstain_reason") or result["status"],
+        )
+
+    pipeline_result = run_pipeline(
+        run_id=run_id,
+        run_type="daily_brief",
+        stages=[stage],
+        recorder=lifecycle.append,
+        budget_preflight=budget_preflight or _default_budget_preflight(generated_at_utc=timestamp),
+    )
+    if pipeline_result["status"] == "stopped_budget" and not execution:
+        execution.update(
+            _persist_budget_stop_outputs(
+                base_dir=base_dir,
+                run_id=run_id,
+                generated_at_utc=timestamp,
+                pipeline_result=pipeline_result,
+            )
+        )
+    execution.setdefault("status", pipeline_result["status"])
+    execution["lifecycle"] = lifecycle
+    execution["pipeline_status"] = pipeline_result["status"]
+    execution["error_summary"] = pipeline_result.get("error_summary")
+    return execution
+
+
 def _execute_daily_brief_slice(
     *,
     base_dir: Path,
@@ -167,10 +225,12 @@ def _execute_daily_brief_slice(
     run_id: str,
     generated_at_utc: str,
     context: Any,
+    use_live_sources: bool = False,
 ) -> dict[str, Any]:
     input_data = prepare_daily_brief_inputs(
         fixture_path=fixture_path,
         generated_at_utc=generated_at_utc,
+        use_live_sources=use_live_sources,
     )
     corpus_data = build_daily_brief_corpus(
         stage_data=input_data,
@@ -258,12 +318,19 @@ def prepare_daily_brief_inputs(
     *,
     fixture_path: Path | None = None,
     generated_at_utc: str,
+    use_live_sources: bool = False,
 ) -> DailyBriefInputStageData:
     registry = load_source_registry()
     active_sources = load_active_source_subset(registry=registry)
-    fixture_payloads = load_active_fixture_payloads(fixture_path=fixture_path)
-    planned_items = plan_fetch_items(sources=active_sources, candidate_payloads=fixture_payloads)
+    candidate_payloads = (
+        load_active_live_payloads(active_sources=active_sources, fetched_at_utc=generated_at_utc)
+        if use_live_sources
+        else load_active_fixture_payloads(fixture_path=fixture_path)
+    )
+    planned_items = plan_fetch_items(sources=active_sources, candidate_payloads=candidate_payloads)
     if not planned_items:
+        if use_live_sources:
+            raise ValueError("No live payloads available for active sources")
         raise ValueError("No fixture payloads available for active sources")
 
     source_rows = [_build_source_row(source=source, generated_at_utc=generated_at_utc) for source in active_sources]
@@ -273,6 +340,25 @@ def prepare_daily_brief_inputs(
         planned_items=planned_items,
         source_rows=source_rows,
     )
+
+
+def load_active_live_payloads(
+    *,
+    active_sources: Iterable[SourceRegistryEntry],
+    fetched_at_utc: str,
+) -> dict[str, list[dict[str, Any]]]:
+    payloads: dict[str, list[dict[str, Any]]] = {}
+    for source in active_sources:
+        source_id = str(source["id"])
+        try:
+            payloads[source_id] = fetch_live_payloads_for_source(
+                source=source,
+                fetched_at_utc=fetched_at_utc,
+            )
+        except Exception:
+            # Keep the live slice usable when one active source is blocked or drifts.
+            payloads[source_id] = []
+    return payloads
 
 
 def build_daily_brief_corpus(

--- a/apps/agent/ingest/live_fetch.py
+++ b/apps/agent/ingest/live_fetch.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any
+from urllib.request import Request, urlopen
+import xml.etree.ElementTree as ET
+
+DEFAULT_REQUEST_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; MVP-Agent/0.1; +https://example.test/local)",
+    "Accept": "application/rss+xml, application/atom+xml, application/xml, text/xml;q=0.9, */*;q=0.8",
+}
+
+
+def fetch_live_payloads_for_source(
+    *,
+    source: Mapping[str, Any],
+    fetched_at_utc: str | None = None,
+    timeout_seconds: int = 20,
+) -> list[dict[str, Any]]:
+    source_type = str(source["type"])
+    if source_type != "rss":
+        raise ValueError(f"Unsupported live fetch source type: {source_type}")
+
+    request = Request(str(source["url"]), headers=DEFAULT_REQUEST_HEADERS)
+    with urlopen(request, timeout=timeout_seconds) as response:
+        feed_bytes = response.read()
+
+    feed_text = feed_bytes.decode("utf-8", errors="replace")
+    resolved_fetched_at = fetched_at_utc or _utc_now_iso()
+    return parse_rss_feed(feed_text=feed_text, fetched_at_utc=resolved_fetched_at)
+
+
+def parse_rss_feed(*, feed_text: str, fetched_at_utc: str) -> list[dict[str, Any]]:
+    root = ET.fromstring(feed_text)
+    items = root.findall(".//item")
+    if items:
+        return [_rss_item_to_payload(item=item, fetched_at_utc=fetched_at_utc) for item in items]
+
+    entries = root.findall(".//{*}entry")
+    if entries:
+        return [_atom_entry_to_payload(entry=entry, fetched_at_utc=fetched_at_utc) for entry in entries]
+
+    return []
+
+
+def _rss_item_to_payload(*, item: ET.Element, fetched_at_utc: str) -> dict[str, Any]:
+    return {
+        "url": _first_text(item, "link"),
+        "title": _first_text(item, "title"),
+        "author": _first_text(item, "author", "{*}creator"),
+        "language": None,
+        "published_at": _normalize_timestamp(_first_text(item, "pubDate", "{*}published", "{*}updated")),
+        "fetched_at": fetched_at_utc,
+        "summary": _first_text(item, "description", "{*}summary"),
+        "body_text": _first_text(item, "{*}encoded", "{*}content"),
+        "doc_type": "rss",
+    }
+
+
+def _atom_entry_to_payload(*, entry: ET.Element, fetched_at_utc: str) -> dict[str, Any]:
+    link = entry.find("{*}link")
+    href = link.get("href") if link is not None else None
+    return {
+        "url": href,
+        "title": _first_text(entry, "{*}title"),
+        "author": _first_text(entry, "{*}author/{*}name", "{*}author"),
+        "language": None,
+        "published_at": _normalize_timestamp(_first_text(entry, "{*}published", "{*}updated")),
+        "fetched_at": fetched_at_utc,
+        "summary": _first_text(entry, "{*}summary"),
+        "body_text": _first_text(entry, "{*}content"),
+        "doc_type": "rss",
+    }
+
+
+def _first_text(element: ET.Element, *paths: str) -> str | None:
+    for path in paths:
+        child = element.find(path)
+        if child is not None and child.text:
+            return child.text.strip()
+    return None
+
+
+def _normalize_timestamp(value: str | None) -> str | None:
+    if not value:
+        return None
+    try:
+        dt = parsedate_to_datetime(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    except (TypeError, ValueError, IndexError):
+        pass
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    except ValueError:
+        return value
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/artifacts/modelling/source_registry.yaml
+++ b/artifacts/modelling/source_registry.yaml
@@ -109,7 +109,7 @@ sources:
 
   - id: us_bea_news
     name: U.S. Bureau of Economic Analysis - News Releases
-    url: https://www.bea.gov/rss/news_release.xml
+    url: https://apps.bea.gov/rss/rss.xml
     type: rss
     tags: [macro_data, growth, us]
     credibility_tier: 1

--- a/scripts/run_daily_brief.py
+++ b/scripts/run_daily_brief.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from apps.agent.daily_brief.runner import run_daily_brief
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the live daily brief on the active source subset.")
+    parser.add_argument("--base-dir", default=str(ROOT), help="Base directory for artifact output.")
+    parser.add_argument("--run-id", default="run_daily_live", help="Stable run identifier for the slice.")
+    parser.add_argument("--generated-at-utc", help="Optional UTC timestamp override in ISO-8601 format.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = run_daily_brief(
+        base_dir=Path(args.base_dir),
+        run_id=args.run_id,
+        generated_at_utc=args.generated_at_utc,
+    )
+    print(json.dumps(result, indent=2))
+    if result["status"] == "failed":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/daily_brief/test_runner.py
+++ b/tests/agent/daily_brief/test_runner.py
@@ -13,6 +13,8 @@ from apps.agent.daily_brief.runner import (
     build_daily_brief_corpus,
     build_daily_brief_synthesis,
     load_active_fixture_payloads,
+    load_active_live_payloads,
+    run_daily_brief,
     run_fixture_daily_brief,
 )
 from apps.agent.daily_brief.synthesis import build_citation_store
@@ -396,6 +398,21 @@ class DailyBriefRunnerTests(unittest.TestCase):
         self.assertEqual(len(stage_data.source_rows), len(stage_data.active_sources))
         self.assertGreater(len(stage_data.planned_items), 0)
 
+    def test_prepare_daily_brief_inputs_can_use_live_payloads_for_active_subset(self):
+        fixture_payloads = load_active_fixture_payloads()
+
+        with patch("apps.agent.daily_brief.runner.fetch_live_payloads_for_source") as live_fetch_mock:
+            live_fetch_mock.side_effect = lambda *, source, fetched_at_utc: fixture_payloads[str(source["id"])]
+            stage_data = prepare_daily_brief_inputs(
+                generated_at_utc="2026-03-10T16:00:00Z",
+                use_live_sources=True,
+            )
+
+        self.assertIsInstance(stage_data, DailyBriefInputStageData)
+        self.assertEqual(len(stage_data.active_sources), 5)
+        self.assertGreater(len(stage_data.planned_items), 0)
+        self.assertEqual(stage_data.planned_items[0]["source_id"], "fed_press_releases")
+
     def test_build_daily_brief_corpus_returns_typed_stage_payload_and_updates_counters(self):
         stage_inputs = prepare_daily_brief_inputs(generated_at_utc="2026-03-10T16:00:00Z")
         context = RunContext(
@@ -475,6 +492,45 @@ class DailyBriefRunnerTests(unittest.TestCase):
         )
         self.assertNotIn("ecb_press_releases", loaded)
 
+    def test_load_active_live_payloads_degrades_source_level_failures(self):
+        active_sources = [
+            {
+                "id": "fed_press_releases",
+                "name": "Federal Reserve - Press Releases",
+                "url": "https://example.test/fed",
+                "type": "rss",
+                "credibility_tier": 1,
+                "paywall_policy": "full",
+                "fetch_interval": "daily",
+                "tags": ["policy_centralbank"],
+            },
+            {
+                "id": "us_bls_news",
+                "name": "U.S. Bureau of Labor Statistics - News Releases",
+                "url": "https://example.test/bls",
+                "type": "rss",
+                "credibility_tier": 1,
+                "paywall_policy": "full",
+                "fetch_interval": "daily",
+                "tags": ["macro_data"],
+            },
+        ]
+
+        def side_effect(*, source, fetched_at_utc):
+            if source["id"] == "us_bls_news":
+                raise ValueError("blocked")
+            return [{"url": "https://example.test/fed", "title": "Fed keeps policy steady"}]
+
+        with patch("apps.agent.daily_brief.runner.fetch_live_payloads_for_source") as live_fetch_mock:
+            live_fetch_mock.side_effect = side_effect
+            loaded = load_active_live_payloads(
+                active_sources=active_sources,
+                fetched_at_utc="2026-03-10T16:00:00Z",
+            )
+
+        self.assertEqual(loaded["fed_press_releases"][0]["title"], "Fed keeps policy steady")
+        self.assertEqual(loaded["us_bls_news"], [])
+
     def test_build_daily_brief_query_uses_repeated_document_terms(self):
         documents = [
             {
@@ -532,6 +588,26 @@ class DailyBriefRunnerTests(unittest.TestCase):
             )
             self.assertEqual(run_summary["guardrail_checks"]["budget_check"], "pass")
             self.assertIn(run_summary["guardrail_checks"]["diversity_check"], {"pass", "fail"})
+
+    def test_run_daily_brief_writes_expected_artifacts_from_live_payloads(self):
+        fixture_payloads = load_active_fixture_payloads()
+
+        with patch("apps.agent.daily_brief.runner.fetch_live_payloads_for_source") as live_fetch_mock, tempfile.TemporaryDirectory() as tmpdir:
+            live_fetch_mock.side_effect = lambda *, source, fetched_at_utc: fixture_payloads.get(str(source["id"]), [])
+            result = run_daily_brief(
+                base_dir=Path(tmpdir),
+                run_id="run_live_ok",
+                generated_at_utc="2026-03-10T16:00:00Z",
+            )
+
+            html_path = Path(result["html_path"])
+            artifact_dir = Path(result["artifact_dir"])
+            run_summary = json.loads((artifact_dir / "run_summary.json").read_text(encoding="utf-8"))
+            self.assertEqual(result["status"], "ok")
+            self.assertTrue(html_path.exists())
+            self.assertTrue((artifact_dir / "documents.json").exists())
+            self.assertEqual(run_summary["docs_fetched"], 5)
+            self.assertEqual(result["pipeline_status"], "ok")
 
     def test_run_fixture_daily_brief_persists_budget_preflight_truthfully(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/agent/ingest/test_live_fetch.py
+++ b/tests/agent/ingest/test_live_fetch.py
@@ -1,0 +1,81 @@
+import unittest
+from unittest.mock import patch
+
+from apps.agent.ingest.live_fetch import fetch_live_payloads_for_source, parse_rss_feed
+
+
+RSS_FEED = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Example Feed</title>
+    <item>
+      <title>Fed keeps policy steady</title>
+      <link>https://example.test/fed</link>
+      <pubDate>Tue, 10 Mar 2026 14:00:00 GMT</pubDate>
+      <description>Fed officials kept policy steady.</description>
+    </item>
+    <item>
+      <title>BLS releases CPI update</title>
+      <link>https://example.test/bls</link>
+      <pubDate>2026-03-10T13:30:00Z</pubDate>
+      <description>CPI update for February.</description>
+    </item>
+  </channel>
+</rss>
+"""
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class LiveFetchTests(unittest.TestCase):
+    def test_parse_rss_feed_returns_runtime_payload_shape(self):
+        payloads = parse_rss_feed(
+            feed_text=RSS_FEED,
+            fetched_at_utc="2026-03-10T16:00:00Z",
+        )
+
+        self.assertEqual(len(payloads), 2)
+        self.assertEqual(payloads[0]["url"], "https://example.test/fed")
+        self.assertEqual(payloads[0]["title"], "Fed keeps policy steady")
+        self.assertEqual(payloads[0]["published_at"], "2026-03-10T14:00:00Z")
+        self.assertEqual(payloads[1]["published_at"], "2026-03-10T13:30:00Z")
+        self.assertEqual(payloads[0]["doc_type"], "rss")
+
+    def test_fetch_live_payloads_for_source_reads_rss_feed(self):
+        source = {
+            "id": "fed_press_releases",
+            "url": "https://example.test/feed.xml",
+            "type": "rss",
+        }
+
+        with patch("apps.agent.ingest.live_fetch.urlopen", return_value=_FakeResponse(RSS_FEED.encode("utf-8"))):
+            payloads = fetch_live_payloads_for_source(
+                source=source,
+                fetched_at_utc="2026-03-10T16:00:00Z",
+            )
+
+        self.assertEqual(len(payloads), 2)
+        self.assertEqual(payloads[0]["fetched_at"], "2026-03-10T16:00:00Z")
+
+    def test_fetch_live_payloads_rejects_non_rss_source_type_for_current_slice(self):
+        with self.assertRaises(ValueError):
+            fetch_live_payloads_for_source(
+                source={"id": "boe_news", "url": "https://example.test/news", "type": "html"},
+                fetched_at_utc="2026-03-10T16:00:00Z",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a live daily-brief entrypoint that fetches the current active RSS subset instead of only committed fixtures
- add a stdlib RSS/Atom fetcher with request headers and source-level degradation when some active feeds are blocked or stale
- keep the deterministic fixture runner for tests, update the BEA feed URL, and document both entrypoints

## Verification
- python -m unittest tests.agent.ingest.test_live_fetch tests.agent.daily_brief.test_runner -v
- python -m compileall -q apps tests scripts
- python scripts/run_daily_brief.py --base-dir <tempdir> --run-id run_live_smoke --generated-at-utc 2026-03-10T16:00:00Z

Closes #64