### PR TITLE
feat(daily-brief): add multi-bullet section synthesis

### DIFF
--- a/apps/agent/daily_brief/synthesis.py
+++ b/apps/agent/daily_brief/synthesis.py
@@ -22,6 +22,12 @@ WATCH_KEYWORDS = (
     "risk",
     "watch",
 )
+WATCH_STRICT_KEYWORDS = (
+    "ahead",
+    "monitor",
+    "next",
+    "watch",
+)
 COUNTER_KEYWORDS = (
     "against",
     "challenge",
@@ -41,6 +47,20 @@ MINORITY_KEYWORDS = (
 )
 INSUFFICIENT_EVIDENCE_TEXT = "[Insufficient evidence to produce a validated output]"
 CHANGED_SECTION_MAX_BULLETS = 3
+SECTION_BULLET_LIMITS: dict[DailyBriefOutputSection, int] = {
+    "prevailing": 3,
+    "counter": 2,
+    "minority": 2,
+    "watch": 3,
+    "changed": CHANGED_SECTION_MAX_BULLETS,
+}
+SECTION_STRICT_SCORE_FLOORS: dict[DailyBriefOutputSection, int] = {
+    "prevailing": 0,
+    "counter": 100,
+    "minority": 100,
+    "watch": 100,
+    "changed": 0,
+}
 
 
 @dataclass(frozen=True)
@@ -48,6 +68,7 @@ class _SectionCandidate:
     chunk_id: str
     item: Mapping[str, Any]
     document: Mapping[str, Any]
+    citation: Mapping[str, Any]
     citation_id: str
     scores: dict[DailyBriefOutputSection, int]
 
@@ -106,19 +127,22 @@ def build_synthesis(
     assignments = _assign_sections(candidates, retry_plan=retry_plan)
 
     for section in DAILY_BRIEF_CORE_OUTPUT_SECTIONS:
-        candidate = assignments.get(section)
-        if candidate is None:
+        section_candidates = assignments.get(section, [])
+        if not section_candidates:
             continue
-        bullet: DailyBriefBullet = {
-            "text": _build_bullet_text(
-                section=section,
-                document=candidate.document,
-                publisher=str(candidate.item["publisher"]),
-            ),
-            "citation_ids": [candidate.citation_id],
-            "confidence_label": _confidence_label(int(candidate.item["credibility_tier"])),
-        }
-        synthesis[section].append(dict(bullet))
+        for candidate in section_candidates:
+            bullet: DailyBriefBullet = {
+                "text": _build_bullet_text(
+                    section=section,
+                    document=candidate.document,
+                    citation=candidate.citation,
+                    publisher=str(candidate.item["publisher"]),
+                    strict_match=_is_strict_section_match(candidate=candidate, section=section),
+                ),
+                "citation_ids": [candidate.citation_id],
+                "confidence_label": _confidence_label(int(candidate.item["credibility_tier"])),
+            }
+            synthesis[section].append(dict(bullet))
     return synthesis
 
 
@@ -178,23 +202,25 @@ def _build_section_candidates(
     documents_by_id: Mapping[str, Mapping[str, Any]],
     citation_store: Mapping[str, Mapping[str, Any]],
 ) -> list[_SectionCandidate]:
-    citation_ids_by_chunk_id = {
-        str(entry["chunk_id"]): str(citation_id)
+    citations_by_chunk_id = {
+        str(entry["chunk_id"]): (str(citation_id), entry)
         for citation_id, entry in citation_store.items()
         if isinstance(entry, Mapping) and entry.get("chunk_id") is not None
     }
     candidates: list[_SectionCandidate] = []
     for item in _sorted_evidence_items(evidence_items):
         chunk_id = str(item["chunk_id"])
-        citation_id = citation_ids_by_chunk_id.get(chunk_id)
-        if citation_id is None:
+        citation_payload = citations_by_chunk_id.get(chunk_id)
+        if citation_payload is None:
             continue
+        citation_id, citation = citation_payload
         document = documents_by_id[str(item["doc_id"])]
         candidates.append(
             _SectionCandidate(
                 chunk_id=chunk_id,
                 item=item,
                 document=document,
+                citation=citation,
                 citation_id=citation_id,
                 scores=_section_scores(item=item, document=document),
             )
@@ -206,37 +232,91 @@ def _assign_sections(
     candidates: Iterable[_SectionCandidate],
     *,
     retry_plan: SynthesisRetryPlan | None = None,
-) -> dict[DailyBriefOutputSection, _SectionCandidate]:
+) -> dict[DailyBriefOutputSection, list[_SectionCandidate]]:
     ordered_candidates = list(candidates)
     candidates_by_chunk_id = {candidate.chunk_id: candidate for candidate in ordered_candidates}
-    best_assignment: dict[DailyBriefOutputSection, _SectionCandidate] = {}
-    best_key: tuple[int, tuple[tuple[int, int, str], ...]] | None = None
     blocked_chunk_ids = frozenset()
-    seeded_assignment: dict[DailyBriefOutputSection, _SectionCandidate] = {}
-    used_chunk_ids = frozenset()
+    assignments: dict[DailyBriefOutputSection, list[_SectionCandidate]] = {}
+    used_chunk_ids: set[str] = set()
     search_order: tuple[DailyBriefOutputSection, ...] = ("watch", "counter", "minority", "prevailing")
 
     if retry_plan is not None:
         blocked_chunk_ids = frozenset(retry_plan.blocked_chunk_ids)
-        used_chunk_ids_mutable: set[str] = set()
         for section, chunk_id in retry_plan.pinned_chunk_ids_by_section.items():
             candidate = candidates_by_chunk_id.get(chunk_id)
             if candidate is None or candidate.chunk_id in blocked_chunk_ids:
                 continue
-            seeded_assignment[section] = candidate
-            used_chunk_ids_mutable.add(candidate.chunk_id)
-        used_chunk_ids = frozenset(used_chunk_ids_mutable)
+            assignments.setdefault(section, []).append(candidate)
+            used_chunk_ids.add(candidate.chunk_id)
         prioritized_targets = tuple(
             section
             for section in retry_plan.target_sections
-            if section not in seeded_assignment
+            if section not in assignments
         )
         remaining_sections = tuple(
             section
             for section in search_order
-            if section not in seeded_assignment and section not in prioritized_targets
+            if section not in assignments and section not in prioritized_targets
         )
         search_order = prioritized_targets + remaining_sections
+
+    initial_assignment = _best_single_assignment(
+        ordered_candidates=ordered_candidates,
+        search_order=search_order,
+        seeded_assignment={section: items[0] for section, items in assignments.items()},
+        blocked_chunk_ids=blocked_chunk_ids,
+    )
+    assignments = {section: [candidate] for section, candidate in initial_assignment.items()}
+    used_chunk_ids = {candidate.chunk_id for candidate in initial_assignment.values()}
+
+    if retry_plan is not None:
+        return assignments
+
+    for section in search_order:
+        section_candidates = assignments.setdefault(section, [])
+        if section_candidates and not _has_validation_safe_lead(section_candidates[0]):
+            continue
+        section_limit = SECTION_BULLET_LIMITS[section]
+        if retry_plan is not None:
+            if section in retry_plan.pinned_chunk_ids_by_section:
+                section_limit = len(section_candidates)
+            elif section in retry_plan.target_sections:
+                section_limit = 1
+        ranked_candidates = sorted(
+            ordered_candidates,
+            key=lambda candidate: _section_sort_key(section=section, candidate=candidate),
+            reverse=True,
+        )
+        for candidate in ranked_candidates:
+            if len(section_candidates) >= section_limit:
+                break
+            if candidate.chunk_id in used_chunk_ids or candidate.chunk_id in blocked_chunk_ids:
+                continue
+            if section != "prevailing" and not _is_strict_section_match(candidate=candidate, section=section):
+                continue
+            section_candidates.append(candidate)
+            used_chunk_ids.add(candidate.chunk_id)
+        if section != "prevailing" and not section_candidates:
+            for candidate in ranked_candidates:
+                if candidate.chunk_id in used_chunk_ids or candidate.chunk_id in blocked_chunk_ids:
+                    continue
+                section_candidates.append(candidate)
+                used_chunk_ids.add(candidate.chunk_id)
+                break
+
+    return {section: items for section, items in assignments.items() if items}
+
+
+def _best_single_assignment(
+    *,
+    ordered_candidates: list[_SectionCandidate],
+    search_order: tuple[DailyBriefOutputSection, ...],
+    seeded_assignment: Mapping[DailyBriefOutputSection, _SectionCandidate],
+    blocked_chunk_ids: frozenset[str],
+) -> dict[DailyBriefOutputSection, _SectionCandidate]:
+    best_assignment: dict[DailyBriefOutputSection, _SectionCandidate] = {}
+    best_key: tuple[int, tuple[tuple[int, int, str], ...]] | None = None
+    seeded_chunk_ids = frozenset(candidate.chunk_id for candidate in seeded_assignment.values())
 
     def search(
         section_index: int,
@@ -252,6 +332,10 @@ def _assign_sections(
             return
 
         section = search_order[section_index]
+        if section in seeded_assignment:
+            search(section_index + 1, used_chunk_ids, assignment)
+            return
+
         assigned_any = False
         for candidate in ordered_candidates:
             if candidate.chunk_id in used_chunk_ids or candidate.chunk_id in blocked_chunk_ids:
@@ -268,7 +352,7 @@ def _assign_sections(
         if not assigned_any:
             search(section_index + 1, used_chunk_ids, assignment)
 
-    search(0, used_chunk_ids, dict(seeded_assignment))
+    search(0, seeded_chunk_ids, dict(seeded_assignment))
     return best_assignment
 
 
@@ -338,15 +422,103 @@ def _recency_bonus(document: Mapping[str, Any]) -> int:
     minutes = int(hhmmss[2:4])
     return hours * 2 + minutes // 15
 
+def _is_strict_section_match(
+    *,
+    candidate: _SectionCandidate,
+    section: DailyBriefOutputSection,
+) -> bool:
+    if section == "prevailing":
+        return True
+    keyword_sets: dict[DailyBriefOutputSection, tuple[str, ...]] = {
+        "counter": COUNTER_KEYWORDS,
+        "minority": MINORITY_KEYWORDS,
+        "watch": WATCH_STRICT_KEYWORDS,
+        "prevailing": (),
+        "changed": (),
+    }
+    text = _normalized_document_text(candidate.document)
+    keywords = keyword_sets[section]
+    if keywords:
+        return any(keyword in text for keyword in keywords)
+    return candidate.scores[section] >= SECTION_STRICT_SCORE_FLOORS[section]
 
-def _build_bullet_text(*, section: str, document: Mapping[str, Any], publisher: str) -> str:
-    title = str(document.get("title") or document.get("rss_snippet") or publisher).strip()
-    normalized_title = title.rstrip(".")
+
+def _section_sort_key(
+    *,
+    section: DailyBriefOutputSection,
+    candidate: _SectionCandidate,
+) -> tuple[int, int, int, str]:
+    credibility_priority = 0
     if section == "watch":
-        if normalized_title.lower().startswith("watch "):
-            return f"{normalized_title}."
-        return f"Watch {normalized_title.lower()}."
-    return f"{normalized_title} ({publisher})."
+        credibility_priority = max(0, 5 - int(candidate.item.get("credibility_tier", 4))) * 10
+    return (
+        credibility_priority,
+        candidate.scores[section],
+        -int(candidate.item.get("rank_in_pack", 9999)),
+        candidate.chunk_id,
+    )
+
+
+def _has_validation_safe_lead(candidate: _SectionCandidate) -> bool:
+    return bool(candidate.citation.get("url")) and bool(candidate.citation.get("published_at"))
+
+
+def _build_bullet_text(
+    *,
+    section: str,
+    document: Mapping[str, Any],
+    citation: Mapping[str, Any],
+    publisher: str,
+    strict_match: bool,
+) -> str:
+    del publisher
+    if section in {"counter", "watch"}:
+        preferred_text = document.get("title")
+    elif strict_match:
+        preferred_text = (
+            citation.get("quote_text")
+            or citation.get("snippet_text")
+            or document.get("rss_snippet")
+        )
+    else:
+        preferred_text = document.get("title")
+    sentence = _normalized_sentence(
+        str(
+            preferred_text
+            or citation.get("snippet_text")
+            or citation.get("quote_text")
+            or document.get("title")
+            or ""
+        )
+    )
+    if section == "counter":
+        return f"Counterpoint: {sentence}"
+    if section == "minority":
+        return f"Minority view: {sentence}"
+    if section == "watch":
+        lowered = sentence[:-1].strip()
+        lowered = lowered[6:] if lowered.lower().startswith("watch ") else lowered
+        lowered = lowered[8:] if lowered.lower().startswith("monitor ") else lowered
+        lowered = _normalize_watch_phrase(lowered)
+        return f"Watch: {lowered}."
+    return sentence
+
+
+def _normalized_sentence(value: str) -> str:
+    sentence = " ".join(part for part in value.strip().split())
+    if not sentence:
+        return "Evidence was available but could not be summarized."
+    return f"{sentence.rstrip('.')}."
+
+
+def _normalize_watch_phrase(value: str) -> str:
+    phrase = value.strip()
+    if not phrase:
+        return phrase
+    first_token = phrase.split(" ", 1)[0]
+    if first_token.isupper() and len(first_token) <= 5:
+        return phrase
+    return phrase[:1].lower() + phrase[1:]
 
 
 def _first_bullet(raw_bullets: Any) -> Mapping[str, Any] | None:

--- a/tests/agent/daily_brief/test_synthesis.py
+++ b/tests/agent/daily_brief/test_synthesis.py
@@ -9,6 +9,278 @@ from apps.agent.daily_brief.synthesis import (
 
 
 class DailyBriefSynthesisTests(unittest.TestCase):
+    def test_build_synthesis_emits_multiple_bullets_per_section_when_evidence_supports_it(self):
+        evidence_items = [
+            {
+                "chunk_id": "doc_prevailing_a_chunk_000",
+                "doc_id": "doc_prevailing_a",
+                "source_id": "fed_press_releases",
+                "publisher": "Federal Reserve",
+                "credibility_tier": 1,
+                "rank_in_pack": 1,
+            },
+            {
+                "chunk_id": "doc_prevailing_b_chunk_000",
+                "doc_id": "doc_prevailing_b",
+                "source_id": "us_bls_news",
+                "publisher": "BLS",
+                "credibility_tier": 1,
+                "rank_in_pack": 2,
+            },
+            {
+                "chunk_id": "doc_counter_a_chunk_000",
+                "doc_id": "doc_counter_a",
+                "source_id": "reuters_business",
+                "publisher": "Reuters",
+                "credibility_tier": 2,
+                "rank_in_pack": 3,
+            },
+            {
+                "chunk_id": "doc_counter_b_chunk_000",
+                "doc_id": "doc_counter_b",
+                "source_id": "wsj_markets",
+                "publisher": "Wall Street Journal",
+                "credibility_tier": 2,
+                "rank_in_pack": 4,
+            },
+            {
+                "chunk_id": "doc_minority_a_chunk_000",
+                "doc_id": "doc_minority_a",
+                "source_id": "macro_letter_a",
+                "publisher": "Macro Letter",
+                "credibility_tier": 3,
+                "rank_in_pack": 5,
+            },
+            {
+                "chunk_id": "doc_minority_b_chunk_000",
+                "doc_id": "doc_minority_b",
+                "source_id": "macro_letter_b",
+                "publisher": "Strategy Weekly",
+                "credibility_tier": 3,
+                "rank_in_pack": 6,
+            },
+            {
+                "chunk_id": "doc_watch_a_chunk_000",
+                "doc_id": "doc_watch_a",
+                "source_id": "cpi_preview",
+                "publisher": "CPI Preview Desk",
+                "credibility_tier": 1,
+                "rank_in_pack": 7,
+            },
+            {
+                "chunk_id": "doc_watch_b_chunk_000",
+                "doc_id": "doc_watch_b",
+                "source_id": "jobs_preview",
+                "publisher": "Jobs Preview Desk",
+                "credibility_tier": 1,
+                "rank_in_pack": 8,
+            },
+        ]
+        documents_by_id = {
+            "doc_prevailing_a": {
+                "canonical_url": "https://example.test/prevailing-a",
+                "title": "Fed keeps policy steady",
+                "published_at": "2026-03-10T14:00:00Z",
+                "fetched_at": "2026-03-10T14:05:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Fed officials kept policy steady while inflation progress remained uneven.",
+            },
+            "doc_prevailing_b": {
+                "canonical_url": "https://example.test/prevailing-b",
+                "title": "Payroll growth remains resilient",
+                "published_at": "2026-03-10T13:30:00Z",
+                "fetched_at": "2026-03-10T13:35:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Payroll growth remained resilient even as hiring cooled from January's pace.",
+            },
+            "doc_counter_a": {
+                "canonical_url": "https://example.test/counter-a",
+                "title": "Bond desks push back on soft landing",
+                "published_at": "2026-03-10T12:45:00Z",
+                "fetched_at": "2026-03-10T12:50:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Bond desks pushed back on the soft-landing consensus as growth indicators cooled.",
+            },
+            "doc_counter_b": {
+                "canonical_url": "https://example.test/counter-b",
+                "title": "Investors question the growth rebound",
+                "published_at": "2026-03-10T12:15:00Z",
+                "fetched_at": "2026-03-10T12:20:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Investors questioned the expected growth rebound after weaker survey data.",
+            },
+            "doc_minority_a": {
+                "canonical_url": "https://example.test/minority-a",
+                "title": "Minority view sees reacceleration risk",
+                "published_at": "2026-03-10T11:45:00Z",
+                "fetched_at": "2026-03-10T11:50:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "A minority of strategists still sees inflation reacceleration risk this spring.",
+            },
+            "doc_minority_b": {
+                "canonical_url": "https://example.test/minority-b",
+                "title": "Contrarian desks expect a sharper slowdown",
+                "published_at": "2026-03-10T11:15:00Z",
+                "fetched_at": "2026-03-10T11:20:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Contrarian desks expect a sharper slowdown than consensus forecasts imply.",
+            },
+            "doc_watch_a": {
+                "canonical_url": "https://example.test/watch-a",
+                "title": "Watch CPI shelter prints",
+                "published_at": "2026-03-10T10:45:00Z",
+                "fetched_at": "2026-03-10T10:50:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Watch the next CPI shelter prints for confirmation that disinflation is broadening.",
+            },
+            "doc_watch_b": {
+                "canonical_url": "https://example.test/watch-b",
+                "title": "Monitor payroll revisions",
+                "published_at": "2026-03-10T10:15:00Z",
+                "fetched_at": "2026-03-10T10:20:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Monitor payroll revisions next week for confirmation that labor demand is cooling.",
+            },
+        }
+        chunks_by_id = {
+            "doc_prevailing_a_chunk_000": {"text": "Fed officials kept policy steady while inflation progress remained uneven."},
+            "doc_prevailing_b_chunk_000": {"text": "Payroll growth remained resilient even as hiring cooled from January's pace."},
+            "doc_counter_a_chunk_000": {"text": "Bond desks pushed back on the soft-landing consensus as growth indicators cooled."},
+            "doc_counter_b_chunk_000": {"text": "Investors questioned the expected growth rebound after weaker survey data."},
+            "doc_minority_a_chunk_000": {"text": "A minority of strategists still sees inflation reacceleration risk this spring."},
+            "doc_minority_b_chunk_000": {"text": "Contrarian desks expect a sharper slowdown than consensus forecasts imply."},
+            "doc_watch_a_chunk_000": {"text": "Watch the next CPI shelter prints for confirmation that disinflation is broadening."},
+            "doc_watch_b_chunk_000": {"text": "Monitor payroll revisions next week for confirmation that labor demand is cooling."},
+        }
+
+        citations = build_citation_store(
+            evidence_items=evidence_items,
+            documents_by_id=documents_by_id,
+            chunks_by_id=chunks_by_id,
+        )
+        synthesis = build_synthesis(
+            evidence_items=evidence_items,
+            documents_by_id=documents_by_id,
+            citation_store=citations,
+        )
+
+        self.assertEqual(len(synthesis["prevailing"]), 2)
+        self.assertEqual(len(synthesis["counter"]), 2)
+        self.assertEqual(len(synthesis["minority"]), 2)
+        self.assertEqual(len(synthesis["watch"]), 2)
+        self.assertEqual(
+            synthesis["prevailing"][0]["citation_ids"] + synthesis["prevailing"][1]["citation_ids"],
+            ["cite_001", "cite_002"],
+        )
+        self.assertEqual(
+            synthesis["counter"][0]["citation_ids"] + synthesis["counter"][1]["citation_ids"],
+            ["cite_003", "cite_004"],
+        )
+
+    def test_build_synthesis_uses_section_specific_bullet_language(self):
+        evidence_items = [
+            {
+                "chunk_id": "doc_prevailing_chunk_000",
+                "doc_id": "doc_prevailing",
+                "source_id": "fed_press_releases",
+                "publisher": "Federal Reserve",
+                "credibility_tier": 1,
+                "rank_in_pack": 1,
+            },
+            {
+                "chunk_id": "doc_counter_chunk_000",
+                "doc_id": "doc_counter",
+                "source_id": "reuters_business",
+                "publisher": "Reuters",
+                "credibility_tier": 2,
+                "rank_in_pack": 2,
+            },
+            {
+                "chunk_id": "doc_minority_chunk_000",
+                "doc_id": "doc_minority",
+                "source_id": "macro_letter",
+                "publisher": "Macro Letter",
+                "credibility_tier": 3,
+                "rank_in_pack": 3,
+            },
+            {
+                "chunk_id": "doc_watch_chunk_000",
+                "doc_id": "doc_watch",
+                "source_id": "bls_preview",
+                "publisher": "BLS Preview Desk",
+                "credibility_tier": 1,
+                "rank_in_pack": 4,
+            },
+        ]
+        documents_by_id = {
+            "doc_prevailing": {
+                "canonical_url": "https://example.test/prevailing",
+                "title": "Fed keeps policy steady",
+                "published_at": "2026-03-10T14:00:00Z",
+                "fetched_at": "2026-03-10T14:05:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Fed officials kept policy steady while inflation progress remained uneven.",
+            },
+            "doc_counter": {
+                "canonical_url": "https://example.test/counter",
+                "title": "Investors question the growth rebound",
+                "published_at": "2026-03-10T13:00:00Z",
+                "fetched_at": "2026-03-10T13:05:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Investors questioned the expected growth rebound after weaker survey data.",
+            },
+            "doc_minority": {
+                "canonical_url": "https://example.test/minority",
+                "title": "Minority view sees reacceleration risk",
+                "published_at": "2026-03-10T12:00:00Z",
+                "fetched_at": "2026-03-10T12:05:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "A minority of strategists still sees inflation reacceleration risk this spring.",
+            },
+            "doc_watch": {
+                "canonical_url": "https://example.test/watch",
+                "title": "Watch CPI shelter prints",
+                "published_at": "2026-03-10T11:00:00Z",
+                "fetched_at": "2026-03-10T11:05:00Z",
+                "paywall_policy": "full",
+                "rss_snippet": "Watch the next CPI shelter prints for confirmation that disinflation is broadening.",
+            },
+        }
+        chunks_by_id = {
+            "doc_prevailing_chunk_000": {"text": "Fed officials kept policy steady while inflation progress remained uneven."},
+            "doc_counter_chunk_000": {"text": "Investors questioned the expected growth rebound after weaker survey data."},
+            "doc_minority_chunk_000": {"text": "A minority of strategists still sees inflation reacceleration risk this spring."},
+            "doc_watch_chunk_000": {"text": "Watch the next CPI shelter prints for confirmation that disinflation is broadening."},
+        }
+
+        citations = build_citation_store(
+            evidence_items=evidence_items,
+            documents_by_id=documents_by_id,
+            chunks_by_id=chunks_by_id,
+        )
+        synthesis = build_synthesis(
+            evidence_items=evidence_items,
+            documents_by_id=documents_by_id,
+            citation_store=citations,
+        )
+
+        self.assertEqual(
+            synthesis["prevailing"][0]["text"],
+            "Fed officials kept policy steady while inflation progress remained uneven.",
+        )
+        self.assertEqual(
+            synthesis["counter"][0]["text"],
+            "Counterpoint: Investors question the growth rebound.",
+        )
+        self.assertEqual(
+            synthesis["minority"][0]["text"],
+            "Minority view: A minority of strategists still sees inflation reacceleration risk this spring.",
+        )
+        self.assertEqual(
+            synthesis["watch"][0]["text"],
+            "Watch: CPI shelter prints.",
+        )
+
     def test_build_changed_section_uses_current_cited_bullets_when_sections_shift(self):
         changed = build_changed_section(
             current_synthesis={


### PR DESCRIPTION
## Summary
- expand daily brief synthesis to emit multiple bullets per section when evidence supports it
- keep retry mode single-replacement for validator safety
- make section language more specific than title-only output

## Testing
- `python -m unittest tests.agent.daily_brief.test_synthesis tests.agent.daily_brief.test_runner tests.agent.delivery.test_html_report -v`
- `python -m compileall -q apps tests scripts`
- `python -m unittest discover -s tests -t . -p test_*.py -v`

Closes #68