### PR TITLE
feat(daily-brief): implement changed-since-yesterday section

### DIFF
--- a/apps/agent/daily_brief/runner.py
+++ b/apps/agent/daily_brief/runner.py
@@ -4,7 +4,7 @@ import json
 import re
 from collections import Counter
 from collections.abc import Iterable, Mapping
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -43,7 +43,12 @@ from apps.agent.runtime.cost_ledger import BudgetWindowSnapshot
 from apps.agent.runtime.source_scope import load_active_source_subset
 from apps.agent.runtime.source_scope import load_source_registry
 from apps.agent.synthesis.postprocess import finalize_validation_outcome
-from apps.agent.daily_brief.synthesis import SynthesisRetryPlan, build_citation_store, build_synthesis
+from apps.agent.daily_brief.synthesis import (
+    SynthesisRetryPlan,
+    build_changed_section,
+    build_citation_store,
+    build_synthesis,
+)
 
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -227,6 +232,7 @@ def _execute_daily_brief_slice(
     context: Any,
     use_live_sources: bool = False,
 ) -> dict[str, Any]:
+    report_date = generated_at_utc[:10]
     input_data = prepare_daily_brief_inputs(
         fixture_path=fixture_path,
         generated_at_utc=generated_at_utc,
@@ -241,8 +247,8 @@ def _execute_daily_brief_slice(
         stage_data=corpus_data,
         registry=input_data.registry,
         run_id=run_id,
+        previous_synthesis=_load_previous_synthesis(base_dir=base_dir, report_date=report_date),
     )
-    report_date = generated_at_utc[:10]
     output_path = base_dir / "artifacts" / "daily" / report_date / "brief.html"
     budget_snapshot = _budget_snapshot(context=context)
     guardrail_checks = _guardrail_checks(
@@ -411,6 +417,7 @@ def build_daily_brief_synthesis(
     stage_data: DailyBriefCorpusStageData,
     registry: Mapping[str, SourceRegistryEntry],
     run_id: str,
+    previous_synthesis: Mapping[str, Any] | None = None,
 ) -> DailyBriefSynthesisStageData:
     query_text = build_daily_brief_query(documents=stage_data.documents)
     evidence_pack_report = build_evidence_pack_report(
@@ -473,6 +480,17 @@ def build_daily_brief_synthesis(
         raise ValueError("Daily brief synthesis did not produce a validation result.")
 
     final_result = finalize_validation_outcome(validation_result=stage8_result)
+    changed_section = build_changed_section(
+        current_synthesis=final_result["synthesis"],
+        previous_synthesis=previous_synthesis,
+    )
+    if changed_section:
+        final_synthesis = dict(final_result["synthesis"])
+        final_synthesis["changed"] = changed_section
+        final_result = {
+            **final_result,
+            "synthesis": final_synthesis,
+        }
     synthesis_id = f"syn_{run_id}"
     return DailyBriefSynthesisStageData(
         query_text=query_text,
@@ -787,6 +805,20 @@ def _artifact_dir(*, base_dir: Path, report_date: str, run_id: str) -> Path:
     artifact_dir = base_dir / "artifacts" / "runtime" / "daily_brief_runs" / report_date / run_id
     artifact_dir.mkdir(parents=True, exist_ok=True)
     return artifact_dir
+
+
+def _load_previous_synthesis(*, base_dir: Path, report_date: str) -> dict[str, Any] | None:
+    current_date = datetime.fromisoformat(report_date).date()
+    previous_date = (current_date - timedelta(days=1)).isoformat()
+    prior_dir = base_dir / "artifacts" / "runtime" / "daily_brief_runs" / previous_date
+    if not prior_dir.exists():
+        return None
+
+    candidate_paths = sorted(prior_dir.glob("*/synthesis.json"))
+    if not candidate_paths:
+        return None
+
+    return json.loads(candidate_paths[-1].read_text(encoding="utf-8"))
 
 
 def _persist_budget_stop_outputs(

--- a/apps/agent/daily_brief/synthesis.py
+++ b/apps/agent/daily_brief/synthesis.py
@@ -39,6 +39,8 @@ MINORITY_KEYWORDS = (
     "minority",
     "outlier",
 )
+INSUFFICIENT_EVIDENCE_TEXT = "[Insufficient evidence to produce a validated output]"
+CHANGED_SECTION_MAX_BULLETS = 3
 
 
 @dataclass(frozen=True)
@@ -118,6 +120,46 @@ def build_synthesis(
         }
         synthesis[section].append(dict(bullet))
     return synthesis
+
+
+def build_changed_section(
+    *,
+    current_synthesis: Mapping[str, Any],
+    previous_synthesis: Mapping[str, Any] | None,
+) -> list[DailyBriefBullet]:
+    if not isinstance(previous_synthesis, Mapping):
+        return []
+
+    changed: list[DailyBriefBullet] = []
+    for section in DAILY_BRIEF_CORE_OUTPUT_SECTIONS:
+        current_bullet = _first_bullet(current_synthesis.get(section))
+        if current_bullet is None:
+            continue
+
+        current_text = str(current_bullet.get("text", "")).strip()
+        if not current_text or current_text == INSUFFICIENT_EVIDENCE_TEXT:
+            continue
+
+        previous_bullet = _first_bullet(previous_synthesis.get(section))
+        previous_text = "" if previous_bullet is None else str(previous_bullet.get("text", "")).strip()
+        if current_text == previous_text:
+            continue
+
+        changed.append(
+            {
+                "text": _build_changed_bullet_text(
+                    section=section,
+                    current_text=current_text,
+                    previous_text=previous_text,
+                ),
+                "citation_ids": [str(citation_id) for citation_id in current_bullet.get("citation_ids", [])],
+                "confidence_label": current_bullet.get("confidence_label"),
+            }
+        )
+        if len(changed) >= CHANGED_SECTION_MAX_BULLETS:
+            break
+
+    return changed
 
 
 def _sorted_evidence_items(evidence_items: Iterable[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
@@ -305,6 +347,24 @@ def _build_bullet_text(*, section: str, document: Mapping[str, Any], publisher: 
             return f"{normalized_title}."
         return f"Watch {normalized_title.lower()}."
     return f"{normalized_title} ({publisher})."
+
+
+def _first_bullet(raw_bullets: Any) -> Mapping[str, Any] | None:
+    if not isinstance(raw_bullets, list) or not raw_bullets:
+        return None
+    bullet = raw_bullets[0]
+    if not isinstance(bullet, Mapping):
+        return None
+    return bullet
+
+
+def _build_changed_bullet_text(*, section: str, current_text: str, previous_text: str) -> str:
+    label = section.replace("_", " ").title()
+    if not previous_text:
+        return f"{label} is newly supported today: {current_text}"
+    if previous_text == INSUFFICIENT_EVIDENCE_TEXT:
+        return f"{label} gained support today: {current_text}"
+    return f"{label} changed versus yesterday: {current_text}"
 
 
 def _confidence_label(credibility_tier: int) -> str:

--- a/apps/agent/delivery/html_report.py
+++ b/apps/agent/delivery/html_report.py
@@ -10,6 +10,7 @@ SECTION_TITLES = {
     "counter": "Counter",
     "minority": "Minority",
     "watch": "Watch",
+    "changed": "Changed Since Yesterday",
 }
 
 
@@ -29,6 +30,8 @@ def render_daily_brief_html(
     sections_html: list[str] = []
     for section, title in SECTION_TITLES.items():
         bullets = synthesis.get(section, [])
+        if section == "changed" and not bullets:
+            continue
         bullet_items = "".join(_render_bullet(bullet) for bullet in bullets)
         sections_html.append(f"<section><h2>{escape(title)}</h2><ul>{bullet_items}</ul></section>")
 

--- a/tests/agent/daily_brief/test_runner.py
+++ b/tests/agent/daily_brief/test_runner.py
@@ -609,6 +609,44 @@ class DailyBriefRunnerTests(unittest.TestCase):
             self.assertEqual(run_summary["docs_fetched"], 5)
             self.assertEqual(result["pipeline_status"], "ok")
 
+    def test_run_fixture_daily_brief_includes_changed_section_when_previous_synthesis_exists(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            previous_synthesis_path = (
+                base_dir
+                / "artifacts"
+                / "runtime"
+                / "daily_brief_runs"
+                / "2026-03-09"
+                / "run_prior"
+                / "synthesis.json"
+            )
+            previous_synthesis_path.parent.mkdir(parents=True, exist_ok=True)
+            previous_synthesis_path.write_text(
+                json.dumps(
+                    {
+                        "prevailing": [{"text": "Yesterday's prevailing view.", "citation_ids": ["cite_old_001"]}],
+                        "counter": [{"text": "Yesterday's counter view.", "citation_ids": ["cite_old_002"]}],
+                        "minority": [{"text": "Yesterday's minority view.", "citation_ids": ["cite_old_003"]}],
+                        "watch": [{"text": "Yesterday's watch view.", "citation_ids": ["cite_old_004"]}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = run_fixture_daily_brief(
+                base_dir=base_dir,
+                run_id="run_fixture_changed",
+                generated_at_utc="2026-03-10T16:00:00Z",
+            )
+
+            synthesis_payload = json.loads((Path(result["artifact_dir"]) / "synthesis.json").read_text(encoding="utf-8"))
+            html = Path(result["html_path"]).read_text(encoding="utf-8")
+
+        self.assertIn("changed", synthesis_payload)
+        self.assertGreater(len(synthesis_payload["changed"]), 0)
+        self.assertIn("Changed Since Yesterday", html)
+
     def test_run_fixture_daily_brief_persists_budget_preflight_truthfully(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             result = run_fixture_daily_brief(

--- a/tests/agent/daily_brief/test_synthesis.py
+++ b/tests/agent/daily_brief/test_synthesis.py
@@ -1,9 +1,37 @@
 import unittest
 
-from apps.agent.daily_brief.synthesis import SynthesisRetryPlan, build_citation_store, build_synthesis
+from apps.agent.daily_brief.synthesis import (
+    SynthesisRetryPlan,
+    build_changed_section,
+    build_citation_store,
+    build_synthesis,
+)
 
 
 class DailyBriefSynthesisTests(unittest.TestCase):
+    def test_build_changed_section_uses_current_cited_bullets_when_sections_shift(self):
+        changed = build_changed_section(
+            current_synthesis={
+                "prevailing": [{"text": "Fed kept policy steady (Federal Reserve).", "citation_ids": ["cite_001"], "confidence_label": "high"}],
+                "counter": [{"text": "Growth is cooling faster (Reuters).", "citation_ids": ["cite_002"], "confidence_label": "medium"}],
+                "minority": [{"text": "Some investors expect a rebound (WSJ).", "citation_ids": ["cite_003"], "confidence_label": "medium"}],
+                "watch": [{"text": "Watch payroll revisions next week.", "citation_ids": ["cite_004"], "confidence_label": "high"}],
+            },
+            previous_synthesis={
+                "prevailing": [{"text": "Inflation stayed sticky yesterday.", "citation_ids": ["cite_old_001"]}],
+                "counter": [{"text": "Growth is cooling faster (Reuters).", "citation_ids": ["cite_old_002"]}],
+                "watch": [{"text": "[Insufficient evidence to produce a validated output]", "citation_ids": []}],
+            },
+        )
+
+        self.assertEqual(len(changed), 3)
+        self.assertEqual(changed[0]["citation_ids"], ["cite_001"])
+        self.assertIn("Prevailing changed versus yesterday", changed[0]["text"])
+        self.assertEqual(changed[1]["citation_ids"], ["cite_003"])
+        self.assertIn("Minority is newly supported today", changed[1]["text"])
+        self.assertEqual(changed[2]["citation_ids"], ["cite_004"])
+        self.assertIn("Watch gained support today", changed[2]["text"])
+
     def test_build_synthesis_retry_plan_reassigns_failed_section_with_alternate_evidence(self):
         evidence_items = [
             {

--- a/tests/agent/delivery/test_html_report.py
+++ b/tests/agent/delivery/test_html_report.py
@@ -62,6 +62,34 @@ class HtmlReportTests(unittest.TestCase):
         self.assertIn("Abstained", html)
         self.assertIn("Insufficient evidence", html)
 
+    def test_render_daily_brief_html_renders_changed_section_only_when_present(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "artifacts" / "daily" / "2026-03-10" / "brief.html"
+
+            render_daily_brief_html(
+                output_path=output_path,
+                report_date="2026-03-10",
+                run_id="run_changed",
+                synthesis={
+                    "prevailing": [{"text": "Fed kept policy steady.", "citation_ids": ["cite_001"]}],
+                    "counter": [{"text": "Growth is cooling faster.", "citation_ids": ["cite_002"]}],
+                    "minority": [{"text": "Some investors expect a rebound.", "citation_ids": ["cite_003"]}],
+                    "watch": [{"text": "Watch payroll revisions.", "citation_ids": ["cite_004"]}],
+                    "changed": [{"text": "Prevailing changed versus yesterday: Fed kept policy steady.", "citation_ids": ["cite_001"]}],
+                },
+                citation_store={
+                    "cite_001": {"title": "Fed release", "url": "https://example.test/fed"},
+                    "cite_002": {"title": "Reuters item", "url": "https://example.test/reuters"},
+                    "cite_003": {"title": "WSJ item", "url": "https://example.test/wsj"},
+                    "cite_004": {"title": "BLS item", "url": "https://example.test/bls"},
+                },
+            )
+
+            html = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("Changed Since Yesterday", html)
+        self.assertIn("Prevailing changed versus yesterday", html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- build a heuristic changed-since-yesterday section by comparing today\'s validated synthesis with the previous day\'s saved synthesis artifact
- attach current citations to changed bullets and cap the section at three bullets
- render the changed section in the HTML report only when there is prior-history-backed content to show

## Verification
- python -m unittest tests.agent.daily_brief.test_synthesis tests.agent.delivery.test_html_report tests.agent.daily_brief.test_runner -v
- python -m compileall -q apps tests scripts

Closes #66