### PR TITLE
feat: add issue and claim contracts for daily brief redesign

### DIFF
--- a/apps/agent/daily_brief/model_interfaces.py
+++ b/apps/agent/daily_brief/model_interfaces.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, TypedDict
+
+from apps.agent.pipeline.types import IssueMap, StructuredClaim
+
+
+class IssuePlannerInput(TypedDict):
+    run_id: str
+    generated_at_utc: str
+    evidence_pack: list[dict[str, Any]]
+    prior_brief_context: dict[str, Any] | None
+
+
+class ClaimComposerInput(TypedDict):
+    run_id: str
+    generated_at_utc: str
+    issue_map: list[IssueMap]
+    citation_store: dict[str, dict[str, Any]]
+    prior_brief_context: dict[str, Any] | None
+
+
+class IssuePlannerProvider(Protocol):
+    def plan_issues(self, *, brief_input: IssuePlannerInput) -> list[IssueMap]:
+        ...
+
+
+class ClaimComposerProvider(Protocol):
+    def compose_claims(self, *, brief_input: ClaimComposerInput) -> list[StructuredClaim]:
+        ...

--- a/apps/agent/pipeline/types.py
+++ b/apps/agent/pipeline/types.py
@@ -22,6 +22,8 @@ class RunStatus(str, Enum):
 
 
 DailyBriefOutputSection = Literal["prevailing", "counter", "minority", "watch", "changed"]
+DailyBriefClaimKind = Literal["prevailing", "counter", "minority", "watch"]
+DailyBriefNoveltyLabel = Literal["new", "continued", "reframed", "weakened", "strengthened", "reversed", "unknown"]
 CitationValidationStatus = Literal["ok", "partial", "retry"]
 FinalSynthesisStatus = Literal["ok", "partial", "abstained"]
 
@@ -165,6 +167,43 @@ class DailyBriefBullet(TypedDict, total=False):
 class DailyBriefMeta(TypedDict):
     status: str
     reason: str
+
+
+class IssueMap(TypedDict):
+    issue_id: str
+    issue_question: str
+    thesis_hint: str
+    supporting_evidence_ids: list[str]
+    opposing_evidence_ids: list[str]
+    minority_evidence_ids: list[str]
+    watch_evidence_ids: list[str]
+
+
+class StructuredClaim(TypedDict):
+    claim_id: str
+    issue_id: str
+    claim_kind: DailyBriefClaimKind
+    claim_text: str
+    supporting_citation_ids: list[str]
+    opposing_citation_ids: list[str]
+    confidence: str
+    novelty_vs_prior_brief: DailyBriefNoveltyLabel
+    why_it_matters: str
+
+
+class DailyBriefIssue(TypedDict):
+    issue_id: str
+    issue_question: str
+    summary: str
+    prevailing: list[StructuredClaim]
+    counter: list[StructuredClaim]
+    minority: list[StructuredClaim]
+    watch: list[StructuredClaim]
+
+
+class DailyBriefSynthesisV2(TypedDict):
+    issues: list[DailyBriefIssue]
+    meta: DailyBriefMeta
 
 
 class DailyBriefSynthesis(TypedDict, total=False):

