### PR TITLE
docs: codify redesign planning workflow

### DIFF
--- a/.codex/mr-flow-and-approvals.md
+++ b/.codex/mr-flow-and-approvals.md
@@ -3,6 +3,10 @@
 ## User Preferences
 - Default workflow is always: `issue -> PR -> merge`.
 - This rule applies to design changes, planning docs, implementation work, and bug fixes.
+- After redesign work, the required sequence is: `redesign -> planning -> child issues -> implementation`.
+- Planning is not optional when a redesign changes architecture, contracts, or multi-step execution.
+- When planning produces multiple implementation tracks, create child issues before implementation starts.
+- Multi-stream implementation should be executed by an agent team aligned to child issues, not as one ad hoc undifferentiated task.
 - Do not repeatedly ask for GitHub-related approvals when an approved command prefix already exists.
 - Prefer reusing saved approved prefixes for `gh`/GitHub operations.
 - Batch GitHub operations to minimize approval prompts.
@@ -11,19 +15,24 @@
 
 ## Standard MR Flow
 1. Confirm there is a tracking issue for the work; if not, create one before treating the task as in-flight.
-2. Identify the latest/open PR tied to the current branch; if none exists, create one.
-3. Check CI status and review state.
-4. Pull unresolved review threads/comments.
-5. Address unaddressed comments in code/docs/workflows.
-6. Resolve addressed threads.
-7. Re-request review and re-check CI.
-8. Iterate steps 4-7 until review threads are resolved and checks pass.
-9. Merge PR (prefer normal merge; use `--admin` only when required by policy/workflow).
-10. Verify merged state and report merge commit SHA.
+2. If the current work is a redesign, land that redesign in its own PR before moving to planning.
+3. After redesign merges, create the planning issue/PR and land planning before implementation begins.
+4. If planning yields multiple execution tracks, create child issues and map implementation branches/PRs to them.
+5. Identify the latest/open PR tied to the current branch; if none exists, create one.
+6. Check CI status and review state.
+7. Pull unresolved review threads/comments.
+8. Address unaddressed comments in code/docs/workflows.
+9. Resolve addressed threads.
+10. Re-request review and re-check CI.
+11. Iterate steps 7-10 until review threads are resolved and checks pass.
+12. Merge PR (prefer normal merge; use `--admin` only when required by policy/workflow).
+13. Verify merged state and report merge commit SHA.
 
 ## Operational Rules For Future Sessions
 - Read this file at the start of MR-related tasks.
 - Treat work without an issue or PR as not yet in the required delivery flow.
+- Treat redesign without a follow-on planning step as incomplete delivery flow.
+- Treat multi-stream implementation without child issues as incomplete delivery flow.
 - Assume user wants end-to-end completion (fix -> resolve -> review -> merge) unless user says otherwise.
 - Surface only hard blockers (policy limitations, failed CI, missing required reviewer approval).
 - Keep user updates brief and action-focused.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ Use `explore -> plan -> code -> verify -> commit` for implementation tasks.
 Use `issue -> PR -> merge` as the default delivery path for all finalized work.
 This applies to design changes, planning documents, implementation work, and bug fixes.
 
+For redesign-heavy work, use the staged delivery chain:
+`redesign issue -> redesign PR -> merge -> planning issue/PR -> merge -> child issues -> implementation PRs -> merge`.
+
+When a redesign expands into multiple execution tracks, do not jump straight from redesign into local implementation.
+First land planning, then split the work into child issues, then execute implementation through an agent team aligned to those child issues.
+
 ### Operating standards
 1. Inspect repository state first (`git status`, current branch, pending local changes).
 2. Keep changes minimal and aligned with existing architecture and conventions.
@@ -35,7 +41,9 @@ This applies to design changes, planning documents, implementation work, and bug
 4. Update docs when behavior, commands, or workflow changes.
 5. Summarize what changed, what was validated, and any residual risk.
 6. When a step is finalized, make sure it is tracked through an issue first, then committed into a PR (or the active PR), and merged instead of leaving completed local-only work unpushed.
-7. For independent tasks that are unlikely to conflict, use separate branches and separate MRs instead of combining them in one MR.
+7. After redesign is merged, create a planning step before implementation starts; if the plan yields multiple workstreams, create child issues before coding.
+8. For independent tasks that are unlikely to conflict, use separate branches and separate MRs instead of combining them in one MR.
+9. For multi-stream implementation, prefer an agent team working against child issues instead of one undifferentiated branch of work.
 
 ### Repo-specific non-negotiables
 1. No uncited factual claims in generated analysis outputs.


### PR DESCRIPTION
## Summary
- codify the required redesign -> planning -> child issues -> implementation sequence
- require planning to land before multi-stream implementation starts
- require agent-team execution to align to child issues for multi-stream work

## Validation
- python scripts/validate_artifacts.py

Closes #100
