### PR TITLE
feat(daily-brief): wire OpenAI runtime providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ Run the deterministic fixture-backed daily brief slice:
 python scripts/run_daily_brief_fixture.py
 ```
 
+Run the fixture slice with real OpenAI issue planning and claim composition:
+
+```bash
+set OPENAI_API_KEY=...
+python scripts/run_daily_brief_fixture.py --provider openai --openai-model gpt-4o-mini
+```
+
 Run the fixture slice with the modeled Asia/Singapore schedule and email delivery:
 
 ```bash

--- a/apps/agent/daily_brief/openai_runtime.py
+++ b/apps/agent/daily_brief/openai_runtime.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping
+from typing import Any, cast
+
+from apps.agent.daily_brief.model_interfaces import (
+    ClaimComposerInput,
+    ClaimComposerProvider,
+    IssuePlannerProvider,
+)
+from apps.agent.daily_brief.openai_claim_composer import OpenAIClaimComposer
+from apps.agent.daily_brief.openai_issue_planner import OpenAIIssuePlanner
+
+DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
+OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
+OPENAI_BASE_URL_ENV = "OPENAI_BASE_URL"
+OPENAI_ORGANIZATION_ENV = "OPENAI_ORGANIZATION"
+OPENAI_PROJECT_ENV = "OPENAI_PROJECT"
+
+
+class OpenAIResponsesTextClient:
+    def __init__(self, *, client: Any, model: str) -> None:
+        self._client = client
+        self._model = model
+
+    def create_json_response(self, request_payload: Mapping[str, Any]) -> str:
+        system_message, input_messages = _split_messages(request_payload=request_payload)
+        text_format = _build_text_format(request_payload=request_payload)
+        response = self._client.responses.create(
+            model=self._model,
+            instructions=system_message,
+            input=input_messages,
+            text={"format": text_format},
+        )
+        output_text = getattr(response, "output_text", None)
+        if not isinstance(output_text, str) or not output_text.strip():
+            raise ValueError("OpenAI response did not include output_text.")
+        return output_text
+
+
+def build_openai_daily_brief_providers(
+    *,
+    api_key: str | None = None,
+    model: str = DEFAULT_OPENAI_MODEL,
+    base_url: str | None = None,
+    organization: str | None = None,
+    project: str | None = None,
+    timeout_seconds: float = 60.0,
+    client_factory: Callable[..., Any] | None = None,
+) -> tuple[IssuePlannerProvider, ClaimComposerProvider]:
+    resolved_api_key = api_key or os.environ.get(OPENAI_API_KEY_ENV)
+    if not resolved_api_key:
+        raise ValueError(f"OpenAI provider requires {OPENAI_API_KEY_ENV}.")
+
+    resolved_client_factory = client_factory or _load_openai_client_factory()
+    client_kwargs: dict[str, Any] = {
+        "api_key": resolved_api_key,
+        "timeout": timeout_seconds,
+    }
+    resolved_base_url = base_url or os.environ.get(OPENAI_BASE_URL_ENV)
+    resolved_organization = organization or os.environ.get(OPENAI_ORGANIZATION_ENV)
+    resolved_project = project or os.environ.get(OPENAI_PROJECT_ENV)
+    if resolved_base_url:
+        client_kwargs["base_url"] = resolved_base_url
+    if resolved_organization:
+        client_kwargs["organization"] = resolved_organization
+    if resolved_project:
+        client_kwargs["project"] = resolved_project
+
+    runtime_client = OpenAIResponsesTextClient(
+        client=resolved_client_factory(**client_kwargs),
+        model=model,
+    )
+    response_loader = runtime_client.create_json_response
+    return (
+        OpenAIIssuePlanner(response_loader=response_loader),
+        OpenAIClaimComposer(
+            response_loader=cast(
+                Callable[[ClaimComposerInput], str | list[dict[str, Any]]],
+                response_loader,
+            )
+        ),
+    )
+
+
+def _load_openai_client_factory() -> Callable[..., Any]:
+    try:
+        from openai import OpenAI
+    except ImportError as exc:
+        raise ValueError("OpenAI runtime requires the `openai` package to be installed.") from exc
+    return OpenAI
+
+
+def _split_messages(*, request_payload: Mapping[str, Any]) -> tuple[str | None, list[dict[str, str]]]:
+    raw_messages = request_payload.get("messages")
+    if not isinstance(raw_messages, list) or not raw_messages:
+        raise ValueError("OpenAI request payload requires at least one message.")
+
+    instructions: str | None = None
+    input_messages: list[dict[str, str]] = []
+    for index, item in enumerate(raw_messages):
+        if not isinstance(item, Mapping):
+            raise ValueError("OpenAI request payload contains an invalid message.")
+        role = str(item.get("role") or "").strip()
+        content = str(item.get("content") or "").strip()
+        if not role or not content:
+            raise ValueError("OpenAI request payload contains an invalid message.")
+        if index == 0 and role == "system":
+            instructions = content
+            continue
+        input_messages.append({"role": role, "content": content})
+    if not input_messages:
+        raise ValueError("OpenAI request payload requires at least one non-system message.")
+    return instructions, input_messages
+
+
+def _build_text_format(*, request_payload: Mapping[str, Any]) -> dict[str, Any]:
+    response_format = request_payload.get("response_format")
+    if not isinstance(response_format, Mapping):
+        raise ValueError("OpenAI request payload requires response_format.")
+    if response_format.get("type") != "json_schema":
+        raise ValueError("OpenAI request payload requires a json_schema response_format.")
+    json_schema = response_format.get("json_schema")
+    if not isinstance(json_schema, Mapping):
+        raise ValueError("OpenAI request payload requires json_schema details.")
+    name = str(json_schema.get("name") or "").strip()
+    schema = json_schema.get("schema")
+    if not name or not isinstance(schema, Mapping):
+        raise ValueError("OpenAI request payload requires a named schema.")
+    return {
+        "type": "json_schema",
+        "name": name,
+        "schema": dict(schema),
+        "strict": bool(json_schema.get("strict", False)),
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Local-first financial news and macro literature-review assistant.
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+  "openai>=2,<3",
   "PyYAML==6.0.2",
   "pypdf>=5,<6",
 ]

