### PR TITLE
feat(ingest): add PDF extraction support end to end

### DIFF
--- a/apps/agent/ingest/extract.py
+++ b/apps/agent/ingest/extract.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import base64
+from io import BytesIO
 from collections.abc import Mapping
 from typing import Any
+
+from pypdf import PdfReader
 
 
 def extract_payload(*, source: Mapping[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -10,6 +14,8 @@ def extract_payload(*, source: Mapping[str, Any], payload: Mapping[str, Any]) ->
         return _extract_rss_payload(source=source, payload=payload)
     if source_type == "html":
         return _extract_html_payload(source=source, payload=payload)
+    if source_type == "pdf":
+        return _extract_pdf_payload(source=source, payload=payload)
     raise ValueError(f"Unsupported source type: {source_type}")
 
 
@@ -41,3 +47,52 @@ def _extract_html_payload(*, source: Mapping[str, Any], payload: Mapping[str, An
         "body_text": payload.get("text", payload.get("body_text")),
         "doc_type": payload.get("doc_type"),
     }
+
+
+def _extract_pdf_payload(*, source: Mapping[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:
+    canonical_url = payload.get("canonical_url", payload.get("url"))
+    if not canonical_url:
+        raise ValueError("PDF payload must include canonical_url or url")
+
+    return {
+        "publisher": source["name"],
+        "canonical_url": canonical_url,
+        "title": payload.get("title"),
+        "author": payload.get("author"),
+        "language": payload.get("language"),
+        "published_at": payload.get("published_at"),
+        "fetched_at": payload.get("fetched_at"),
+        "rss_snippet": payload.get("summary", payload.get("snippet")),
+        "body_text": _extract_pdf_text(payload=payload),
+        "doc_type": payload.get("doc_type", "report"),
+    }
+
+
+def _extract_pdf_text(*, payload: Mapping[str, Any]) -> str | None:
+    if payload.get("text") is not None:
+        return str(payload["text"])
+    if payload.get("body_text") is not None:
+        return str(payload["body_text"])
+
+    pdf_bytes = _load_pdf_bytes(payload=payload)
+    if pdf_bytes is None:
+        raise ValueError("PDF payload must include text, body_text, pdf_bytes, or pdf_base64")
+
+    reader = PdfReader(BytesIO(pdf_bytes))
+    page_text = [(page.extract_text() or "").strip() for page in reader.pages]
+    normalized_pages = [text for text in page_text if text]
+    if not normalized_pages:
+        return None
+    return "\n\n".join(normalized_pages)
+
+
+def _load_pdf_bytes(*, payload: Mapping[str, Any]) -> bytes | None:
+    raw_bytes = payload.get("pdf_bytes")
+    if isinstance(raw_bytes, bytes):
+        return raw_bytes
+
+    base64_text = payload.get("pdf_base64")
+    if isinstance(base64_text, str):
+        return base64.b64decode(base64_text.encode("ascii"))
+
+    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "PyYAML==6.0.2",
+  "pypdf>=5,<6",
 ]
 
 [project.optional-dependencies]

--- a/tests/agent/ingest/test_extract.py
+++ b/tests/agent/ingest/test_extract.py
@@ -3,6 +3,34 @@ import unittest
 from apps.agent.ingest.extract import extract_payload
 
 
+def _build_pdf_bytes(text: str) -> bytes:
+    escaped_text = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+    content_stream = f"BT\n/F1 18 Tf\n72 72 Td\n({escaped_text}) Tj\nET"
+    objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+        f"<< /Length {len(content_stream.encode('latin-1'))} >>\nstream\n{content_stream}\nendstream",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+
+    parts: list[bytes] = [b"%PDF-1.4\n"]
+    offsets: list[int] = [0]
+    current_offset = len(parts[0])
+    for index, body in enumerate(objects, start=1):
+        object_bytes = f"{index} 0 obj\n{body}\nendobj\n".encode("latin-1")
+        offsets.append(current_offset)
+        parts.append(object_bytes)
+        current_offset += len(object_bytes)
+
+    xref_offset = current_offset
+    xref_rows = ["0000000000 65535 f \n"]
+    xref_rows.extend(f"{offset:010d} 00000 n \n" for offset in offsets[1:])
+    xref = f"xref\n0 {len(objects) + 1}\n{''.join(xref_rows)}"
+    trailer = f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF"
+    return b"".join(parts) + xref.encode("latin-1") + trailer.encode("latin-1")
+
+
 class ExtractPayloadTests(unittest.TestCase):
     def test_extracts_rss_payload_to_common_shape(self):
         source = {
@@ -57,6 +85,51 @@ class ExtractPayloadTests(unittest.TestCase):
         self.assertEqual(extracted["author"], payload["byline"])
         self.assertEqual(extracted["rss_snippet"], payload["snippet"])
         self.assertEqual(extracted["body_text"], payload["text"])
+
+    def test_extracts_pdf_payload_to_common_shape(self):
+        source = {
+            "id": "fomc_minutes_pdf",
+            "name": "Federal Reserve - Minutes PDF",
+            "type": "pdf",
+            "paywall_policy": "full",
+        }
+        payload = {
+            "url": "https://example.com/fed/minutes.pdf",
+            "title": "FOMC Minutes",
+            "author": "Federal Reserve",
+            "language": "en",
+            "published_at": "2026-03-10T03:00:00Z",
+            "fetched_at": "2026-03-10T03:05:00Z",
+            "summary": "Minutes for the latest FOMC meeting.",
+            "pdf_bytes": _build_pdf_bytes("FOMC minutes note inflation progress."),
+            "doc_type": "minutes",
+        }
+
+        extracted = extract_payload(source=source, payload=payload)
+
+        self.assertEqual(extracted["publisher"], "Federal Reserve - Minutes PDF")
+        self.assertEqual(extracted["canonical_url"], payload["url"])
+        self.assertEqual(extracted["title"], payload["title"])
+        self.assertEqual(extracted["rss_snippet"], payload["summary"])
+        self.assertIn("FOMC minutes note inflation progress.", extracted["body_text"])
+        self.assertEqual(extracted["doc_type"], "minutes")
+
+    def test_pdf_payload_requires_text_or_bytes(self):
+        source = {
+            "id": "fomc_minutes_pdf",
+            "name": "Federal Reserve - Minutes PDF",
+            "type": "pdf",
+            "paywall_policy": "full",
+        }
+
+        with self.assertRaisesRegex(ValueError, "PDF payload must include text, body_text, pdf_bytes, or pdf_base64"):
+            extract_payload(
+                source=source,
+                payload={
+                    "url": "https://example.com/fed/minutes.pdf",
+                    "fetched_at": "2026-03-10T03:05:00Z",
+                },
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a real pdf source type to the extractor instead of failing on non-rss/html sources
- extract page text from PDF bytes or base64 payloads with pypdf
- add regression coverage for PDF payload extraction and missing-payload failure cases

## Verification
- python -m pip install -e .[dev]
- python -m unittest tests.agent.ingest.test_extract -v
- python -m compileall -q apps tests scripts

Closes #65