--- a/tests/agent/daily_brief/test_model_interfaces.py
+++ b/tests/agent/daily_brief/test_model_interfaces.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import inspect
+import unittest
+from typing import get_type_hints
+
+from apps.agent.daily_brief.model_interfaces import (
+    ClaimComposerInput,
+    ClaimComposerProvider,
+    IssuePlannerInput,
+    IssuePlannerProvider,
+)
+from apps.agent.pipeline.types import IssueMap, StructuredClaim
+
+
+class DailyBriefModelInterfaceTests(unittest.TestCase):
+    def test_issue_planner_provider_is_task_specific(self) -> None:
+        signature = inspect.signature(IssuePlannerProvider.plan_issues)
+        self.assertIn("brief_input", signature.parameters)
+        hints = get_type_hints(IssuePlannerProvider.plan_issues)
+        self.assertEqual(hints["brief_input"], IssuePlannerInput)
+        self.assertEqual(hints["return"], list[IssueMap])
+
+    def test_claim_composer_provider_is_task_specific(self) -> None:
+        signature = inspect.signature(ClaimComposerProvider.compose_claims)
+        self.assertIn("brief_input", signature.parameters)
+        hints = get_type_hints(ClaimComposerProvider.compose_claims)
+        self.assertEqual(hints["brief_input"], ClaimComposerInput)
+        self.assertEqual(hints["return"], list[StructuredClaim])
+
+    def test_interface_inputs_use_structured_context(self) -> None:
+        self.assertEqual(
+            set(IssuePlannerInput.__annotations__),
+            {"run_id", "generated_at_utc", "evidence_pack", "prior_brief_context"},
+        )
+        self.assertEqual(
+            set(ClaimComposerInput.__annotations__),
+            {
+                "run_id",
+                "generated_at_utc",
+                "issue_map",
+                "citation_store",
+                "prior_brief_context",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/pipeline/test_daily_brief_types.py
+++ b/tests/agent/pipeline/test_daily_brief_types.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import unittest
+from typing import get_args
+
+from apps.agent.pipeline.types import (
+    DailyBriefClaimKind,
+    DailyBriefIssue,
+    DailyBriefNoveltyLabel,
+    DailyBriefSynthesisV2,
+    IssueMap,
+    StructuredClaim,
+)
+
+
+class DailyBriefTypeContractsTests(unittest.TestCase):
+    def test_issue_map_contract_exposes_required_fields(self) -> None:
+        self.assertEqual(
+            set(IssueMap.__annotations__),
+            {
+                "issue_id",
+                "issue_question",
+                "thesis_hint",
+                "supporting_evidence_ids",
+                "opposing_evidence_ids",
+                "minority_evidence_ids",
+                "watch_evidence_ids",
+            },
+        )
+
+    def test_structured_claim_contract_exposes_required_fields(self) -> None:
+        self.assertEqual(
+            set(StructuredClaim.__annotations__),
+            {
+                "claim_id",
+                "issue_id",
+                "claim_kind",
+                "claim_text",
+                "supporting_citation_ids",
+                "opposing_citation_ids",
+                "confidence",
+                "novelty_vs_prior_brief",
+                "why_it_matters",
+            },
+        )
+
+    def test_issue_centered_synthesis_groups_claims_by_issue(self) -> None:
+        self.assertEqual(
+            set(DailyBriefIssue.__annotations__),
+            {
+                "issue_id",
+                "issue_question",
+                "summary",
+                "prevailing",
+                "counter",
+                "minority",
+                "watch",
+            },
+        )
+        self.assertEqual(set(DailyBriefSynthesisV2.__annotations__), {"issues", "meta"})
+
+    def test_literal_vocabularies_match_redesign(self) -> None:
+        self.assertEqual(
+            set(get_args(DailyBriefClaimKind)),
+            {"prevailing", "counter", "minority", "watch"},
+        )
+        self.assertEqual(
+            set(get_args(DailyBriefNoveltyLabel)),
+            {"new", "continued", "reframed", "weakened", "strengthened", "reversed", "unknown"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add structured issue and claim contracts for issue-centered daily briefs
- add provider-agnostic task-specific interfaces for issue planning and claim composition
- add focused tests for the new contracts and interfaces

## Linked Issues
- Closes #96

## Validation
- python -m unittest tests.agent.pipeline.test_daily_brief_types -v
- python -m unittest tests.agent.daily_brief.test_model_interfaces -v
- python -m ruff check apps/agent/pipeline/types.py apps/agent/daily_brief/model_interfaces.py tests/agent/pipeline/test_daily_brief_types.py tests/agent/daily_brief/test_model_interfaces.py
- python -m mypy apps/agent/pipeline/types.py apps/agent/daily_brief/model_interfaces.py