--- a/scripts/run_daily_brief.py
+++ b/scripts/run_daily_brief.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the live daily brief on the active source subset.")
@@ -26,15 +28,34 @@ def parse_args() -> argparse.Namespace:
         default=[],
         help="Recipient address for email delivery. Repeat for multiple recipients.",
     )
+    parser.add_argument(
+        "--provider",
+        choices=("deterministic", "openai"),
+        default="deterministic",
+        help="Daily-brief synthesis provider mode.",
+    )
+    parser.add_argument(
+        "--openai-model",
+        default=os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
+        help="OpenAI model name when --provider openai is used.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
+    from apps.agent.daily_brief.openai_runtime import build_openai_daily_brief_providers
     from apps.agent.daily_brief.runner import run_daily_brief
     from apps.agent.delivery.email_sender import EmailDeliveryConfig
     from apps.agent.delivery.scheduler import DailyBriefSchedule
 
     args = parse_args()
+    issue_planner = None
+    claim_composer = None
+    if args.provider == "openai":
+        try:
+            issue_planner, claim_composer = build_openai_daily_brief_providers(model=args.openai_model)
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
     email_config = None
     if args.smtp_host or args.sender_email or args.recipient_email:
         if not args.smtp_host or not args.sender_email or not args.recipient_email:
@@ -55,6 +76,8 @@ def main() -> None:
             delivery_minute=args.delivery_minute,
         ),
         email_config=email_config,
+        issue_planner=issue_planner,
+        claim_composer=claim_composer,
     )
     print(json.dumps(result, indent=2))
     if result["status"] == "failed":

--- a/scripts/run_daily_brief_fixture.py
+++ b/scripts/run_daily_brief_fixture.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the deterministic daily-brief fixture slice.")
@@ -27,15 +29,34 @@ def parse_args() -> argparse.Namespace:
         default=[],
         help="Recipient address for email delivery. Repeat for multiple recipients.",
     )
+    parser.add_argument(
+        "--provider",
+        choices=("deterministic", "openai"),
+        default="deterministic",
+        help="Daily-brief synthesis provider mode.",
+    )
+    parser.add_argument(
+        "--openai-model",
+        default=os.environ.get("OPENAI_MODEL", "gpt-4o-mini"),
+        help="OpenAI model name when --provider openai is used.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
+    from apps.agent.daily_brief.openai_runtime import build_openai_daily_brief_providers
     from apps.agent.daily_brief.runner import run_fixture_daily_brief
     from apps.agent.delivery.email_sender import EmailDeliveryConfig
     from apps.agent.delivery.scheduler import DailyBriefSchedule
 
     args = parse_args()
+    issue_planner = None
+    claim_composer = None
+    if args.provider == "openai":
+        try:
+            issue_planner, claim_composer = build_openai_daily_brief_providers(model=args.openai_model)
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
     email_config = None
     if args.smtp_host or args.sender_email or args.recipient_email:
         if not args.smtp_host or not args.sender_email or not args.recipient_email:
@@ -57,6 +78,8 @@ def main() -> None:
             delivery_minute=args.delivery_minute,
         ),
         email_config=email_config,
