### PR TITLE
feat: orchestrate issue planner and claim composer in runner

### DIFF
--- a/apps/agent/daily_brief/openai_claim_composer.py
+++ b/apps/agent/daily_brief/openai_claim_composer.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any, cast
+
+from apps.agent.daily_brief.model_interfaces import ClaimComposerInput, ClaimComposerProvider
+from apps.agent.pipeline.types import StructuredClaim
+
+VALID_CLAIM_KINDS = {"prevailing", "counter", "minority", "watch"}
+VALID_NOVELTY_LABELS = {
+    "new",
+    "continued",
+    "reframed",
+    "weakened",
+    "strengthened",
+    "reversed",
+    "unknown",
+}
+
+
+class OpenAIClaimComposer(ClaimComposerProvider):
+    def __init__(self, *, response_loader: Callable[[ClaimComposerInput], str | list[dict[str, Any]]] | None) -> None:
+        self._response_loader = response_loader
+
+    def compose_claims(self, *, brief_input: ClaimComposerInput) -> list[StructuredClaim]:
+        if self._response_loader is None:
+            raise ValueError("OpenAIClaimComposer requires a response_loader for this local runtime slice.")
+        payload = self._response_loader(brief_input)
+        if isinstance(payload, str):
+            parsed = json.loads(payload)
+        else:
+            parsed = payload
+        if not isinstance(parsed, list):
+            raise ValueError("Claim composer output must be a list.")
+
+        claims: list[StructuredClaim] = []
+        required_fields = set(StructuredClaim.__annotations__)
+        for item in parsed:
+            if not isinstance(item, dict) or set(item) != required_fields:
+                raise ValueError("Malformed claim composer output.")
+            claims.append(_validate_structured_claim(item))
+        return claims
+
+
+def _validate_structured_claim(item: dict[str, Any]) -> StructuredClaim:
+    if not all(
+        isinstance(item.get(field), str) and item[field].strip()
+        for field in ("claim_id", "issue_id", "claim_text", "confidence", "why_it_matters")
+    ):
+        raise ValueError("Malformed claim composer output.")
+    if item.get("claim_kind") not in VALID_CLAIM_KINDS:
+        raise ValueError("Malformed claim composer output.")
+    if item.get("novelty_vs_prior_brief") not in VALID_NOVELTY_LABELS:
+        raise ValueError("Malformed claim composer output.")
+    for field in ("supporting_citation_ids", "opposing_citation_ids"):
+        values = item.get(field)
+        if not isinstance(values, list) or not all(isinstance(value, str) and value for value in values):
+            raise ValueError("Malformed claim composer output.")
+    return cast(StructuredClaim, item)

--- a/apps/agent/daily_brief/openai_issue_planner.py
+++ b/apps/agent/daily_brief/openai_issue_planner.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any, cast
+
+from apps.agent.daily_brief.model_interfaces import IssuePlannerInput, IssuePlannerProvider
+from apps.agent.pipeline.types import IssueMap
+
+
+class OpenAIIssuePlanner(IssuePlannerProvider):
+    def __init__(self, *, response_loader: Callable[[IssuePlannerInput], str | list[dict[str, Any]]] | None) -> None:
+        self._response_loader = response_loader
+
+    def plan_issues(self, *, brief_input: IssuePlannerInput) -> list[IssueMap]:
+        if self._response_loader is None:
+            raise ValueError("OpenAIIssuePlanner requires a response_loader for this local runtime slice.")
+        payload = self._response_loader(brief_input)
+        if isinstance(payload, str):
+            parsed = json.loads(payload)
+        else:
+            parsed = payload
+        if not isinstance(parsed, list):
+            raise ValueError("Issue planner output must be a list.")
+
+        issues: list[IssueMap] = []
+        required_fields = set(IssueMap.__annotations__)
+        for item in parsed:
+            if not isinstance(item, dict) or set(item) != required_fields:
+                raise ValueError("Malformed issue planner output.")
+            issues.append(_validate_issue_map(item))
+        return issues
+
+
+def _validate_issue_map(item: dict[str, Any]) -> IssueMap:
+    list_fields = (
+        "supporting_evidence_ids",
+        "opposing_evidence_ids",
+        "minority_evidence_ids",
+        "watch_evidence_ids",
+    )
+    if not all(
+        isinstance(item.get(field), str) and item[field].strip()
+        for field in ("issue_id", "issue_question", "thesis_hint")
+    ):
+        raise ValueError("Malformed issue planner output.")
+    for field in list_fields:
+        values = item.get(field)
+        if not isinstance(values, list) or not all(isinstance(value, str) and value for value in values):
+            raise ValueError("Malformed issue planner output.")
+    return cast(IssueMap, item)

--- a/apps/agent/daily_brief/prior_brief_context.py
+++ b/apps/agent/daily_brief/prior_brief_context.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def build_prior_brief_context(
+    *,
+    previous_synthesis: Mapping[str, Any] | None,
+    previous_generated_at_utc: str | None,
+) -> dict[str, Any] | None:
+    if not isinstance(previous_synthesis, Mapping):
+        return None
+
+    claim_summaries: list[str] = []
+    citation_ids: list[str] = []
+    for section in ("prevailing", "counter", "minority", "watch"):
+        bullets = previous_synthesis.get(section, [])
+        if not isinstance(bullets, list):
+            continue
+        for bullet in bullets[:1]:
+            if not isinstance(bullet, Mapping):
+                continue
+            text = str(bullet.get("text", "")).strip()
+            if text:
+                claim_summaries.append(text)
+            current_citation_ids = bullet.get("citation_ids", [])
+            if isinstance(current_citation_ids, list):
+                for citation_id in current_citation_ids:
+                    citation_ids.append(str(citation_id))
+
+    return {
+        "previous_generated_at_utc": previous_generated_at_utc,
+        "claim_summaries": claim_summaries,
+        "citation_ids": citation_ids,
+    }

--- a/apps/agent/daily_brief/runner.py
+++ b/apps/agent/daily_brief/runner.py
@@ -9,11 +9,19 @@ from pathlib import Path
 from smtplib import SMTP
 from typing import Any, cast
 
