### PR TITLE
feat(daily-brief): harden claim composer and prior context

### DIFF
--- a/apps/agent/daily_brief/openai_claim_composer.py
+++ b/apps/agent/daily_brief/openai_claim_composer.py
@@ -17,44 +17,83 @@ VALID_NOVELTY_LABELS = {
     "reversed",
     "unknown",
 }
+REQUIRED_STRUCTURED_CLAIM_FIELDS = frozenset(StructuredClaim.__annotations__)
 
 
 class OpenAIClaimComposer(ClaimComposerProvider):
     def __init__(self, *, response_loader: Callable[[ClaimComposerInput], str | list[dict[str, Any]]] | None) -> None:
         self._response_loader = response_loader
 
-    def compose_claims(self, *, brief_input: ClaimComposerInput) -> list[StructuredClaim]:
-        if self._response_loader is None:
-            raise ValueError("OpenAIClaimComposer requires a response_loader for this local runtime slice.")
-        payload = self._response_loader(brief_input)
-        if isinstance(payload, str):
-            parsed = json.loads(payload)
-        else:
-            parsed = payload
+    def build_request_payload(self, *, brief_input: ClaimComposerInput) -> dict[str, Any]:
+        return {
+            "run_id": str(brief_input["run_id"]),
+            "generated_at_utc": str(brief_input["generated_at_utc"]),
+            "issue_map": [dict(issue) for issue in brief_input["issue_map"]],
+            "citation_store": {
+                str(citation_id): dict(citation_payload)
+                for citation_id, citation_payload in brief_input["citation_store"].items()
+            },
+            "prior_brief_context": (
+                None
+                if brief_input["prior_brief_context"] is None
+                else dict(brief_input["prior_brief_context"])
+            ),
+        }
+
+    def parse_response_payload(self, *, payload: str | list[dict[str, Any]]) -> list[StructuredClaim]:
+        parsed = json.loads(payload) if isinstance(payload, str) else payload
         if not isinstance(parsed, list):
             raise ValueError("Claim composer output must be a list.")
 
         claims: list[StructuredClaim] = []
-        required_fields = set(StructuredClaim.__annotations__)
         for item in parsed:
-            if not isinstance(item, dict) or set(item) != required_fields:
+            if not isinstance(item, dict) or set(item) != REQUIRED_STRUCTURED_CLAIM_FIELDS:
                 raise ValueError("Malformed claim composer output.")
             claims.append(_validate_structured_claim(item))
         return claims
 
+    def compose_claims(self, *, brief_input: ClaimComposerInput) -> list[StructuredClaim]:
+        if self._response_loader is None:
+            raise ValueError("OpenAIClaimComposer requires a response_loader for this local runtime slice.")
+        request_payload = self.build_request_payload(brief_input=brief_input)
+        response_payload = self._response_loader(cast(ClaimComposerInput, request_payload))
+        return self.parse_response_payload(payload=response_payload)
+
 
 def _validate_structured_claim(item: dict[str, Any]) -> StructuredClaim:
-    if not all(
-        isinstance(item.get(field), str) and item[field].strip()
-        for field in ("claim_id", "issue_id", "claim_text", "confidence", "why_it_matters")
-    ):
+    normalized_text_fields: dict[str, str] = {}
+    for field in ("claim_id", "issue_id", "claim_text", "confidence", "why_it_matters"):
+        value = item.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError("Malformed claim composer output.")
+        normalized_text_fields[field] = value.strip()
+    claim_kind = item.get("claim_kind")
+    if claim_kind not in VALID_CLAIM_KINDS:
         raise ValueError("Malformed claim composer output.")
-    if item.get("claim_kind") not in VALID_CLAIM_KINDS:
+    novelty = item.get("novelty_vs_prior_brief")
+    if novelty not in VALID_NOVELTY_LABELS:
         raise ValueError("Malformed claim composer output.")
-    if item.get("novelty_vs_prior_brief") not in VALID_NOVELTY_LABELS:
-        raise ValueError("Malformed claim composer output.")
+    normalized_citation_fields: dict[str, list[str]] = {}
     for field in ("supporting_citation_ids", "opposing_citation_ids"):
         values = item.get(field)
-        if not isinstance(values, list) or not all(isinstance(value, str) and value for value in values):
+        if not isinstance(values, list):
             raise ValueError("Malformed claim composer output.")