+        issue_planner=issue_planner,
+        claim_composer=claim_composer,
     )
     print(json.dumps(result, indent=2))
     if result["status"] == "failed":

--- a/tests/agent/daily_brief/test_openai_runtime.py
+++ b/tests/agent/daily_brief/test_openai_runtime.py
@@ -1,0 +1,120 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from apps.agent.daily_brief.openai_claim_composer import OpenAIClaimComposer
+from apps.agent.daily_brief.openai_issue_planner import OpenAIIssuePlanner
+from apps.agent.daily_brief.openai_runtime import (
+    DEFAULT_OPENAI_MODEL,
+    OpenAIResponsesTextClient,
+    build_openai_daily_brief_providers,
+)
+
+
+class _FakeResponsesApi:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        payload = json.dumps(
+            [
+                {
+                    "issue_id": "issue_001",
+                    "issue_question": "Will growth slow enough to change Fed expectations?",
+                    "thesis_hint": "Growth is cooling while inflation remains uneven.",
+                    "supporting_evidence_ids": ["chunk_001"],
+                    "opposing_evidence_ids": ["chunk_002"],
+                    "minority_evidence_ids": ["chunk_003"],
+                    "watch_evidence_ids": ["chunk_004"],
+                }
+            ]
+        )
+        return type("FakeResponse", (), {"output_text": payload})()
+
+
+class _FakeOpenAIClient:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.responses = _FakeResponsesApi()
+
+
+class OpenAIRuntimeTests(unittest.TestCase):
+    def test_build_openai_daily_brief_providers_requires_api_key(self) -> None:
+        with self.assertRaises(ValueError):
+            build_openai_daily_brief_providers(api_key=None, client_factory=_FakeOpenAIClient)
+
+    def test_build_openai_daily_brief_providers_returns_runtime_backed_adapters(self) -> None:
+        planner, composer = build_openai_daily_brief_providers(
+            api_key="test-key",
+            model="gpt-4o-mini",
+            client_factory=_FakeOpenAIClient,
+        )
+
+        self.assertIsInstance(planner, OpenAIIssuePlanner)
+        self.assertIsInstance(composer, OpenAIClaimComposer)
+
+    def test_openai_responses_text_client_translates_request_payload(self) -> None:
+        fake_client = _FakeOpenAIClient(api_key="test-key")
+        runtime_client = OpenAIResponsesTextClient(client=fake_client, model="gpt-4o-mini")
+
+        output_text = runtime_client.create_json_response(
+            {
+                "messages": [
+                    {"role": "system", "content": "Plan issue-centered topics."},
+                    {"role": "user", "content": "Return strict JSON."},
+                ],
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "issue_map_list",
+                        "strict": True,
+                        "schema": {"type": "array"},
+                    },
+                },
+            }
+        )
+
+        self.assertIn('"issue_id": "issue_001"', output_text)
+        call = fake_client.responses.calls[0]
+        self.assertEqual(call["model"], "gpt-4o-mini")
+        self.assertEqual(call["instructions"], "Plan issue-centered topics.")
+        self.assertEqual(call["input"], [{"role": "user", "content": "Return strict JSON."}])
+        self.assertEqual(call["text"]["format"]["type"], "json_schema")
+        self.assertEqual(call["text"]["format"]["name"], "issue_map_list")
+        self.assertTrue(call["text"]["format"]["strict"])
+
+    def test_fixture_script_fails_clearly_when_openai_provider_requested_without_key(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        script_path = repo_root / "scripts" / "run_daily_brief_fixture.py"
+        env = dict(os.environ)
+        env.pop("OPENAI_API_KEY", None)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(script_path),
+                    "--base-dir",
+                    tmpdir,
+                    "--provider",
+                    "openai",
+                    "--openai-model",
+                    DEFAULT_OPENAI_MODEL,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+            )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("OPENAI_API_KEY", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- wire a real OpenAI runtime client boundary into the daily-brief adapters
- add --provider openai support to the daily brief scripts
- fail clearly when OpenAI mode is requested without OPENAI_API_KEY
- document the OpenAI-backed fixture demo path and add focused runtime tests

## Validation
- python -m unittest tests.agent.daily_brief.test_openai_runtime -v
- python -m unittest tests.agent.daily_brief.test_runner tests.agent.daily_brief.test_openai_runtime -v
- python -m ruff check apps/agent/daily_brief/openai_runtime.py scripts/run_daily_brief.py scripts/run_daily_brief_fixture.py tests/agent/daily_brief/test_openai_runtime.py
- python -m mypy apps
- python scripts/validate_artifacts.py
- python -m compileall -q apps tests scripts
- python scripts/run_daily_brief_fixture.py --base-dir .tmp_openai_provider_check --provider openai --openai-model gpt-4o-mini

Closes #108