### PR TITLE
feat(runtime): persist daily brief to sqlite

### DIFF
--- a/apps/agent/daily_brief/runner.py
+++ b/apps/agent/daily_brief/runner.py
@@ -17,6 +17,7 @@ from apps.agent.ingest.normalize import build_document_record
 from apps.agent.orchestrator import run_pipeline
 from apps.agent.pipeline.stage10_decision_record import build_and_persist_decision_record
 from apps.agent.pipeline.stage8_validation import run_stage8_citation_validation
+from apps.agent.pipeline.identifiers import build_document_id, build_synthesis_id
 from apps.agent.pipeline.types import (
     DAILY_BRIEF_OUTPUT_SECTIONS,
     BulletCitationRow,
@@ -42,6 +43,7 @@ from apps.agent.runtime.budget_guard import BudgetCaps
 from apps.agent.runtime.cost_ledger import BudgetWindowSnapshot
 from apps.agent.runtime.source_scope import load_active_source_subset
 from apps.agent.runtime.source_scope import load_source_registry
+from apps.agent.storage.sqlite_runtime import persist_daily_brief_runtime
 from apps.agent.synthesis.postprocess import finalize_validation_outcome
 from apps.agent.daily_brief.synthesis import (
     SynthesisRetryPlan,
@@ -163,6 +165,14 @@ def run_fixture_daily_brief(
     execution["lifecycle"] = lifecycle
     execution["pipeline_status"] = pipeline_result["status"]
     execution["error_summary"] = pipeline_result.get("error_summary")
+    execution["runtime_db_path"] = str(
+        _persist_run_state(
+            base_dir=base_dir,
+            generated_at_utc=timestamp,
+            execution=execution,
+            pipeline_result=pipeline_result,
+        )
+    )
     return execution
 
 
@@ -220,6 +230,14 @@ def run_daily_brief(
     execution["lifecycle"] = lifecycle
     execution["pipeline_status"] = pipeline_result["status"]
     execution["error_summary"] = pipeline_result.get("error_summary")
+    execution["runtime_db_path"] = str(
+        _persist_run_state(
+            base_dir=base_dir,
+            generated_at_utc=timestamp,
+            execution=execution,
+            pipeline_result=pipeline_result,
+        )
+    )
     return execution
 
 
@@ -377,14 +395,14 @@ def build_daily_brief_corpus(
     chunks: list[RuntimeChunkRow] = []
     fts_rows: list[FtsRow] = []
 
-    for index, planned in enumerate(stage_data.planned_items, start=1):
+    for planned in stage_data.planned_items:
         source_id = str(planned["source_id"])
         source = stage_data.registry[source_id]
         extracted = extract_payload(source=source, payload=planned["payload"])
         document = _build_runtime_document_record(
             source=source,
             extracted=extracted,
-            doc_id=f"doc_{index:03d}",
+            doc_id=build_document_id(canonical_url=str(extracted["canonical_url"])),
             run_id=run_id,
         )
 
@@ -491,7 +509,7 @@ def build_daily_brief_synthesis(
             **final_result,
             "synthesis": final_synthesis,
         }
-    synthesis_id = f"syn_{run_id}"
+    synthesis_id = build_synthesis_id(run_id=run_id)
     return DailyBriefSynthesisStageData(
         query_text=query_text,
         evidence_pack_items=evidence_pack_items,
@@ -874,6 +892,85 @@ def _persist_budget_stop_outputs(
         "query_text": None,
         "abstain_reason": pipeline_result.get("error_summary"),
     }
+
+
+def _persist_run_state(
+    *,
+    base_dir: Path,
+    generated_at_utc: str,
+    execution: Mapping[str, Any],
+    pipeline_result: Mapping[str, Any],
+) -> Path:
+    report_date = generated_at_utc[:10]
+    run_row = dict(pipeline_result)
+    artifact_dir_value = execution.get("artifact_dir")
+
+    if artifact_dir_value:
+        artifact_dir = Path(str(artifact_dir_value))
+        if not (artifact_dir / "sources.json").exists():
+            return persist_daily_brief_runtime(
+                base_dir=base_dir,
+                generated_at_utc=generated_at_utc,
+                report_date=report_date,
+                query_text="",
+                source_rows=[],
+                documents=[],
+                chunks=[],
+                evidence_pack_items=[],
+                evidence_pack_report={"diversity_stats": {}},
+                citation_rows=[],
+                synthesis_rows=[],
+                bullet_citation_rows=[],
+                run_row=run_row,
+                budget_ledger_rows=pipeline_result.get("budget_ledger_rows", []),
+            )
+        source_rows = json.loads((artifact_dir / "sources.json").read_text(encoding="utf-8"))
+        documents = json.loads((artifact_dir / "documents.json").read_text(encoding="utf-8"))
+        chunks = json.loads((artifact_dir / "chunks.json").read_text(encoding="utf-8"))
+        evidence_pack_items = json.loads(
+            (artifact_dir / "evidence_pack_items.json").read_text(encoding="utf-8")
+        )
+        citations = json.loads((artifact_dir / "citations.json").read_text(encoding="utf-8"))
+        synthesis_bullets = json.loads(
+            (artifact_dir / "synthesis_bullets.json").read_text(encoding="utf-8")
+        )
+        bullet_citations = json.loads(
+            (artifact_dir / "bullet_citations.json").read_text(encoding="utf-8")
+        )
+        run_summary = json.loads((artifact_dir / "run_summary.json").read_text(encoding="utf-8"))
+        return persist_daily_brief_runtime(
+            base_dir=base_dir,
+            generated_at_utc=generated_at_utc,
+            report_date=report_date,
+            query_text=str(execution.get("query_text") or ""),
+            source_rows=source_rows,
+            documents=documents,
+            chunks=chunks,
+            evidence_pack_items=evidence_pack_items,
+            evidence_pack_report={"diversity_stats": run_summary.get("diversity_stats", {})},
+            citation_rows=citations,
+            synthesis_rows=synthesis_bullets,
+            bullet_citation_rows=bullet_citations,
+            run_row=run_row,
+            budget_ledger_rows=run_summary.get("budget_ledger_rows", []),
+        )
+
+    return persist_daily_brief_runtime(
+        base_dir=base_dir,
+        generated_at_utc=generated_at_utc,
+        report_date=report_date,
+        query_text="",
+        source_rows=[],
+        documents=[],
+        chunks=[],
+        evidence_pack_items=[],
+        evidence_pack_report={"diversity_stats": {}},
+        citation_rows=[],
+        synthesis_rows=[],
+        bullet_citation_rows=[],
+        run_row=run_row,
+        budget_ledger_rows=pipeline_result.get("budget_ledger_rows", []),
+    )
 
 
 def _utc_now_iso() -> str:

--- a/apps/agent/pipeline/identifiers.py
+++ b/apps/agent/pipeline/identifiers.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import uuid
+
+
+_SEPARATOR = "\x1f"
+
+
+def build_prefixed_uuid_id(prefix: str, *parts: object) -> str:
+    if not prefix:
+        raise ValueError("prefix must be a non-empty string")
+    if not parts:
+        raise ValueError("at least one identity part is required")
+
+    material = _SEPARATOR.join(str(part) for part in parts)
+    return f"{prefix}_{uuid.uuid5(uuid.NAMESPACE_URL, material)}"
+
+
+def build_document_id(*, canonical_url: str) -> str:
+    return build_prefixed_uuid_id("doc", canonical_url)
+
+
+def build_chunk_id(*, doc_id: str, chunk_index: int) -> str:
+    return build_prefixed_uuid_id("chunk", doc_id, chunk_index)
+
+
+def build_synthesis_id(*, run_id: str) -> str:
+    return build_prefixed_uuid_id("syn", run_id)
+
+
+def build_pack_id(*, run_id: str, query_text: str) -> str:
+    return build_prefixed_uuid_id("pack", run_id, query_text)
+
+
+def build_citation_id(
+    *,
+    source_id: str,
+    doc_id: str,
+    chunk_id: str,
+    url: str,
+) -> str:
+    return build_prefixed_uuid_id("cite", source_id, doc_id, chunk_id, url)

--- a/apps/agent/retrieval/chunker.py
+++ b/apps/agent/retrieval/chunker.py
@@ -4,6 +4,8 @@ import re
 from collections.abc import Mapping
 from typing import Any
 
+from apps.agent.pipeline.identifiers import build_chunk_id
+
 
 def chunk_document(*, document: Mapping[str, Any], max_chars: int = 800) -> list[dict[str, int | str]]:
     if document.get("metadata_only") or not document.get("body_text"):
@@ -43,7 +45,10 @@ def build_chunk_rows(*, document: Mapping[str, Any], max_chars: int = 800) -> li
         chunk_index = int(chunk["chunk_index"])
         chunk_rows.append(
             {
-                "chunk_id": f"{document['doc_id']}_chunk_{chunk_index:03d}",
+                "chunk_id": build_chunk_id(
+                    doc_id=str(document["doc_id"]),
+                    chunk_index=chunk_index,
+                ),
                 "doc_id": document["doc_id"],
                 "chunk_index": chunk_index,
                 "text": chunk["text"],

--- a/apps/agent/storage/__init__.py
+++ b/apps/agent/storage/__init__.py
@@ -1,0 +1,1 @@
+"""SQLite-backed runtime persistence helpers."""

--- a/apps/agent/storage/sqlite_runtime.py
+++ b/apps/agent/storage/sqlite_runtime.py
@@ -1,0 +1,612 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from apps.agent.pipeline.identifiers import build_citation_id, build_pack_id
+
+
+def runtime_db_path(*, base_dir: Path) -> Path:
+    runtime_dir = base_dir / "artifacts" / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    return runtime_dir / "agent_runtime.sqlite3"
+
+
+def persist_daily_brief_runtime(
+    *,
+    base_dir: Path,
+    generated_at_utc: str,
+    report_date: str,
+    query_text: str,
+    source_rows: Iterable[Mapping[str, Any]],
+    documents: Iterable[Mapping[str, Any]],
+    chunks: Iterable[Mapping[str, Any]],
+    evidence_pack_items: Iterable[Mapping[str, Any]],
+    evidence_pack_report: Mapping[str, Any],
+    citation_rows: Iterable[Mapping[str, Any]],
+    synthesis_rows: Iterable[Mapping[str, Any]],
+    bullet_citation_rows: Iterable[Mapping[str, Any]],
+    run_row: Mapping[str, Any],
+    budget_ledger_rows: Iterable[Mapping[str, Any]],
+) -> Path:
+    db_path = runtime_db_path(base_dir=base_dir)
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.row_factory = sqlite3.Row
+        _initialize_schema(connection)
+
+        source_rows_list = [dict(row) for row in source_rows]
+        document_rows_list = [dict(row) for row in documents]
+        chunk_rows_list = [dict(row) for row in chunks]
+        evidence_pack_rows_list = [dict(row) for row in evidence_pack_items]
+        citation_rows_list = [dict(row) for row in citation_rows]
+        synthesis_rows_list = [dict(row) for row in synthesis_rows]
+        bullet_citation_rows_list = [dict(row) for row in bullet_citation_rows]
+        budget_ledger_rows_list = [dict(row) for row in budget_ledger_rows]
+
+        pack_id = build_pack_id(run_id=str(run_row["run_id"]), query_text=query_text)
+        _persist_run(connection, row=dict(run_row))
+        _persist_sources(connection, rows=source_rows_list)
+        _persist_documents(connection, rows=document_rows_list)
+        _persist_chunks(connection, rows=chunk_rows_list)
+        _persist_evidence_pack(
+            connection,
+            pack_id=pack_id,
+            query_text=query_text,
+            generated_at_utc=generated_at_utc,
+            stats=evidence_pack_report.get("diversity_stats", {}),
+        )
+        _persist_evidence_pack_items(connection, pack_id=pack_id, rows=evidence_pack_rows_list)
+        persisted_citation_ids = _persist_citations(
+            connection,
+            rows=citation_rows_list,
+            valid_doc_ids={str(row["doc_id"]) for row in document_rows_list},
+            valid_chunk_ids={str(row["chunk_id"]) for row in chunk_rows_list},
+        )
+        _persist_synthesis(
+            connection,
+            rows=synthesis_rows_list,
+            run_row=run_row,
+            report_date=report_date,
+            generated_at_utc=generated_at_utc,
+            pack_id=pack_id,
+        )
+        _persist_bullet_citations(
+            connection,
+            rows=bullet_citation_rows_list,
+            citation_id_map=persisted_citation_ids,
+        )
+        _persist_budget_ledger(connection, rows=budget_ledger_rows_list)
+        connection.commit()
+    finally:
+        connection.close()
+    return db_path
+
+
+def _initialize_schema(connection: sqlite3.Connection) -> None:
+    connection.execute("PRAGMA foreign_keys = ON")
+    statements = (
+        """
+        CREATE TABLE IF NOT EXISTS sources (
+          source_id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          base_url TEXT NOT NULL,
+          source_type TEXT NOT NULL,
+          credibility_tier INTEGER NOT NULL,
+          paywall_policy TEXT NOT NULL,
+          fetch_interval TEXT NOT NULL,
+          tags_json TEXT NOT NULL,
+          enabled INTEGER NOT NULL DEFAULT 1,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS documents (
+          doc_id TEXT PRIMARY KEY,
+          source_id TEXT NOT NULL REFERENCES sources(source_id),
+          publisher TEXT NOT NULL,
+          canonical_url TEXT NOT NULL,
+          title TEXT,
+          author TEXT,
+          language TEXT,
+          doc_type TEXT,
+          published_at TEXT,
+          fetched_at TEXT NOT NULL,
+          paywall_policy TEXT NOT NULL,
+          metadata_only INTEGER NOT NULL,
+          rss_snippet TEXT,
+          body_text TEXT,
+          content_hash TEXT NOT NULL,
+          ingestion_run_id TEXT REFERENCES runs(run_id),
+          status TEXT NOT NULL DEFAULT 'active',
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          UNIQUE(canonical_url),
+          UNIQUE(content_hash)
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS chunks (
+          chunk_id TEXT PRIMARY KEY,
+          doc_id TEXT NOT NULL REFERENCES documents(doc_id) ON DELETE CASCADE,
+          chunk_index INTEGER NOT NULL,
+          text TEXT NOT NULL,
+          token_count INTEGER,
+          char_start INTEGER,
+          char_end INTEGER,
+          embedding_model TEXT,
+          embedding_vector BLOB,
+          created_at TEXT NOT NULL,
+          UNIQUE(doc_id, chunk_index)
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS evidence_packs (
+          pack_id TEXT PRIMARY KEY,
+          purpose TEXT NOT NULL,
+          query_text TEXT NOT NULL,
+          generated_at TEXT NOT NULL,
+          unique_publishers INTEGER NOT NULL,
+          tier_1_pct REAL NOT NULL,
+          tier_2_pct REAL NOT NULL,
+          tier_3_pct REAL NOT NULL,
+          tier_4_pct REAL NOT NULL,
+          max_publisher_pct REAL NOT NULL,
+          created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS evidence_pack_items (
+          pack_id TEXT NOT NULL REFERENCES evidence_packs(pack_id) ON DELETE CASCADE,
+          chunk_id TEXT NOT NULL REFERENCES chunks(chunk_id),
+          source_id TEXT NOT NULL REFERENCES sources(source_id),
+          publisher TEXT NOT NULL,
+          credibility_tier INTEGER NOT NULL,
+          retrieval_score REAL NOT NULL,
+          semantic_score REAL,
+          recency_score REAL,
+          credibility_score REAL,
+          rank_in_pack INTEGER NOT NULL,
+          PRIMARY KEY (pack_id, chunk_id)
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS syntheses (
+          synthesis_id TEXT PRIMARY KEY,
+          kind TEXT NOT NULL,
+          run_id TEXT REFERENCES runs(run_id),
+          pack_id TEXT REFERENCES evidence_packs(pack_id),
+          scheduled_for_local_date TEXT,
+          generated_at TEXT NOT NULL,
+          validation_passed INTEGER NOT NULL,
+          removed_bullets_count INTEGER NOT NULL DEFAULT 0,
+          retry_count INTEGER NOT NULL DEFAULT 0,
+          status TEXT NOT NULL,
+          created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS synthesis_bullets (
+          synthesis_id TEXT NOT NULL REFERENCES syntheses(synthesis_id) ON DELETE CASCADE,
+          section TEXT NOT NULL,
+          bullet_index INTEGER NOT NULL,
+          text TEXT NOT NULL,
+          claim_span_count INTEGER NOT NULL DEFAULT 1,
+          is_abstain INTEGER NOT NULL DEFAULT 0,
+          confidence_label TEXT,
+          PRIMARY KEY (synthesis_id, section, bullet_index)
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS citations (
+          citation_id TEXT PRIMARY KEY,
+          source_id TEXT NOT NULL REFERENCES sources(source_id),
+          publisher TEXT NOT NULL,
+          doc_id TEXT NOT NULL REFERENCES documents(doc_id),
+          chunk_id TEXT REFERENCES chunks(chunk_id),
+          url TEXT NOT NULL,
+          title TEXT,
+          published_at TEXT,
+          fetched_at TEXT,
+          quote_start INTEGER,
+          quote_end INTEGER,
+          quote_text TEXT,
+          snippet_text TEXT,
+          created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS bullet_citations (
+          synthesis_id TEXT NOT NULL,
+          section TEXT NOT NULL,
+          bullet_index INTEGER NOT NULL,
+          claim_span_index INTEGER NOT NULL DEFAULT 0,
+          citation_id TEXT NOT NULL REFERENCES citations(citation_id) ON DELETE CASCADE,
+          PRIMARY KEY (synthesis_id, section, bullet_index, claim_span_index, citation_id),
+          FOREIGN KEY (synthesis_id, section, bullet_index)
+            REFERENCES synthesis_bullets(synthesis_id, section, bullet_index)
+            ON DELETE CASCADE
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS runs (
+          run_id TEXT PRIMARY KEY,
+          run_type TEXT NOT NULL,
+          started_at TEXT NOT NULL,
+          ended_at TEXT,
+          status TEXT NOT NULL,
+          docs_fetched INTEGER NOT NULL DEFAULT 0,
+          docs_ingested INTEGER NOT NULL DEFAULT 0,
+          chunks_indexed INTEGER NOT NULL DEFAULT 0,
+          tool_calls INTEGER NOT NULL DEFAULT 0,
+          pages_fetched INTEGER NOT NULL DEFAULT 0,
+          model_input_tokens INTEGER NOT NULL DEFAULT 0,
+          model_output_tokens INTEGER NOT NULL DEFAULT 0,
+          estimated_cost_usd REAL NOT NULL DEFAULT 0,
+          error_summary TEXT,
+          created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS budget_ledger (
+          ledger_id TEXT PRIMARY KEY,
+          run_id TEXT REFERENCES runs(run_id),
+          recorded_at TEXT NOT NULL,
+          window_type TEXT NOT NULL,
+          window_start TEXT NOT NULL,
+          window_end TEXT NOT NULL,
+          cost_usd REAL NOT NULL,
+          cap_usd REAL NOT NULL,
+          exceeded INTEGER NOT NULL
+        )
+        """,
+    )
+    for statement in statements:
+        connection.execute(statement)
+
+
+def _persist_sources(connection: sqlite3.Connection, *, rows: list[dict[str, Any]]) -> None:
+    connection.executemany(
+        """
+        INSERT INTO sources (
+          source_id, name, base_url, source_type, credibility_tier, paywall_policy,
+          fetch_interval, tags_json, enabled, created_at, updated_at
+        ) VALUES (
+          :source_id, :name, :base_url, :source_type, :credibility_tier, :paywall_policy,
+          :fetch_interval, :tags_json, :enabled, :created_at, :updated_at
+        )
+        ON CONFLICT(source_id) DO UPDATE SET
+          name=excluded.name,
+          base_url=excluded.base_url,
+          source_type=excluded.source_type,
+          credibility_tier=excluded.credibility_tier,
+          paywall_policy=excluded.paywall_policy,
+          fetch_interval=excluded.fetch_interval,
+          tags_json=excluded.tags_json,
+          enabled=excluded.enabled,
+          updated_at=excluded.updated_at
+        """,
+        rows,
+    )
+
+
+def _persist_documents(connection: sqlite3.Connection, *, rows: list[dict[str, Any]]) -> None:
+    connection.executemany(
+        """
+        INSERT INTO documents (
+          doc_id, source_id, publisher, canonical_url, title, author, language, doc_type,
+          published_at, fetched_at, paywall_policy, metadata_only, rss_snippet, body_text,
+          content_hash, ingestion_run_id, status, created_at, updated_at
+        ) VALUES (
+          :doc_id, :source_id, :publisher, :canonical_url, :title, :author, :language, :doc_type,
+          :published_at, :fetched_at, :paywall_policy, :metadata_only, :rss_snippet, :body_text,
+          :content_hash, :ingestion_run_id, :status, :created_at, :updated_at
+        )
+        ON CONFLICT(doc_id) DO UPDATE SET
+          source_id=excluded.source_id,
+          publisher=excluded.publisher,
+          canonical_url=excluded.canonical_url,
+          title=excluded.title,
+          author=excluded.author,
+          language=excluded.language,
+          doc_type=excluded.doc_type,
+          published_at=excluded.published_at,
+          fetched_at=excluded.fetched_at,
+          paywall_policy=excluded.paywall_policy,
+          metadata_only=excluded.metadata_only,
+          rss_snippet=excluded.rss_snippet,
+          body_text=excluded.body_text,
+          content_hash=excluded.content_hash,
+          ingestion_run_id=excluded.ingestion_run_id,
+          status=excluded.status,
+          updated_at=excluded.updated_at
+        """,
+        rows,
+    )
+
+
+def _persist_chunks(connection: sqlite3.Connection, *, rows: list[dict[str, Any]]) -> None:
+    connection.executemany(
+        """
+        INSERT INTO chunks (
+          chunk_id, doc_id, chunk_index, text, token_count, char_start, char_end,
+          embedding_model, embedding_vector, created_at
+        ) VALUES (
+          :chunk_id, :doc_id, :chunk_index, :text, :token_count, :char_start, :char_end,
+          NULL, NULL, :created_at
+        )
+        ON CONFLICT(chunk_id) DO UPDATE SET
+          doc_id=excluded.doc_id,
+          chunk_index=excluded.chunk_index,
+          text=excluded.text,
+          token_count=excluded.token_count,
+          char_start=excluded.char_start,
+          char_end=excluded.char_end,
+          created_at=excluded.created_at
+        """,
+        rows,
+    )
+
+
+def _persist_evidence_pack(
+    connection: sqlite3.Connection,
+    *,
+    pack_id: str,
+    query_text: str,
+    generated_at_utc: str,
+    stats: Mapping[str, Any],
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO evidence_packs (
+          pack_id, purpose, query_text, generated_at, unique_publishers,
+          tier_1_pct, tier_2_pct, tier_3_pct, tier_4_pct, max_publisher_pct, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(pack_id) DO UPDATE SET
+          query_text=excluded.query_text,
+          generated_at=excluded.generated_at,
+          unique_publishers=excluded.unique_publishers,
+          tier_1_pct=excluded.tier_1_pct,
+          tier_2_pct=excluded.tier_2_pct,
+          tier_3_pct=excluded.tier_3_pct,
+          tier_4_pct=excluded.tier_4_pct,
+          max_publisher_pct=excluded.max_publisher_pct
+        """,
+        (
+            pack_id,
+            "daily_brief",
+            query_text,
+            generated_at_utc,
+            int(stats.get("unique_publishers", 0)),
+            float(stats.get("tier_1_pct", 0.0)),
+            float(stats.get("tier_2_pct", 0.0)),
+            float(stats.get("tier_3_pct", 0.0)),
+            float(stats.get("tier_4_pct", 0.0)),
+            float(stats.get("max_publisher_pct", 0.0)),
+            generated_at_utc,
+        ),
+    )
+
+
+def _persist_evidence_pack_items(
+    connection: sqlite3.Connection,
+    *,
+    pack_id: str,
+    rows: list[dict[str, Any]],
+) -> None:
+    connection.execute("DELETE FROM evidence_pack_items WHERE pack_id = ?", (pack_id,))
+    for row in rows:
+        connection.execute(
+            """
+            INSERT INTO evidence_pack_items (
+              pack_id, chunk_id, source_id, publisher, credibility_tier, retrieval_score,
+              semantic_score, recency_score, credibility_score, rank_in_pack
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                pack_id,
+                row["chunk_id"],
+                row["source_id"],
+                row["publisher"],
+                row["credibility_tier"],
+                row["retrieval_score"],
+                row.get("semantic_score"),
+                row.get("recency_score"),
+                row.get("credibility_score"),
+                row["rank_in_pack"],
+            ),
+        )
+
+
+def _persist_citations(
+    connection: sqlite3.Connection,
+    *,
+    rows: list[dict[str, Any]],
+    valid_doc_ids: set[str],
+    valid_chunk_ids: set[str],
+) -> dict[str, str]:
+    persisted_ids: dict[str, str] = {}
+    for row in rows:
+        doc_id = str(row["doc_id"])
+        chunk_id = str(row["chunk_id"])
+        if doc_id not in valid_doc_ids or chunk_id not in valid_chunk_ids:
+            continue
+        persisted_id = build_citation_id(
+            source_id=str(row["source_id"]),
+            doc_id=doc_id,
+            chunk_id=chunk_id,
+            url=str(row["url"]),
+        )
+        persisted_ids[str(row["citation_id"])] = persisted_id
+        connection.execute(
+            """
+            INSERT INTO citations (
+              citation_id, source_id, publisher, doc_id, chunk_id, url, title, published_at,
+              fetched_at, quote_start, quote_end, quote_text, snippet_text, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?)
+            ON CONFLICT(citation_id) DO UPDATE SET
+              source_id=excluded.source_id,
+              publisher=excluded.publisher,
+              doc_id=excluded.doc_id,
+              chunk_id=excluded.chunk_id,
+              url=excluded.url,
+              title=excluded.title,
+              published_at=excluded.published_at,
+              fetched_at=excluded.fetched_at,
+              quote_text=excluded.quote_text,
+              snippet_text=excluded.snippet_text
+            """,
+            (
+                persisted_id,
+                row["source_id"],
+                row["publisher"],
+                doc_id,
+                chunk_id,
+                row["url"],
+                row.get("title"),
+                row.get("published_at"),
+                row.get("fetched_at"),
+                row.get("quote_text"),
+                row.get("snippet_text"),
+                row.get("fetched_at") or row.get("published_at") or "",
+            ),
+        )
+    return persisted_ids
+
+
+def _persist_synthesis(
+    connection: sqlite3.Connection,
+    *,
+    rows: list[dict[str, Any]],
+    run_row: Mapping[str, Any],
+    report_date: str,
+    generated_at_utc: str,
+    pack_id: str,
+) -> None:
+    if not rows:
+        return
+
+    synthesis_id = str(rows[0]["synthesis_id"])
+    removed_bullets = 0
+    retry_count = 0
+    validation_passed = 1 if str(run_row["status"]) == "ok" else 0
+    connection.execute(
+        """
+        INSERT INTO syntheses (
+          synthesis_id, kind, run_id, pack_id, scheduled_for_local_date, generated_at,
+          validation_passed, removed_bullets_count, retry_count, status, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(synthesis_id) DO UPDATE SET
+          run_id=excluded.run_id,
+          pack_id=excluded.pack_id,
+          scheduled_for_local_date=excluded.scheduled_for_local_date,
+          generated_at=excluded.generated_at,
+          validation_passed=excluded.validation_passed,
+          removed_bullets_count=excluded.removed_bullets_count,
+          retry_count=excluded.retry_count,
+          status=excluded.status
+        """,
+        (
+            synthesis_id,
+            "daily_brief",
+            run_row["run_id"],
+            pack_id,
+            report_date,
+            generated_at_utc,
+            validation_passed,
+            removed_bullets,
+            retry_count,
+            run_row["status"],
+            generated_at_utc,
+        ),
+    )
+    connection.executemany(
+        """
+        INSERT INTO synthesis_bullets (
+          synthesis_id, section, bullet_index, text, claim_span_count, is_abstain, confidence_label
+        ) VALUES (
+          :synthesis_id, :section, :bullet_index, :text, :claim_span_count, :is_abstain, :confidence_label
+        )
+        ON CONFLICT(synthesis_id, section, bullet_index) DO UPDATE SET
+          text=excluded.text,
+          claim_span_count=excluded.claim_span_count,
+          is_abstain=excluded.is_abstain,
+          confidence_label=excluded.confidence_label
+        """,
+        rows,
+    )
+
+
+def _persist_bullet_citations(
+    connection: sqlite3.Connection,
+    *,
+    rows: list[dict[str, Any]],
+    citation_id_map: Mapping[str, str],
+) -> None:
+    for row in rows:
+        persisted_citation_id = citation_id_map.get(str(row["citation_id"]))
+        if persisted_citation_id is None:
+            continue
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO bullet_citations (
+              synthesis_id, section, bullet_index, claim_span_index, citation_id
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                row["synthesis_id"],
+                row["section"],
+                row["bullet_index"],
+                row["claim_span_index"],
+                persisted_citation_id,
+            ),
+        )
+
+
+def _persist_run(connection: sqlite3.Connection, *, row: dict[str, Any]) -> None:
+    connection.execute(
+        """
+        INSERT INTO runs (
+          run_id, run_type, started_at, ended_at, status, docs_fetched, docs_ingested,
+          chunks_indexed, tool_calls, pages_fetched, model_input_tokens, model_output_tokens,
+          estimated_cost_usd, error_summary, created_at
+        ) VALUES (
+          :run_id, :run_type, :started_at, :ended_at, :status, :docs_fetched, :docs_ingested,
+          :chunks_indexed, :tool_calls, :pages_fetched, :model_input_tokens, :model_output_tokens,
+          :estimated_cost_usd, :error_summary, :created_at
+        )
+        ON CONFLICT(run_id) DO UPDATE SET
+          ended_at=excluded.ended_at,
+          status=excluded.status,
+          docs_fetched=excluded.docs_fetched,
+          docs_ingested=excluded.docs_ingested,
+          chunks_indexed=excluded.chunks_indexed,
+          tool_calls=excluded.tool_calls,
+          pages_fetched=excluded.pages_fetched,
+          model_input_tokens=excluded.model_input_tokens,
+          model_output_tokens=excluded.model_output_tokens,
+          estimated_cost_usd=excluded.estimated_cost_usd,
+          error_summary=excluded.error_summary
+        """,
+        row,
+    )
+
+
+def _persist_budget_ledger(connection: sqlite3.Connection, *, rows: list[dict[str, Any]]) -> None:
+    connection.executemany(
+        """
+        INSERT INTO budget_ledger (
+          ledger_id, run_id, recorded_at, window_type, window_start, window_end, cost_usd, cap_usd, exceeded
+        ) VALUES (
+          :ledger_id, :run_id, :recorded_at, :window_type, :window_start, :window_end, :cost_usd, :cap_usd, :exceeded
+        )
+        ON CONFLICT(ledger_id) DO UPDATE SET
+          cost_usd=excluded.cost_usd,
+          cap_usd=excluded.cap_usd,
+          exceeded=excluded.exceeded
+        """,
+        rows,
+    )

--- a/tests/agent/daily_brief/test_runner.py
+++ b/tests/agent/daily_brief/test_runner.py
@@ -1,4 +1,5 @@
 import json
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -588,6 +589,79 @@ class DailyBriefRunnerTests(unittest.TestCase):
             )
             self.assertEqual(run_summary["guardrail_checks"]["budget_check"], "pass")
             self.assertIn(run_summary["guardrail_checks"]["diversity_check"], {"pass", "fail"})
+
+    def test_run_fixture_daily_brief_persists_modeled_rows_to_sqlite(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = run_fixture_daily_brief(
+                base_dir=Path(tmpdir),
+                run_id="run_fixture_sqlite",
+                generated_at_utc="2026-03-10T16:00:00Z",
+            )
+
+            runtime_db_path = Path(result["runtime_db_path"])
+            self.assertTrue(runtime_db_path.exists())
+
+            connection = sqlite3.connect(runtime_db_path)
+            try:
+                documents = connection.execute(
+                    "SELECT doc_id, canonical_url FROM documents ORDER BY canonical_url"
+                ).fetchall()
+                chunks = connection.execute(
+                    "SELECT chunk_id, doc_id, chunk_index FROM chunks ORDER BY doc_id, chunk_index"
+                ).fetchall()
+                syntheses = connection.execute(
+                    "SELECT synthesis_id, kind, status FROM syntheses"
+                ).fetchall()
+                runs = connection.execute(
+                    "SELECT run_id, run_type, status FROM runs"
+                ).fetchall()
+            finally:
+                connection.close()
+
+        self.assertGreater(len(documents), 0)
+        self.assertTrue(all(doc_id.startswith("doc_") for doc_id, _url in documents))
+        self.assertNotIn("doc_001", {doc_id for doc_id, _url in documents})
+        self.assertGreater(len(chunks), 0)
+        self.assertTrue(all(chunk_id.startswith("chunk_") for chunk_id, _doc_id, _chunk_index in chunks))
+        self.assertEqual(len(syntheses), 1)
+        self.assertTrue(syntheses[0][0].startswith("syn_"))
+        self.assertEqual(syntheses[0][1:], ("daily_brief", "ok"))
+        self.assertEqual(runs, [("run_fixture_sqlite", "daily_brief", "ok")])
+
+    def test_run_fixture_daily_brief_reuses_stable_document_ids_across_runs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            first_result = run_fixture_daily_brief(
+                base_dir=Path(tmpdir),
+                run_id="run_fixture_sqlite_first",
+                generated_at_utc="2026-03-10T16:00:00Z",
+            )
+            second_result = run_fixture_daily_brief(
+                base_dir=Path(tmpdir),
+                run_id="run_fixture_sqlite_second",
+                generated_at_utc="2026-03-11T16:00:00Z",
+            )
+
+            runtime_db_path = Path(second_result["runtime_db_path"])
+            self.assertEqual(runtime_db_path, Path(first_result["runtime_db_path"]))
+
+            connection = sqlite3.connect(runtime_db_path)
+            try:
+                document_rows = connection.execute(
+                    "SELECT doc_id, canonical_url FROM documents ORDER BY canonical_url"
+                ).fetchall()
+                document_count = connection.execute(
+                    "SELECT COUNT(*) FROM documents"
+                ).fetchone()[0]
+                run_count = connection.execute(
+                    "SELECT COUNT(*) FROM runs"
+                ).fetchone()[0]
+            finally:
+                connection.close()
+
+        self.assertEqual(document_count, len(document_rows))
+        self.assertGreater(run_count, 1)
+        self.assertTrue(all(doc_id.startswith("doc_") for doc_id, _url in document_rows))
+        self.assertEqual(len({doc_id for doc_id, _url in document_rows}), len(document_rows))
 
     def test_run_daily_brief_writes_expected_artifacts_from_live_payloads(self):
         fixture_payloads = load_active_fixture_payloads()

--- a/tests/agent/retrieval/test_chunker.py
+++ b/tests/agent/retrieval/test_chunker.py
@@ -1,5 +1,6 @@
 import unittest
 
+from apps.agent.pipeline.identifiers import build_chunk_id
 from apps.agent.retrieval.chunker import build_chunk_rows, chunk_document
 
 
@@ -78,7 +79,7 @@ class ChunkDocumentTests(unittest.TestCase):
             chunk_rows,
             [
                 {
-                    "chunk_id": "doc_003_chunk_000",
+                    "chunk_id": build_chunk_id(doc_id="doc_003", chunk_index=0),
                     "doc_id": "doc_003",
                     "chunk_index": 0,
                     "text": "Alpha beta gamma delta",
@@ -88,7 +89,7 @@ class ChunkDocumentTests(unittest.TestCase):
                     "created_at": "2026-03-10T09:05:00Z",
                 },
                 {
-                    "chunk_id": "doc_003_chunk_001",
+                    "chunk_id": build_chunk_id(doc_id="doc_003", chunk_index=1),
                     "doc_id": "doc_003",
                     "chunk_index": 1,
                     "text": "epsilon zeta eta theta",
@@ -98,7 +99,7 @@ class ChunkDocumentTests(unittest.TestCase):
                     "created_at": "2026-03-10T09:05:00Z",
                 },
                 {
-                    "chunk_id": "doc_003_chunk_002",
+                    "chunk_id": build_chunk_id(doc_id="doc_003", chunk_index=2),
                     "doc_id": "doc_003",
                     "chunk_index": 2,
                     "text": "iota.",


### PR DESCRIPTION
## Summary
- switch daily brief runtime documents and chunks onto stable prefixed IDs
- persist the executed daily brief slice into a local SQLite database aligned to the modeled schema
- keep existing JSON artifacts while exposing the SQLite runtime database path

## Testing
- `python -m unittest tests.agent.daily_brief.test_runner.DailyBriefRunnerTests.test_run_fixture_daily_brief_persists_modeled_rows_to_sqlite tests.agent.daily_brief.test_runner.DailyBriefRunnerTests.test_run_fixture_daily_brief_reuses_stable_document_ids_across_runs -v`
- `python -m unittest tests.agent.daily_brief.test_runner -v`
- `python -m unittest tests.agent.retrieval.test_chunker -v`
- `python scripts/validate_artifacts.py`
- `python scripts/validate_decision_record_schema.py`
- `python -m compileall -q apps tests scripts`
- `python -m unittest discover -s tests -t . -p test_*.py -v`

Closes #70