-    return cast(StructuredClaim, item)
+        normalized_values = []
+        for value in values:
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError("Malformed claim composer output.")
+            normalized_values.append(value.strip())
+        if field == "supporting_citation_ids" and not normalized_values:
+            raise ValueError("Malformed claim composer output.")
+        normalized_citation_fields[field] = normalized_values
+    return StructuredClaim(
+        claim_id=normalized_text_fields["claim_id"],
+        issue_id=normalized_text_fields["issue_id"],
+        claim_kind=claim_kind,
+        claim_text=normalized_text_fields["claim_text"],
+        supporting_citation_ids=normalized_citation_fields["supporting_citation_ids"],
+        opposing_citation_ids=normalized_citation_fields["opposing_citation_ids"],
+        confidence=normalized_text_fields["confidence"],
+        novelty_vs_prior_brief=novelty,
+        why_it_matters=normalized_text_fields["why_it_matters"],
+    )

--- a/apps/agent/daily_brief/prior_brief_context.py
+++ b/apps/agent/daily_brief/prior_brief_context.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+MAX_PRIOR_ISSUES = 3
+MAX_CLAIMS_PER_ISSUE = 2
+ISSUE_SECTION_ORDER = ("prevailing", "counter", "minority", "watch")
+
 
 def build_prior_brief_context(
     *,
@@ -12,25 +16,121 @@ def build_prior_brief_context(
     if not isinstance(previous_synthesis, Mapping):
         return None
 
-    claim_summaries: list[str] = []
-    citation_ids: list[str] = []
-    for section in ("prevailing", "counter", "minority", "watch"):
-        bullets = previous_synthesis.get(section, [])
-        if not isinstance(bullets, list):
-            continue
-        for bullet in bullets[:1]:
-            if not isinstance(bullet, Mapping):
-                continue
-            text = str(bullet.get("text", "")).strip()
-            if text:
-                claim_summaries.append(text)
-            current_citation_ids = bullet.get("citation_ids", [])
-            if isinstance(current_citation_ids, list):
-                for citation_id in current_citation_ids:
-                    citation_ids.append(str(citation_id))
+    issues = _extract_issue_contexts(previous_synthesis=previous_synthesis)
+    claim_summaries = [claim for issue in issues for claim in issue["claim_summaries"]]
+    citation_ids = [citation_id for issue in issues for citation_id in issue["citation_ids"]]
 
     return {
         "previous_generated_at_utc": previous_generated_at_utc,
+        "issue_count": len(issues),
+        "issues": issues,
         "claim_summaries": claim_summaries,
         "citation_ids": citation_ids,
     }
+
+
+def _extract_issue_contexts(*, previous_synthesis: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw_issues = previous_synthesis.get("issues")
+    if isinstance(raw_issues, list):
+        issue_contexts = [_build_issue_context(issue, index=index) for index, issue in enumerate(raw_issues, start=1)]
+        return [issue for issue in issue_contexts if issue][:MAX_PRIOR_ISSUES]
+
+    legacy_issue = _build_issue_context(
+        {
+            "issue_id": "prior_issue_001",
+            "issue_question": "Previous daily brief",
+            **{section: previous_synthesis.get(section, []) for section in ISSUE_SECTION_ORDER},
+        },
+        index=1,
+    )
+    return [] if legacy_issue is None else [legacy_issue]
+
+
+def _build_issue_context(issue: Any, *, index: int) -> dict[str, Any] | None:
+    if not isinstance(issue, Mapping):
+        return None
+
+    claim_summaries: list[str] = []
+    citation_ids: list[str] = []
+    source_refs: list[str] = []
+    for bullet in _iter_issue_bullets(issue)[:MAX_CLAIMS_PER_ISSUE]:
+        text = _as_non_empty_string(bullet.get("text"))
+        if text is not None:
+            claim_summaries.append(text)
+        citation_ids.extend(_extract_citation_ids(bullet))
+        source_refs.extend(_extract_source_refs(bullet))
+
+    issue_question = (
+        _as_non_empty_string(issue.get("issue_question"))
+        or _as_non_empty_string(issue.get("title"))
+        or f"Previous issue {index}"
+    )
+    return {
+        "issue_id": _as_non_empty_string(issue.get("issue_id")) or f"prior_issue_{index:03d}",
+        "issue_question": issue_question,
+        "summary": _as_non_empty_string(issue.get("summary")),
+        "claim_summaries": claim_summaries,
+        "citation_ids": _dedupe_preserve_order(citation_ids),
+        "source_refs": _dedupe_preserve_order(source_refs),
+    }
+
+
+def _iter_issue_bullets(issue: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    bullets: list[Mapping[str, Any]] = []
+    for section in ISSUE_SECTION_ORDER:
+        raw_bullets = issue.get(section)
+        if not isinstance(raw_bullets, list):
+            continue
+        for bullet in raw_bullets:
+            if isinstance(bullet, Mapping):
+                bullets.append(bullet)
+    return bullets
+
+
+def _extract_citation_ids(bullet: Mapping[str, Any]) -> list[str]:
+    raw_citation_ids = bullet.get("citation_ids")
+    if not isinstance(raw_citation_ids, list):
+        return []
+    citation_ids = []
+    for citation_id in raw_citation_ids:
+        normalized = _as_non_empty_string(citation_id)
+        if normalized is not None:
+            citation_ids.append(normalized)
+    return citation_ids
+
+
+def _extract_source_refs(bullet: Mapping[str, Any]) -> list[str]:
+    raw_evidence = bullet.get("evidence")
+    if not isinstance(raw_evidence, list):
+        return []
+    source_refs: list[str] = []
+    for evidence_item in raw_evidence:
+        if not isinstance(evidence_item, Mapping):
+            continue
+        publisher = _as_non_empty_string(evidence_item.get("publisher"))
+        published_at = _as_non_empty_string(evidence_item.get("published_at"))
+        if publisher and published_at:
+            source_refs.append(f"{publisher} @ {published_at}")
+        elif publisher:
+            source_refs.append(publisher)
+        elif published_at:
+            source_refs.append(published_at)
+    return source_refs
+
+
+def _dedupe_preserve_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+def _as_non_empty_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None

--- a/tests/agent/daily_brief/test_openai_claim_composer.py
+++ b/tests/agent/daily_brief/test_openai_claim_composer.py
@@ -7,6 +7,33 @@ from apps.agent.daily_brief.openai_claim_composer import OpenAIClaimComposer
 
 
 class OpenAIClaimComposerTests(unittest.TestCase):
+    def test_build_request_payload_preserves_issue_map_citation_store_and_prior_context(self) -> None:
+        composer = OpenAIClaimComposer(response_loader=lambda _brief_input: [])
+        brief_input = ClaimComposerInput(
+            run_id="run_001",
+            generated_at_utc="2026-03-12T00:00:00Z",
+            issue_map=[
+                {
+                    "issue_id": "issue_oil",
+                    "issue_question": "Will oil prices keep rising over the next few weeks?",
+                    "thesis_hint": "Supply concerns are keeping near-term pressure skewed upward.",
+                    "supporting_evidence_ids": ["chunk_1"],
+                    "opposing_evidence_ids": ["chunk_2"],
+                    "minority_evidence_ids": ["chunk_3"],
+                    "watch_evidence_ids": ["chunk_4"],
+                }
+            ],
+            citation_store={"cite_001": {"citation_id": "cite_001"}},
+            prior_brief_context={"issue_count": 1, "claim_summaries": ["Yesterday's prevailing claim."]},
+        )
+
+        payload = composer.build_request_payload(brief_input=brief_input)
+
+        self.assertEqual(payload["run_id"], "run_001")
+        self.assertEqual(payload["issue_map"][0]["issue_id"], "issue_oil")
+        self.assertEqual(payload["citation_store"]["cite_001"]["citation_id"], "cite_001")
+        self.assertEqual(payload["prior_brief_context"]["issue_count"], 1)
+
     def test_composes_claims_from_schema_valid_json(self) -> None:
         composer = OpenAIClaimComposer(
             response_loader=lambda _brief_input: """
@@ -49,6 +76,50 @@ class OpenAIClaimComposerTests(unittest.TestCase):
         self.assertEqual(result[0]["claim_kind"], "prevailing")
         self.assertEqual(result[0]["novelty_vs_prior_brief"], "strengthened")
 
+    def test_composes_claims_using_explicit_request_payload_boundary(self) -> None:
+        captured_payload = {}
+
+        def _loader(brief_input):
+            captured_payload.update(brief_input)
+            return [
+                {
+                    "claim_id": "claim_oil_prevailing",
+                    "issue_id": "issue_oil",
+                    "claim_kind": "prevailing",
+                    "claim_text": "Most sources still expect near-term upside in oil prices.",
+                    "supporting_citation_ids": ["cite_001", "cite_002"],
+                    "opposing_citation_ids": ["cite_003"],
+                    "confidence": "medium",
+                    "novelty_vs_prior_brief": "strengthened",
+                    "why_it_matters": "Near-term energy inflation risk remains elevated.",
+                }
+            ]
+
+        composer = OpenAIClaimComposer(response_loader=_loader)
+        result = composer.compose_claims(
+            brief_input=ClaimComposerInput(
+                run_id="run_001",
+                generated_at_utc="2026-03-12T00:00:00Z",
+                issue_map=[
+                    {
+                        "issue_id": "issue_oil",
+                        "issue_question": "Will oil prices keep rising over the next few weeks?",
+                        "thesis_hint": "Supply concerns are keeping near-term pressure skewed upward.",
+                        "supporting_evidence_ids": ["chunk_1"],
+                        "opposing_evidence_ids": ["chunk_2"],
+                        "minority_evidence_ids": ["chunk_3"],
+                        "watch_evidence_ids": ["chunk_4"],
+                    }
+                ],
+                citation_store={"cite_001": {"citation_id": "cite_001"}},
+                prior_brief_context={"issue_count": 1},
+            )
+        )
+
+        self.assertEqual(captured_payload["run_id"], "run_001")
+        self.assertEqual(captured_payload["prior_brief_context"]["issue_count"], 1)
+        self.assertEqual(result[0]["claim_id"], "claim_oil_prevailing")
+
     def test_rejects_malformed_claim_output(self) -> None:
         composer = OpenAIClaimComposer(response_loader=lambda _brief_input: '[{"claim_id": "missing_fields"}]')
 
@@ -76,6 +147,36 @@ class OpenAIClaimComposerTests(unittest.TestCase):
                 "opposing_citation_ids": ["cite_003"],
                 "confidence": "medium",
                 "novelty_vs_prior_brief": "stronger",
+                "why_it_matters": "Near-term energy inflation risk remains elevated."
+              }
+            ]
+            """
+        )
+
+        with self.assertRaises(ValueError):
+            composer.compose_claims(
+                brief_input=ClaimComposerInput(
+                    run_id="run_001",
+                    generated_at_utc="2026-03-12T00:00:00Z",
+                    issue_map=[],
+                    citation_store={},
+                    prior_brief_context=None,
+                )
+            )
+
+    def test_rejects_claims_without_supporting_citation_ids(self) -> None:
+        composer = OpenAIClaimComposer(
+            response_loader=lambda _brief_input: """
+            [
+              {
+                "claim_id": "claim_oil_prevailing",
+                "issue_id": "issue_oil",
+                "claim_kind": "prevailing",
+                "claim_text": "Most sources still expect near-term upside in oil prices.",
+                "supporting_citation_ids": [],
+                "opposing_citation_ids": ["cite_003"],
+                "confidence": "medium",
+                "novelty_vs_prior_brief": "unknown",
                 "why_it_matters": "Near-term energy inflation risk remains elevated."
               }
             ]

--- a/tests/agent/daily_brief/test_prior_brief_context.py
+++ b/tests/agent/daily_brief/test_prior_brief_context.py
@@ -6,7 +6,7 @@ from apps.agent.daily_brief.prior_brief_context import build_prior_brief_context
 
 
 class PriorBriefContextTests(unittest.TestCase):
-    def test_extracts_bounded_context_from_previous_synthesis(self) -> None:
+    def test_extracts_bounded_context_from_flat_previous_synthesis(self) -> None:
         previous_synthesis = {
             "prevailing": [{"text": "Prevailing claim.", "citation_ids": ["cite_001"]}],
             "counter": [{"text": "Counter claim.", "citation_ids": ["cite_002"]}],
@@ -21,6 +21,105 @@ class PriorBriefContextTests(unittest.TestCase):
         self.assertEqual(context["previous_generated_at_utc"], "2026-03-11T00:00:00Z")
         self.assertEqual(context["claim_summaries"], ["Prevailing claim.", "Counter claim."])
         self.assertEqual(context["citation_ids"], ["cite_001", "cite_002"])
+        self.assertEqual(context["issues"][0]["issue_question"], "Previous daily brief")
+        self.assertEqual(context["issues"][0]["claim_summaries"], ["Prevailing claim.", "Counter claim."])
+
+    def test_extracts_issue_centered_prior_questions_claims_and_source_refs(self) -> None:
+        previous_synthesis = {
+            "issues": [
+                {
+                    "issue_id": "issue_oil",
+                    "issue_question": "Will oil prices keep rising over the next few weeks?",
+                    "summary": "The prior brief leaned bullish on supply pressure.",
+                    "prevailing": [
+                        {
+                            "text": "Supply risks kept the short-term bias upward.",
+                            "citation_ids": ["cite_001"],
+                            "evidence": [
+                                {
+                                    "citation_id": "cite_001",
+                                    "publisher": "Reuters",
+                                    "published_at": "2026-03-11T01:00:00Z",
+                                    "support_text": "Supply disruptions stayed in focus.",
+                                }
+                            ],
+                        }
+                    ],
+                    "counter": [
+                        {
+                            "text": "Demand concerns could cap the move.",
+                            "citation_ids": ["cite_002"],
+                            "evidence": [
+                                {
+                                    "citation_id": "cite_002",
+                                    "publisher": "WSJ",
+                                    "published_at": "2026-03-11T02:00:00Z",
+                                    "support_text": "Demand concerns may cap the rally.",
+                                }
+                            ],
+                        }
+                    ],
+                    "minority": [],
+                    "watch": [],
+                }
+            ]
+        }
+
+        context = build_prior_brief_context(
+            previous_synthesis=previous_synthesis,
+            previous_generated_at_utc="2026-03-11T07:05:00Z",
+        )
+
+        self.assertEqual(context["previous_generated_at_utc"], "2026-03-11T07:05:00Z")
+        self.assertEqual(context["issue_count"], 1)
+        self.assertEqual(context["issues"][0]["issue_id"], "issue_oil")
+        self.assertEqual(
+            context["issues"][0]["issue_question"],
+            "Will oil prices keep rising over the next few weeks?",
+        )
+        self.assertEqual(
+            context["issues"][0]["claim_summaries"],
+            [
+                "Supply risks kept the short-term bias upward.",
+                "Demand concerns could cap the move.",
+            ],
+        )
+        self.assertEqual(context["issues"][0]["citation_ids"], ["cite_001", "cite_002"])
+        self.assertEqual(
+            context["issues"][0]["source_refs"],
+            [
+                "Reuters @ 2026-03-11T01:00:00Z",
+                "WSJ @ 2026-03-11T02:00:00Z",
+            ],
+        )
+
+    def test_bounds_issue_centered_context_to_three_issues_and_two_claims_per_issue(self) -> None:
+        previous_synthesis = {
+            "issues": [
+                {
+                    "issue_id": f"issue_{index}",
+                    "issue_question": f"Issue question {index}",
+                    "prevailing": [{"text": f"Prevailing {index}", "citation_ids": [f"cite_p_{index}"]}],
+                    "counter": [{"text": f"Counter {index}", "citation_ids": [f"cite_c_{index}"]}],
+                    "minority": [{"text": f"Minority {index}", "citation_ids": [f"cite_m_{index}"]}],
+                    "watch": [{"text": f"Watch {index}", "citation_ids": [f"cite_w_{index}"]}],
+                }
+                for index in range(1, 5)
+            ]
+        }
+
+        context = build_prior_brief_context(
+            previous_synthesis=previous_synthesis,
+            previous_generated_at_utc="2026-03-11T07:05:00Z",
+        )
+
+        self.assertEqual(context["issue_count"], 3)
+        self.assertEqual([issue["issue_id"] for issue in context["issues"]], ["issue_1", "issue_2", "issue_3"])
+        self.assertEqual(
+            context["issues"][0]["claim_summaries"],
+            ["Prevailing 1", "Counter 1"],
+        )
+        self.assertEqual(len(context["claim_summaries"]), 6)
 
     def test_returns_none_when_previous_synthesis_missing(self) -> None:
         self.assertIsNone(


### PR DESCRIPTION
## Summary
- harden the OpenAI claim composer adapter with explicit request and parse boundaries
- upgrade prior-brief context extraction to issue-centered bounded context with source refs
- strengthen unit coverage for schema validation and prior-brief shaping

## Validation
- python -m unittest tests.agent.daily_brief.test_openai_claim_composer tests.agent.daily_brief.test_prior_brief_context -v
- python -m ruff check apps/agent/daily_brief/openai_claim_composer.py apps/agent/daily_brief/prior_brief_context.py tests/agent/daily_brief/test_openai_claim_composer.py tests/agent/daily_brief/test_prior_brief_context.py

Closes #104