+from apps.agent.daily_brief.model_interfaces import (
+    ClaimComposerInput,
+    ClaimComposerProvider,
+    IssuePlannerInput,
+    IssuePlannerProvider,
+)
+from apps.agent.daily_brief.prior_brief_context import build_prior_brief_context
 from apps.agent.daily_brief.synthesis import (
     SynthesisRetryPlan,
     build_changed_section,
     build_citation_store,
     build_synthesis,
+    build_synthesis_from_structured_claims,
 )
 from apps.agent.delivery.email_sender import EmailDeliveryConfig, send_daily_brief_email
 from apps.agent.delivery.html_report import render_daily_brief_html
@@ -34,6 +42,7 @@ from apps.agent.pipeline.stage10_decision_record import build_and_persist_decisi
 from apps.agent.pipeline.types import (
     DAILY_BRIEF_OUTPUT_SECTIONS,
     BulletCitationRow,
+    CitationStoreEntry,
     CitationValidationResult,
     DailyBriefCorpusStageData,
     DailyBriefInputStageData,
@@ -43,12 +52,14 @@ from apps.agent.pipeline.types import (
     DailyBriefSynthesisStageData,
     EvidencePackItem,
     FtsRow,
+    IssueMap,
     RunStatus,
     RuntimeChunkRow,
     RuntimeDocumentRecord,
     SourceRegistryEntry,
     SourceRow,
     StageResult,
+    StructuredClaim,
 )
 from apps.agent.portfolio.input_store import load_portfolio_positions
 from apps.agent.portfolio.relevance import build_portfolio_relevance_flags
@@ -129,6 +140,8 @@ def run_fixture_daily_brief(
     delivery_schedule: DailyBriefSchedule | None = None,
     email_config: EmailDeliveryConfig | None = None,
     smtp_class: Any = SMTP,
+    issue_planner: IssuePlannerProvider | None = None,
+    claim_composer: ClaimComposerProvider | None = None,
 ) -> dict[str, Any]:
     lifecycle: list[dict[str, Any]] = []
     execution: dict[str, Any] = {}
@@ -145,6 +158,8 @@ def run_fixture_daily_brief(
                 delivery_schedule=delivery_schedule,
                 email_config=email_config,
                 smtp_class=smtp_class,
+                issue_planner=issue_planner,
+                claim_composer=claim_composer,
             )
         except Exception as exc:
             execution["status"] = "failed"
@@ -199,6 +214,8 @@ def run_daily_brief(
     delivery_schedule: DailyBriefSchedule | None = None,
     email_config: EmailDeliveryConfig | None = None,
     smtp_class: Any = SMTP,
+    issue_planner: IssuePlannerProvider | None = None,
+    claim_composer: ClaimComposerProvider | None = None,
 ) -> dict[str, Any]:
     lifecycle: list[dict[str, Any]] = []
     execution: dict[str, Any] = {}
@@ -216,6 +233,8 @@ def run_daily_brief(
                 delivery_schedule=delivery_schedule,
                 email_config=email_config,
                 smtp_class=smtp_class,
+                issue_planner=issue_planner,
+                claim_composer=claim_composer,
             )
         except Exception as exc:
             execution["status"] = "failed"
@@ -272,6 +291,8 @@ def _execute_daily_brief_slice(
     delivery_schedule: DailyBriefSchedule | None = None,
     email_config: EmailDeliveryConfig | None = None,
     smtp_class: Any = SMTP,
+    issue_planner: IssuePlannerProvider | None = None,
+    claim_composer: ClaimComposerProvider | None = None,
 ) -> dict[str, Any]:
     report_date = generated_at_utc[:10]
     schedule = delivery_schedule or DailyBriefSchedule()
@@ -297,7 +318,10 @@ def _execute_daily_brief_slice(
         stage_data=corpus_data,
         registry=input_data.registry,
         run_id=run_id,
+        generated_at_utc=generated_at_utc,
         previous_synthesis=_load_previous_synthesis(base_dir=base_dir, report_date=report_date),
+        issue_planner=issue_planner,
+        claim_composer=claim_composer,
     )
     portfolio_positions = load_portfolio_positions(base_dir=base_dir)
     portfolio_relevance_flags = build_portfolio_relevance_flags(
@@ -353,6 +377,8 @@ def _execute_daily_brief_slice(
     _write_json(artifact_dir / "chunks.json", corpus_data.chunks)
     _write_json(artifact_dir / "fts_rows.json", corpus_data.fts_rows)
     _write_json(artifact_dir / "evidence_pack_items.json", synthesis_data.evidence_pack_items)
+    _write_json(artifact_dir / "issue_map.json", synthesis_data.issue_map)
+    _write_json(artifact_dir / "claim_objects.json", synthesis_data.structured_claims)
     _write_json(artifact_dir / "citations.json", synthesis_data.citation_rows)
     _write_json(artifact_dir / "synthesis.json", synthesis_data.final_result["synthesis"])
     _write_json(artifact_dir / "synthesis_bullets.json", synthesis_data.synthesis_bullet_rows)
@@ -371,6 +397,8 @@ def _execute_daily_brief_slice(
             "run_id": run_id,
             "report_date": report_date,
             "query_text": synthesis_data.query_text,
+            "issue_count": len(synthesis_data.issue_map),
+            "claim_count": len(synthesis_data.structured_claims),
             "docs_fetched": context.counters.docs_fetched,
             "docs_ingested": context.counters.docs_ingested,
             "chunks_indexed": context.counters.chunks_indexed,
@@ -501,8 +529,15 @@ def build_daily_brief_synthesis(
     stage_data: DailyBriefCorpusStageData,
     registry: Mapping[str, SourceRegistryEntry],
     run_id: str,
+    generated_at_utc: str | None = None,
     previous_synthesis: Mapping[str, Any] | None = None,
+    issue_planner: IssuePlannerProvider | None = None,
+    claim_composer: ClaimComposerProvider | None = None,
 ) -> DailyBriefSynthesisStageData:
+    if (issue_planner is None) != (claim_composer is None):
+        raise ValueError("Daily brief synthesis requires both issue_planner and claim_composer together.")
+
+    synthesis_generated_at_utc = generated_at_utc or _utc_now_iso()
     query_text = build_daily_brief_query(documents=stage_data.documents)
     evidence_pack_report = build_evidence_pack_report(
         fts_rows=stage_data.fts_rows,
@@ -522,6 +557,22 @@ def build_daily_brief_synthesis(
         documents_by_id=documents_by_id,
         chunks_by_id=chunks_by_id,
     )
+    prior_brief_context = build_prior_brief_context(
+        previous_synthesis=previous_synthesis,
+        previous_generated_at_utc=None,
+    )
+    use_structured_orchestration = issue_planner is not None and claim_composer is not None
+    issue_map: list[IssueMap] = []
+    structured_claims: list[StructuredClaim] = []
+    if use_structured_orchestration:
+        issue_map = _build_issue_map(
+            query_text=query_text,
+            evidence_pack_items=evidence_pack_items,
+            issue_planner=issue_planner,
+            prior_brief_context=prior_brief_context,
+            run_id=run_id,
+            generated_at_utc=synthesis_generated_at_utc,
+        )
     validation_registry = _build_validation_registry(
         registry=registry,
         documents=stage_data.documents,
@@ -530,12 +581,25 @@ def build_daily_brief_synthesis(
     stage8_result: CitationValidationResult | None = None
     retry_plan: SynthesisRetryPlan | None = None
     for validation_attempt in range(1, MAX_VALIDATION_ATTEMPTS + 1):
-        synthesis = build_synthesis(
-            evidence_items=evidence_pack_items,
-            documents_by_id=documents_by_id,
-            citation_store=citation_store,
-            retry_plan=retry_plan,
-        )
+        if use_structured_orchestration:
+            structured_claims = _build_structured_claims(
+                issue_map=issue_map,
+                citation_store=citation_store,
+                evidence_pack_items=evidence_pack_items,
+                documents_by_id=documents_by_id,
+                claim_composer=claim_composer,
+                prior_brief_context=prior_brief_context,
+                run_id=run_id,
+                generated_at_utc=synthesis_generated_at_utc,
+            )
+            synthesis = build_synthesis_from_structured_claims(structured_claims=structured_claims)
+        else:
+            synthesis = build_synthesis(
+                evidence_items=evidence_pack_items,
+                documents_by_id=documents_by_id,
+                citation_store=citation_store,
+                retry_plan=retry_plan,
+            )
         current_result = run_stage8_citation_validation(
             synthesis,
             citation_store,
@@ -575,11 +639,26 @@ def build_daily_brief_synthesis(
             **final_result,
             "synthesis": cast(DailyBriefSynthesis, final_synthesis),
         }
+    if not use_structured_orchestration:
+        issue_map = _build_issue_map(
+            query_text=query_text,
+            evidence_pack_items=evidence_pack_items,
+            issue_planner=None,
+            prior_brief_context=prior_brief_context,
+            run_id=run_id,
+            generated_at_utc=synthesis_generated_at_utc,
+        )
+        structured_claims = _build_structured_claims_from_synthesis(
+            issue_map=issue_map,
+            synthesis=final_result["synthesis"],
+        )
     synthesis_id = build_synthesis_id(run_id=run_id)
     return DailyBriefSynthesisStageData(
         query_text=query_text,
         evidence_pack_items=evidence_pack_items,
         evidence_pack_report=evidence_pack_report,
+        issue_map=issue_map,
+        structured_claims=structured_claims,
         citation_store=stage8_result["citation_store"],
         stage8_result=stage8_result,
         final_result=final_result,
@@ -599,7 +678,7 @@ def _build_retry_plan(
     *,
     synthesis: DailyBriefSynthesis,
     validation_result: CitationValidationResult,
-    citation_store: Mapping[str, Mapping[str, Any]],
+    citation_store: Mapping[str, CitationStoreEntry],
 ) -> SynthesisRetryPlan:
     target_sections = tuple(
         section
@@ -651,11 +730,132 @@ def _build_retry_plan(
     )
 
 
+def _build_issue_map(
+    *,
+    query_text: str,
+    evidence_pack_items: list[EvidencePackItem],
+    issue_planner: IssuePlannerProvider | None,
+    prior_brief_context: dict[str, Any] | None,
+    run_id: str,
+    generated_at_utc: str,
+) -> list[IssueMap]:
+    if issue_planner is not None:
+        return issue_planner.plan_issues(
+            brief_input=IssuePlannerInput(
+                run_id=run_id,
+                generated_at_utc=generated_at_utc,
+                evidence_pack=[dict(item) for item in evidence_pack_items],
+                prior_brief_context=prior_brief_context,
+            )
+        )
+
+    fallback_topic = query_text or "today's dominant narrative"
+    issue_question = (
+        f"What is the latest debate around {query_text}?"
+        if query_text
+        else "What is the latest market debate?"
+    )
+    chunk_ids = [str(item["chunk_id"]) for item in evidence_pack_items]
+    return [
+        IssueMap(
+            issue_id="issue_001",
+            issue_question=issue_question,
+            thesis_hint=f"The latest evidence pack centers on {fallback_topic}.",
+            supporting_evidence_ids=chunk_ids[:2],
+            opposing_evidence_ids=chunk_ids[2:3],
+            minority_evidence_ids=chunk_ids[3:4],
+            watch_evidence_ids=chunk_ids[:1],
+        )
+    ]
+
+
+def _build_structured_claims(
+    *,
+    issue_map: list[IssueMap],
+    citation_store: Mapping[str, CitationStoreEntry],
+    evidence_pack_items: list[EvidencePackItem],
+    documents_by_id: Mapping[str, RuntimeDocumentRecord],
+    claim_composer: ClaimComposerProvider | None,
+    prior_brief_context: dict[str, Any] | None,
+    run_id: str,
+    generated_at_utc: str,
+) -> list[StructuredClaim]:
+    if claim_composer is not None:
+        return claim_composer.compose_claims(
+            brief_input=ClaimComposerInput(
+                run_id=run_id,
+                generated_at_utc=generated_at_utc,
+                issue_map=issue_map,
+                citation_store={key: dict(value) for key, value in citation_store.items()},
+                prior_brief_context=prior_brief_context,
+            )
+        )
+
+    legacy_synthesis = build_synthesis(
+        evidence_items=evidence_pack_items,
+        documents_by_id=documents_by_id,
+        citation_store=citation_store,
+    )
+    issue_id = issue_map[0]["issue_id"] if issue_map else "issue_001"
+    structured_claims: list[StructuredClaim] = []
+    for claim_kind in ("prevailing", "counter", "minority", "watch"):
+        bullets = legacy_synthesis.get(claim_kind, [])
+        if not isinstance(bullets, list):
+            continue
+        for index, bullet in enumerate(bullets, start=1):
+            if not isinstance(bullet, Mapping):
+                continue
+            structured_claims.append(
+                StructuredClaim(
+                    claim_id=f"{issue_id}_{claim_kind}_{index:03d}",
+                    issue_id=issue_id,
+                    claim_kind=claim_kind,
+                    claim_text=str(bullet.get("text", "")),
+                    supporting_citation_ids=[str(citation_id) for citation_id in bullet.get("citation_ids", [])],
+                    opposing_citation_ids=[],
+                    confidence=str(bullet.get("confidence_label", "medium")),
+                    novelty_vs_prior_brief="unknown",
+                    why_it_matters=f"This affects the current {claim_kind} case for the issue.",
+                )
+            )
+    return structured_claims
+
+
+def _build_structured_claims_from_synthesis(
+    *,
+    issue_map: list[IssueMap],
+    synthesis: DailyBriefSynthesis,
+) -> list[StructuredClaim]:
+    issue_id = issue_map[0]["issue_id"] if issue_map else "issue_001"
+    structured_claims: list[StructuredClaim] = []
+    for claim_kind in ("prevailing", "counter", "minority", "watch"):
+        bullets = synthesis.get(claim_kind, [])
+        if not isinstance(bullets, list):
+            continue
+        for index, bullet in enumerate(bullets, start=1):
+            if not isinstance(bullet, Mapping):
+                continue
+            structured_claims.append(
+                StructuredClaim(
+                    claim_id=f"{issue_id}_{claim_kind}_{index:03d}",
+                    issue_id=issue_id,
+                    claim_kind=claim_kind,
+                    claim_text=str(bullet.get("text", "")),
+                    supporting_citation_ids=[str(citation_id) for citation_id in bullet.get("citation_ids", [])],
+                    opposing_citation_ids=[],
+                    confidence=str(bullet.get("confidence_label", "medium")),
+                    novelty_vs_prior_brief="unknown",
+                    why_it_matters=f"This affects the current {claim_kind} case for the issue.",
+                )
+            )
+    return structured_claims
+
+
 def _chunk_ids_for_section(
     *,
     synthesis: Mapping[str, Any],
     section: str,
-    citation_store: Mapping[str, Mapping[str, Any]],
+    citation_store: Mapping[str, CitationStoreEntry],
 ) -> list[str]:
     bullets = synthesis.get(section, [])
     if not isinstance(bullets, list):

--- a/apps/agent/daily_brief/synthesis.py
+++ b/apps/agent/daily_brief/synthesis.py
@@ -13,6 +13,7 @@ from apps.agent.pipeline.types import (
     EvidencePackItem,
     RuntimeChunkRow,
     RuntimeDocumentRecord,
+    StructuredClaim,
 )
 
 WATCH_KEYWORDS = (
@@ -191,6 +192,30 @@ def build_changed_section(
             break
 
     return changed
+
+
+def build_synthesis_from_structured_claims(
+    *,
+    structured_claims: Iterable[StructuredClaim],
+) -> DailyBriefSynthesis:
+    synthesis: DailyBriefSynthesis = {
+        "prevailing": [],
+        "counter": [],
+        "minority": [],
+        "watch": [],
+    }
+    for claim in structured_claims:
+        claim_kind = claim["claim_kind"]
+        if claim_kind not in {"prevailing", "counter", "minority", "watch"}:
+            continue
+        synthesis[claim_kind].append(
+            DailyBriefBullet(
+                text=claim["claim_text"],
+                citation_ids=list(claim["supporting_citation_ids"]),
+                confidence_label=str(claim["confidence"]),
+            )
+        )
+    return synthesis
 
 
 def _sorted_evidence_items(evidence_items: Iterable[Mapping[str, Any]]) -> list[Mapping[str, Any]]:

--- a/apps/agent/pipeline/types.py
+++ b/apps/agent/pipeline/types.py
@@ -338,6 +338,8 @@ class DailyBriefSynthesisStageData:
     query_text: str
     evidence_pack_items: list[EvidencePackItem]
     evidence_pack_report: dict[str, Any]
+    issue_map: list[IssueMap]
+    structured_claims: list[StructuredClaim]
     citation_store: dict[str, CitationStoreEntry]
     stage8_result: CitationValidationResult
     final_result: FinalSynthesisResult

--- a/tests/agent/daily_brief/test_openai_claim_composer.py
+++ b/tests/agent/daily_brief/test_openai_claim_composer.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import unittest
+
+from apps.agent.daily_brief.model_interfaces import ClaimComposerInput
+from apps.agent.daily_brief.openai_claim_composer import OpenAIClaimComposer
+
+
+class OpenAIClaimComposerTests(unittest.TestCase):
+    def test_composes_claims_from_schema_valid_json(self) -> None:
+        composer = OpenAIClaimComposer(
+            response_loader=lambda _brief_input: """
+            [
+              {
+                "claim_id": "claim_oil_prevailing",
+                "issue_id": "issue_oil",
+                "claim_kind": "prevailing",
+                "claim_text": "Most sources still expect near-term upside in oil prices.",
+                "supporting_citation_ids": ["cite_001", "cite_002"],
+                "opposing_citation_ids": ["cite_003"],
+                "confidence": "medium",
+                "novelty_vs_prior_brief": "strengthened",
+                "why_it_matters": "Near-term energy inflation risk remains elevated."
+              }
+            ]
+            """
+        )
+
+        result = composer.compose_claims(
+            brief_input=ClaimComposerInput(
+                run_id="run_001",
+                generated_at_utc="2026-03-12T00:00:00Z",
+                issue_map=[
+                    {
+                        "issue_id": "issue_oil",
+                        "issue_question": "Will oil prices keep rising over the next few weeks?",
+                        "thesis_hint": "Supply concerns are keeping near-term pressure skewed upward.",
+                        "supporting_evidence_ids": ["chunk_1"],
+                        "opposing_evidence_ids": ["chunk_2"],
+                        "minority_evidence_ids": ["chunk_3"],
+                        "watch_evidence_ids": ["chunk_4"],
+                    }
+                ],
+                citation_store={"cite_001": {"citation_id": "cite_001"}},
+                prior_brief_context=None,
+            )
+        )
+
+        self.assertEqual(result[0]["claim_kind"], "prevailing")
+        self.assertEqual(result[0]["novelty_vs_prior_brief"], "strengthened")
+
+    def test_rejects_malformed_claim_output(self) -> None:
+        composer = OpenAIClaimComposer(response_loader=lambda _brief_input: '[{"claim_id": "missing_fields"}]')
+
+        with self.assertRaises(ValueError):
+            composer.compose_claims(
+                brief_input=ClaimComposerInput(
+                    run_id="run_001",
+                    generated_at_utc="2026-03-12T00:00:00Z",
+                    issue_map=[],
+                    citation_store={},
+                    prior_brief_context=None,
+                )
+            )
+
+    def test_rejects_wrong_claim_field_types_and_enum_values(self) -> None:
+        composer = OpenAIClaimComposer(
+            response_loader=lambda _brief_input: """
+            [
+              {
+                "claim_id": "claim_oil_prevailing",
+                "issue_id": "issue_oil",
+                "claim_kind": "dominant",
+                "claim_text": "Most sources still expect near-term upside in oil prices.",
+                "supporting_citation_ids": "cite_001",
+                "opposing_citation_ids": ["cite_003"],
+                "confidence": "medium",
+                "novelty_vs_prior_brief": "stronger",
+                "why_it_matters": "Near-term energy inflation risk remains elevated."
+              }
+            ]
+            """
+        )
+
+        with self.assertRaises(ValueError):
+            composer.compose_claims(
+                brief_input=ClaimComposerInput(
+                    run_id="run_001",
+                    generated_at_utc="2026-03-12T00:00:00Z",
+                    issue_map=[],
+                    citation_store={},
+                    prior_brief_context=None,
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/daily_brief/test_openai_issue_planner.py
+++ b/tests/agent/daily_brief/test_openai_issue_planner.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import unittest
+
+from apps.agent.daily_brief.model_interfaces import IssuePlannerInput
+from apps.agent.daily_brief.openai_issue_planner import OpenAIIssuePlanner
+
+
+class OpenAIIssuePlannerTests(unittest.TestCase):
+    def test_plans_issues_from_schema_valid_json(self) -> None:
+        planner = OpenAIIssuePlanner(
+            response_loader=lambda _brief_input: """
+            [
+              {
+                "issue_id": "issue_oil",
+                "issue_question": "Will oil prices keep rising over the next few weeks?",
+                "thesis_hint": "Supply concerns are keeping near-term pressure skewed upward.",
+                "supporting_evidence_ids": ["chunk_1", "chunk_2"],
+                "opposing_evidence_ids": ["chunk_3"],
+                "minority_evidence_ids": ["chunk_4"],
+                "watch_evidence_ids": ["chunk_5"]
+              }
+            ]
+            """
+        )
+
+        result = planner.plan_issues(
+            brief_input=IssuePlannerInput(
+                run_id="run_001",
+                generated_at_utc="2026-03-12T00:00:00Z",
+                evidence_pack=[{"chunk_id": "chunk_1"}],
+                prior_brief_context=None,
+            )
+        )
+
+        self.assertEqual(result[0]["issue_id"], "issue_oil")
+        self.assertEqual(result[0]["supporting_evidence_ids"], ["chunk_1", "chunk_2"])
+
+    def test_rejects_malformed_issue_map_output(self) -> None:
+        planner = OpenAIIssuePlanner(response_loader=lambda _brief_input: '[{"issue_id": "missing_fields"}]')
+
+        with self.assertRaises(ValueError):
+            planner.plan_issues(
+                brief_input=IssuePlannerInput(
+                    run_id="run_001",
+                    generated_at_utc="2026-03-12T00:00:00Z",
+                    evidence_pack=[],
+                    prior_brief_context=None,
+                )
+            )
+
+    def test_rejects_wrong_issue_map_field_types(self) -> None:
+        planner = OpenAIIssuePlanner(
+            response_loader=lambda _brief_input: """
+            [
+              {
+                "issue_id": "issue_oil",
+                "issue_question": "Will oil prices keep rising over the next few weeks?",
+                "thesis_hint": "Supply concerns are keeping near-term pressure skewed upward.",
+                "supporting_evidence_ids": "chunk_1",
+                "opposing_evidence_ids": ["chunk_3"],
+                "minority_evidence_ids": ["chunk_4"],
+                "watch_evidence_ids": ["chunk_5"]
+              }
+            ]
+            """
+        )
+
+        with self.assertRaises(ValueError):
+            planner.plan_issues(
+                brief_input=IssuePlannerInput(
+                    run_id="run_001",
+                    generated_at_utc="2026-03-12T00:00:00Z",
+                    evidence_pack=[],
+                    prior_brief_context=None,
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/daily_brief/test_prior_brief_context.py
+++ b/tests/agent/daily_brief/test_prior_brief_context.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import unittest
+
+from apps.agent.daily_brief.prior_brief_context import build_prior_brief_context
+
+
+class PriorBriefContextTests(unittest.TestCase):
+    def test_extracts_bounded_context_from_previous_synthesis(self) -> None:
+        previous_synthesis = {
+            "prevailing": [{"text": "Prevailing claim.", "citation_ids": ["cite_001"]}],
+            "counter": [{"text": "Counter claim.", "citation_ids": ["cite_002"]}],
+            "changed": [{"text": "Changed claim.", "citation_ids": ["cite_003"]}],
+        }
+
+        context = build_prior_brief_context(
+            previous_synthesis=previous_synthesis,
+            previous_generated_at_utc="2026-03-11T00:00:00Z",
+        )
+
+        self.assertEqual(context["previous_generated_at_utc"], "2026-03-11T00:00:00Z")
+        self.assertEqual(context["claim_summaries"], ["Prevailing claim.", "Counter claim."])
+        self.assertEqual(context["citation_ids"], ["cite_001", "cite_002"])
+
+    def test_returns_none_when_previous_synthesis_missing(self) -> None:
+        self.assertIsNone(
+            build_prior_brief_context(
+                previous_synthesis=None,
+                previous_generated_at_utc=None,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/daily_brief/test_runner.py
+++ b/tests/agent/daily_brief/test_runner.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import get_args, get_type_hints
 from unittest.mock import patch
 
+from apps.agent.daily_brief.model_interfaces import ClaimComposerProvider, IssuePlannerProvider
 from apps.agent.daily_brief.runner import (
     build_daily_brief_corpus,
     build_daily_brief_query,
@@ -31,6 +32,7 @@ from apps.agent.pipeline.types import (
     EvidencePackItem,
     FinalSynthesisResult,
     FtsRow,
+    IssueMap,
     PlannedFetchItem,
     RunContext,
     RunStatus,
@@ -39,6 +41,7 @@ from apps.agent.pipeline.types import (
     RunType,
     SourceRegistryEntry,
     SourceRow,
+    StructuredClaim,
 )
 from apps.agent.portfolio.input_store import PortfolioPosition, replace_portfolio_positions
 from apps.agent.runtime.budget_guard import BudgetCaps
@@ -1116,6 +1119,271 @@ class DailyBriefRunnerTests(unittest.TestCase):
             DailyBriefRunnerTests._FakeSMTP.last_instance.sent_messages[0]["Subject"],
             "Daily Brief: 2026-03-11",
         )
+
+    def test_build_daily_brief_synthesis_calls_issue_planner_before_claim_composer(self):
+        call_order: list[str] = []
+        test_case = self
+
+        class _Planner(IssuePlannerProvider):
+            def plan_issues(self, *, brief_input):
+                call_order.append("planner")
+                test_case.assertEqual(brief_input["generated_at_utc"], "2026-03-10T16:00:00Z")
+                return [
+                    IssueMap(
+                        issue_id="issue_001",
+                        issue_question="Will softer growth change near-term Fed expectations?",
+                        thesis_hint="Growth is cooling, but inflation remains sticky.",
+                        supporting_evidence_ids=["doc_prevailing_chunk_000"],
+                        opposing_evidence_ids=["doc_counter_retry_chunk_000"],
+                        minority_evidence_ids=["doc_minority_chunk_000"],
+                        watch_evidence_ids=["doc_watch_chunk_000"],
+                    )
+                ]
+
+        class _Composer(ClaimComposerProvider):
+            def compose_claims(self, *, brief_input):
+                call_order.append("composer")
+                test_case.assertEqual(brief_input["issue_map"][0]["issue_id"], "issue_001")
+                test_case.assertEqual(brief_input["generated_at_utc"], "2026-03-10T16:00:00Z")
+                return [
+                    StructuredClaim(
+                        claim_id="claim_prevailing",
+                        issue_id="issue_001",
+                        claim_kind="prevailing",
+                        claim_text="Softer growth is raising later-cut expectations.",
+                        supporting_citation_ids=["cite_003"],
+                        opposing_citation_ids=["cite_005"],
+                        confidence="medium",
+                        novelty_vs_prior_brief="new",
+                        why_it_matters="Rate-sensitive assets remain exposed to data surprises.",
+                    ),
+                    StructuredClaim(
+                        claim_id="claim_counter",
+                        issue_id="issue_001",
+                        claim_kind="counter",
+                        claim_text="Sticky inflation still argues against a quick pivot.",
+                        supporting_citation_ids=["cite_005"],
+                        opposing_citation_ids=["cite_003"],
+                        confidence="medium",
+                        novelty_vs_prior_brief="new",
+                        why_it_matters="Policy may stay restrictive longer than bulls expect.",
+                    ),
+                    StructuredClaim(
+                        claim_id="claim_minority",
+                        issue_id="issue_001",
+                        claim_kind="minority",
+                        claim_text="A smaller camp expects a sharper growth slowdown.",
+                        supporting_citation_ids=["cite_002"],
+                        opposing_citation_ids=[],
+                        confidence="low",
+                        novelty_vs_prior_brief="new",
+                        why_it_matters="Downside tail risk is still present.",
+                    ),
+                    StructuredClaim(
+                        claim_id="claim_watch",
+                        issue_id="issue_001",
+                        claim_kind="watch",
+                        claim_text="The next CPI release is the key falsification point.",
+                        supporting_citation_ids=["cite_001"],
+                        opposing_citation_ids=[],
+                        confidence="high",
+                        novelty_vs_prior_brief="new",
+                        why_it_matters="The next inflation print can reprice the whole debate.",
+                    ),
+                ]
+
+        stage_data = DailyBriefCorpusStageData(
+            source_rows=[],
+            documents=[
+                {
+                    "source_id": "bls_preview",
+                    "publisher": "BLS Preview Desk",
+                    "canonical_url": "https://example.test/watch",
+                    "title": "Watch Friday CPI for shelter inflation",
+                    "author": None,
+                    "language": "en",
+                    "doc_type": "analysis",
+                    "published_at": "2026-03-10T16:00:00Z",
+                    "fetched_at": "2026-03-10T16:05:00Z",
+                    "paywall_policy": "full",
+                    "metadata_only": 0,
+                    "rss_snippet": "Markets are watching Friday CPI for shelter inflation surprises.",
+                    "body_text": "Watch Friday CPI for shelter inflation surprises.",
+                    "content_hash": "hash_watch",
+                    "status": "active",
+                    "created_at": "2026-03-10T16:05:00Z",
+                    "updated_at": "2026-03-10T16:05:00Z",
+                    "doc_id": "doc_watch",
+                    "credibility_tier": 1,
+                    "ingestion_run_id": "run_issue_flow",
+                },
+                {
+                    "source_id": "market_commentary",
+                    "publisher": "Market Commentary",
+                    "canonical_url": "https://example.test/minority",
+                    "title": "Minority view still expects a hard landing",
+                    "author": None,
+                    "language": "en",
+                    "doc_type": "analysis",
+                    "published_at": "2026-03-10T15:30:00Z",
+                    "fetched_at": "2026-03-10T15:35:00Z",
+                    "paywall_policy": "full",
+                    "metadata_only": 0,
+                    "rss_snippet": "A minority of investors still expects a hard landing.",
+                    "body_text": "A minority of investors still expects a hard landing.",
+                    "content_hash": "hash_minority",
+                    "status": "active",
+                    "created_at": "2026-03-10T15:35:00Z",
+                    "updated_at": "2026-03-10T15:35:00Z",
+                    "doc_id": "doc_minority",
+                    "credibility_tier": 3,
+                    "ingestion_run_id": "run_issue_flow",
+                },
+                {
+                    "source_id": "fed_press_releases",
+                    "publisher": "Federal Reserve",
+                    "canonical_url": "https://example.test/prevailing",
+                    "title": "Fed keeps policy steady",
+                    "author": None,
+                    "language": "en",
+                    "doc_type": "statement",
+                    "published_at": "2026-03-10T14:00:00Z",
+                    "fetched_at": "2026-03-10T14:05:00Z",
+                    "paywall_policy": "full",
+                    "metadata_only": 0,
+                    "rss_snippet": "Fed officials kept policy steady while inflation progress remained uneven.",
+                    "body_text": "Fed officials kept policy steady while inflation progress remained uneven.",
+                    "content_hash": "hash_prevailing",
+                    "status": "active",
+                    "created_at": "2026-03-10T14:05:00Z",
+                    "updated_at": "2026-03-10T14:05:00Z",
+                    "doc_id": "doc_prevailing",
+                    "credibility_tier": 1,
+                    "ingestion_run_id": "run_issue_flow",
+                },
+                {
+                    "source_id": "wsj_markets",
+                    "publisher": "Wall Street Journal",
+                    "canonical_url": "https://example.test/counter-retry",
+                    "title": "Investors question the soft-landing narrative",
+                    "author": None,
+                    "language": "en",
+                    "doc_type": "news",
+                    "published_at": "2026-03-10T14:20:00Z",
+                    "fetched_at": "2026-03-10T14:25:00Z",
+                    "paywall_policy": "full",
+                    "metadata_only": 0,
+                    "rss_snippet": "Investors question the soft-landing narrative as growth data weakens.",
+                    "body_text": "Investors question the soft-landing narrative as growth data weakens.",
+                    "content_hash": "hash_counter_retry",
+                    "status": "active",
+                    "created_at": "2026-03-10T14:25:00Z",
+                    "updated_at": "2026-03-10T14:25:00Z",
+                    "doc_id": "doc_counter_retry",
+                    "credibility_tier": 2,
+                    "ingestion_run_id": "run_issue_flow",
+                },
+            ],
+            chunks=[
+                {"chunk_id": "doc_watch_chunk_000", "doc_id": "doc_watch", "chunk_index": 0, "text": "Watch Friday CPI for shelter inflation surprises.", "token_count": 6, "char_start": 0, "char_end": 43, "created_at": "2026-03-10T16:05:00Z"},
+                {"chunk_id": "doc_minority_chunk_000", "doc_id": "doc_minority", "chunk_index": 0, "text": "A minority of investors still expects a hard landing.", "token_count": 9, "char_start": 0, "char_end": 55, "created_at": "2026-03-10T15:35:00Z"},
+                {"chunk_id": "doc_prevailing_chunk_000", "doc_id": "doc_prevailing", "chunk_index": 0, "text": "Fed officials kept policy steady while inflation progress remained uneven.", "token_count": 10, "char_start": 0, "char_end": 71, "created_at": "2026-03-10T14:05:00Z"},
+                {"chunk_id": "doc_counter_retry_chunk_000", "doc_id": "doc_counter_retry", "chunk_index": 0, "text": "Investors question the soft-landing narrative as growth data weakens.", "token_count": 9, "char_start": 0, "char_end": 68, "created_at": "2026-03-10T14:25:00Z"},
+            ],
+            fts_rows=[
+                {"text": "Watch Friday CPI for shelter inflation surprises.", "doc_id": "doc_watch", "chunk_id": "doc_watch_chunk_000", "publisher": "BLS Preview Desk", "source_id": "bls_preview", "published_at": "2026-03-10T16:00:00Z", "credibility_tier": 1},
+                {"text": "A minority of investors still expects a hard landing.", "doc_id": "doc_minority", "chunk_id": "doc_minority_chunk_000", "publisher": "Market Commentary", "source_id": "market_commentary", "published_at": "2026-03-10T15:30:00Z", "credibility_tier": 3},
+                {"text": "Fed officials kept policy steady while inflation progress remained uneven.", "doc_id": "doc_prevailing", "chunk_id": "doc_prevailing_chunk_000", "publisher": "Federal Reserve", "source_id": "fed_press_releases", "published_at": "2026-03-10T14:00:00Z", "credibility_tier": 1},
+                {"text": "Investors question the soft-landing narrative as growth data weakens.", "doc_id": "doc_counter_retry", "chunk_id": "doc_counter_retry_chunk_000", "publisher": "Wall Street Journal", "source_id": "wsj_markets", "published_at": "2026-03-10T14:20:00Z", "credibility_tier": 2},
+            ],
+        )
+        registry = {
+            "bls_preview": {"id": "bls_preview", "name": "BLS Preview Desk", "url": "https://example.test/watch", "type": "rss", "credibility_tier": 1, "paywall_policy": "full", "fetch_interval": "daily", "tags": ["macro_data"]},
+            "market_commentary": {"id": "market_commentary", "name": "Market Commentary", "url": "https://example.test/minority", "type": "rss", "credibility_tier": 3, "paywall_policy": "full", "fetch_interval": "daily", "tags": ["market_narrative"]},
+            "fed_press_releases": {"id": "fed_press_releases", "name": "Federal Reserve", "url": "https://example.test/prevailing", "type": "rss", "credibility_tier": 1, "paywall_policy": "full", "fetch_interval": "daily", "tags": ["policy_centralbank"]},
+            "wsj_markets": {"id": "wsj_markets", "name": "Wall Street Journal", "url": "https://example.test/counter-retry", "type": "rss", "credibility_tier": 2, "paywall_policy": "full", "fetch_interval": "daily", "tags": ["market_narrative"]},
+        }
+
+        with patch("apps.agent.daily_brief.runner.build_evidence_pack_report") as evidence_pack_report_mock:
+            evidence_pack_report_mock.return_value = {
+                "items": [
+                    {"chunk_id": "doc_watch_chunk_000", "source_id": "bls_preview", "publisher": "BLS Preview Desk", "credibility_tier": 1, "retrieval_score": 0.95, "semantic_score": 0.95, "recency_score": 0.90, "credibility_score": 1.0, "rank_in_pack": 1},
+                    {"chunk_id": "doc_minority_chunk_000", "source_id": "market_commentary", "publisher": "Market Commentary", "credibility_tier": 3, "retrieval_score": 0.90, "semantic_score": 0.90, "recency_score": 0.80, "credibility_score": 0.6, "rank_in_pack": 2},
+                    {"chunk_id": "doc_prevailing_chunk_000", "source_id": "fed_press_releases", "publisher": "Federal Reserve", "credibility_tier": 1, "retrieval_score": 0.88, "semantic_score": 0.88, "recency_score": 0.70, "credibility_score": 1.0, "rank_in_pack": 3},
+                    {"chunk_id": "doc_counter_retry_chunk_000", "source_id": "wsj_markets", "publisher": "Wall Street Journal", "credibility_tier": 2, "retrieval_score": 0.84, "semantic_score": 0.84, "recency_score": 0.66, "credibility_score": 0.8, "rank_in_pack": 4},
+                ],
+                "diversity_stats": {"unique_publishers": 4},
+                "diversity_check": "pass",
+                "notes": [],
+            }
+
+            synthesis = build_daily_brief_synthesis(
+                stage_data=stage_data,
+                registry=registry,
+                run_id="run_issue_flow",
+                generated_at_utc="2026-03-10T16:00:00Z",
+                issue_planner=_Planner(),
+                claim_composer=_Composer(),
+            )
+
+        self.assertEqual(call_order[:2], ["planner", "composer"])
+        self.assertGreaterEqual(call_order.count("composer"), 1)
+        self.assertEqual(synthesis.issue_map[0]["issue_id"], "issue_001")
+        self.assertEqual(synthesis.structured_claims[0]["claim_id"], "claim_prevailing")
+        self.assertEqual(synthesis.structured_claims[0]["supporting_citation_ids"], ["cite_003"])
+
+    def test_build_daily_brief_synthesis_rejects_partial_provider_injection(self):
+        stage_data = DailyBriefCorpusStageData(
+            source_rows=[],
+            documents=[],
+            chunks=[],
+            fts_rows=[],
+        )
+
+        class _Planner(IssuePlannerProvider):
+            def plan_issues(self, *, brief_input):
+                return []
+
+        with self.assertRaises(ValueError):
+            build_daily_brief_synthesis(
+                stage_data=stage_data,
+                registry={},
+                run_id="run_partial_provider",
+                issue_planner=_Planner(),
+            )
+
+    def test_run_fixture_daily_brief_forwards_providers_to_execute_slice(self):
+        class _Planner(IssuePlannerProvider):
+            def plan_issues(self, *, brief_input):
+                return []
+
+        class _Composer(ClaimComposerProvider):
+            def compose_claims(self, *, brief_input):
+                return []
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with patch("apps.agent.daily_brief.runner._execute_daily_brief_slice") as execute_mock:
+                execute_mock.return_value = {
+                    "status": "ok",
+                    "html_path": str(Path(temp_dir) / "brief.html"),
+                    "decision_record_path": str(Path(temp_dir) / "decision_record.json"),
+                    "artifact_dir": str(Path(temp_dir) / "artifacts"),
+                    "query_text": "inflation growth",
+                    "abstain_reason": None,
+                    "scheduled_for_local_date": "2026-03-11",
+                    "next_scheduled_run_at_utc": "2026-03-12T00:00:00Z",
+                    "email_delivery": None,
+                }
+
+                run_fixture_daily_brief(
+                    base_dir=Path(temp_dir),
+                    generated_at_utc="2026-03-10T16:00:00Z",
+                    issue_planner=_Planner(),
+                    claim_composer=_Composer(),
+                )
+
+        self.assertIsInstance(execute_mock.call_args.kwargs["issue_planner"], _Planner)
+        self.assertIsInstance(execute_mock.call_args.kwargs["claim_composer"], _Composer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- wire issue planner and claim composer through the runnable daily-brief entrypoints
- keep retries on the structured orchestration path instead of falling back to legacy synthesis
- harden OpenAI-first adapters with field-type and enum validation

## Testing
- python -m unittest tests.agent.daily_brief.test_runner tests.agent.daily_brief.test_openai_issue_planner tests.agent.daily_brief.test_openai_claim_composer tests.agent.daily_brief.test_prior_brief_context -v
- python -m ruff check apps/agent/daily_brief/runner.py apps/agent/daily_brief/synthesis.py apps/agent/daily_brief/prior_brief_context.py apps/agent/daily_brief/openai_issue_planner.py apps/agent/daily_brief/openai_claim_composer.py tests/agent/daily_brief/test_runner.py tests/agent/daily_brief/test_openai_issue_planner.py tests/agent/daily_brief/test_openai_claim_composer.py tests/agent/daily_brief/test_prior_brief_context.py apps/agent/pipeline/types.py
- python -m mypy apps/agent/daily_brief/runner.py apps/agent/daily_brief/synthesis.py apps/agent/daily_brief/prior_brief_context.py apps/agent/daily_brief/openai_issue_planner.py apps/agent/daily_brief/openai_claim_composer.py apps/agent/pipeline/types.py
- python -m compileall -q apps tests scripts

Closes #95
