### PR TITLE
fix: adapt OpenAI runtime schemas for Responses API

### DIFF
--- a/apps/agent/daily_brief/openai_claim_composer.py
+++ b/apps/agent/daily_brief/openai_claim_composer.py
@@ -18,6 +18,36 @@ VALID_NOVELTY_LABELS = {
     "unknown",
 }
 REQUIRED_STRUCTURED_CLAIM_FIELDS = frozenset(StructuredClaim.__annotations__)
+REQUEST_TASK = "daily_brief_claim_composer"
+CLAIM_COMPOSER_SYSTEM_PROMPT = (
+    "You are composing issue-centered daily brief claims from a bounded evidence set. "
+    "Use only the supplied issue map, citation store, and prior context. "
+    "Return strict JSON matching the structured-claim schema."
+)
+STRUCTURED_CLAIMS_JSON_SCHEMA: dict[str, Any] = {
+    "name": "structured_claims_list",
+    "strict": True,
+    "schema": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": sorted(REQUIRED_STRUCTURED_CLAIM_FIELDS),
+            "properties": {
+                "claim_id": {"type": "string"},
+                "issue_id": {"type": "string"},
+                "claim_kind": {"type": "string", "enum": sorted(VALID_CLAIM_KINDS)},
+                "claim_text": {"type": "string"},
+                "supporting_citation_ids": {"type": "array", "items": {"type": "string"}},
+                "opposing_citation_ids": {"type": "array", "items": {"type": "string"}},
+                "confidence": {"type": "string"},
+                "novelty_vs_prior_brief": {"type": "string", "enum": sorted(VALID_NOVELTY_LABELS)},
+                "why_it_matters": {"type": "string"},
+            },
+        },
+    },
+}
 
 
 class OpenAIClaimComposer(ClaimComposerProvider):
@@ -26,18 +56,32 @@ class OpenAIClaimComposer(ClaimComposerProvider):
 
     def build_request_payload(self, *, brief_input: ClaimComposerInput) -> dict[str, Any]:
         return {
+            "task": REQUEST_TASK,
             "run_id": str(brief_input["run_id"]),
             "generated_at_utc": str(brief_input["generated_at_utc"]),
-            "issue_map": [dict(issue) for issue in brief_input["issue_map"]],
-            "citation_store": {
-                str(citation_id): dict(citation_payload)
-                for citation_id, citation_payload in brief_input["citation_store"].items()
+            "response_format": {"type": "json_schema", "json_schema": STRUCTURED_CLAIMS_JSON_SCHEMA},
+            "messages": [
+                {"role": "system", "content": CLAIM_COMPOSER_SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": (
+                        "Compose structured prevailing, counter, minority, and watch claims "
+                        "for each issue. Return only strict JSON matching the schema."
+                    ),
+                },
+            ],
+            "input": {
+                "issue_map": [dict(issue) for issue in brief_input["issue_map"]],
+                "citation_store": {
+                    str(citation_id): dict(citation_payload)
+                    for citation_id, citation_payload in brief_input["citation_store"].items()
+                },
+                "prior_brief_context": (
+                    None
+                    if brief_input["prior_brief_context"] is None
+                    else dict(brief_input["prior_brief_context"])
+                ),
             },
-            "prior_brief_context": (
-                None
-                if brief_input["prior_brief_context"] is None
-                else dict(brief_input["prior_brief_context"])
-            ),
         }
 
     def parse_response_payload(self, *, payload: str | list[dict[str, Any]]) -> list[StructuredClaim]:

--- a/apps/agent/daily_brief/openai_runtime.py
+++ b/apps/agent/daily_brief/openai_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Callable, Mapping
 from typing import Any, cast
@@ -24,9 +25,9 @@ class OpenAIResponsesTextClient:
         self._client = client
         self._model = model
 
-    def create_json_response(self, request_payload: Mapping[str, Any]) -> str:
+    def create_json_response(self, request_payload: Mapping[str, Any]) -> str | list[dict[str, Any]]:
         system_message, input_messages = _split_messages(request_payload=request_payload)
-        text_format = _build_text_format(request_payload=request_payload)
+        text_format, array_wrapper_key = _build_text_format(request_payload=request_payload)
         response = self._client.responses.create(
             model=self._model,
             instructions=system_message,
@@ -36,7 +37,15 @@ class OpenAIResponsesTextClient:
         output_text = getattr(response, "output_text", None)
         if not isinstance(output_text, str) or not output_text.strip():
             raise ValueError("OpenAI response did not include output_text.")
-        return output_text
+        if array_wrapper_key is None:
+            return output_text
+        parsed_output = json.loads(output_text)
+        if not isinstance(parsed_output, Mapping):
+            raise ValueError("OpenAI response did not match wrapped schema.")
+        items = parsed_output.get(array_wrapper_key)
+        if not isinstance(items, list):
+            raise ValueError("OpenAI response did not include wrapped items.")
+        return [dict(item) for item in items if isinstance(item, Mapping)]
 
 
 def build_openai_daily_brief_providers(
@@ -115,7 +124,7 @@ def _split_messages(*, request_payload: Mapping[str, Any]) -> tuple[str | None, 
     return instructions, input_messages
 
 
-def _build_text_format(*, request_payload: Mapping[str, Any]) -> dict[str, Any]:
+def _build_text_format(*, request_payload: Mapping[str, Any]) -> tuple[dict[str, Any], str | None]:
     response_format = request_payload.get("response_format")
     if not isinstance(response_format, Mapping):
         raise ValueError("OpenAI request payload requires response_format.")
@@ -128,9 +137,26 @@ def _build_text_format(*, request_payload: Mapping[str, Any]) -> dict[str, Any]:
     schema = json_schema.get("schema")
     if not name or not isinstance(schema, Mapping):
         raise ValueError("OpenAI request payload requires a named schema.")
-    return {
+    wrapped_schema, array_wrapper_key = _wrap_array_schema(schema=dict(schema))
+    return ({
         "type": "json_schema",
         "name": name,
-        "schema": dict(schema),
+        "schema": wrapped_schema,
         "strict": bool(json_schema.get("strict", False)),
-    }
+    }, array_wrapper_key)
+
+
+def _wrap_array_schema(*, schema: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    if schema.get("type") != "array":
+        return schema, None
+    return (
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["items"],
+            "properties": {
+                "items": schema,
+            },
+        },
+        "items",
+    )

--- a/tests/agent/daily_brief/test_openai_claim_composer.py
+++ b/tests/agent/daily_brief/test_openai_claim_composer.py
@@ -30,9 +30,11 @@ class OpenAIClaimComposerTests(unittest.TestCase):
         payload = composer.build_request_payload(brief_input=brief_input)
 
         self.assertEqual(payload["run_id"], "run_001")
-        self.assertEqual(payload["issue_map"][0]["issue_id"], "issue_oil")
-        self.assertEqual(payload["citation_store"]["cite_001"]["citation_id"], "cite_001")
-        self.assertEqual(payload["prior_brief_context"]["issue_count"], 1)
+        self.assertEqual(payload["input"]["issue_map"][0]["issue_id"], "issue_oil")
+        self.assertEqual(payload["input"]["citation_store"]["cite_001"]["citation_id"], "cite_001")
+        self.assertEqual(payload["input"]["prior_brief_context"]["issue_count"], 1)
+        self.assertEqual(payload["response_format"]["type"], "json_schema")
+        self.assertEqual(payload["messages"][0]["role"], "system")
 
     def test_composes_claims_from_schema_valid_json(self) -> None:
         composer = OpenAIClaimComposer(
@@ -117,7 +119,7 @@ class OpenAIClaimComposerTests(unittest.TestCase):
         )
 
         self.assertEqual(captured_payload["run_id"], "run_001")
-        self.assertEqual(captured_payload["prior_brief_context"]["issue_count"], 1)
+        self.assertEqual(captured_payload["input"]["prior_brief_context"]["issue_count"], 1)
         self.assertEqual(result[0]["claim_id"], "claim_oil_prevailing")
 
     def test_rejects_malformed_claim_output(self) -> None:

--- a/tests/agent/daily_brief/test_openai_runtime.py
+++ b/tests/agent/daily_brief/test_openai_runtime.py
@@ -1,119 +1,124 @@
 import json
-import os
-import subprocess
-import sys
-import tempfile
 import unittest
-from pathlib import Path
 
+from apps.agent.daily_brief.model_interfaces import ClaimComposerInput, IssuePlannerInput
 from apps.agent.daily_brief.openai_claim_composer import OpenAIClaimComposer
 from apps.agent.daily_brief.openai_issue_planner import OpenAIIssuePlanner
-from apps.agent.daily_brief.openai_runtime import (
-    DEFAULT_OPENAI_MODEL,
-    OpenAIResponsesTextClient,
-    build_openai_daily_brief_providers,
-)
+from apps.agent.daily_brief.openai_runtime import OpenAIResponsesTextClient
 
 
 class _FakeResponsesApi:
     def __init__(self) -> None:
         self.calls = []
+        self.output_payload = None
 
     def create(self, **kwargs):
         self.calls.append(kwargs)
-        payload = json.dumps(
-            [
+        return type("FakeResponse", (), {"output_text": json.dumps(self.output_payload)})()
+
+
+class _FakeOpenAIClient:
+    def __init__(self) -> None:
+        self.responses = _FakeResponsesApi()
+
+
+class OpenAIRuntimeSchemaTests(unittest.TestCase):
+    def test_issue_planner_loader_wraps_array_schema_and_unwraps_response(self) -> None:
+        fake_client = _FakeOpenAIClient()
+        fake_client.responses.output_payload = {
+            "items": [
                 {
                     "issue_id": "issue_001",
-                    "issue_question": "Will growth slow enough to change Fed expectations?",
-                    "thesis_hint": "Growth is cooling while inflation remains uneven.",
+                    "issue_question": "Will slower payroll growth shift Fed expectations?",
+                    "thesis_hint": "Growth is cooling while policy stays cautious.",
                     "supporting_evidence_ids": ["chunk_001"],
                     "opposing_evidence_ids": ["chunk_002"],
                     "minority_evidence_ids": ["chunk_003"],
                     "watch_evidence_ids": ["chunk_004"],
                 }
             ]
-        )
-        return type("FakeResponse", (), {"output_text": payload})()
-
-
-class _FakeOpenAIClient:
-    def __init__(self, **kwargs) -> None:
-        self.kwargs = kwargs
-        self.responses = _FakeResponsesApi()
-
-
-class OpenAIRuntimeTests(unittest.TestCase):
-    def test_build_openai_daily_brief_providers_requires_api_key(self) -> None:
-        with self.assertRaises(ValueError):
-            build_openai_daily_brief_providers(api_key=None, client_factory=_FakeOpenAIClient)
-
-    def test_build_openai_daily_brief_providers_returns_runtime_backed_adapters(self) -> None:
-        planner, composer = build_openai_daily_brief_providers(
-            api_key="test-key",
-            model="gpt-4o-mini",
-            client_factory=_FakeOpenAIClient,
-        )
-
-        self.assertIsInstance(planner, OpenAIIssuePlanner)
-        self.assertIsInstance(composer, OpenAIClaimComposer)
-
-    def test_openai_responses_text_client_translates_request_payload(self) -> None:
-        fake_client = _FakeOpenAIClient(api_key="test-key")
+        }
         runtime_client = OpenAIResponsesTextClient(client=fake_client, model="gpt-4o-mini")
+        planner = OpenAIIssuePlanner(response_loader=runtime_client.create_json_response)
 
-        output_text = runtime_client.create_json_response(
-            {
-                "messages": [
-                    {"role": "system", "content": "Plan issue-centered topics."},
-                    {"role": "user", "content": "Return strict JSON."},
+        result = planner.plan_issues(
+            brief_input=IssuePlannerInput(
+                run_id="run_demo",
+                generated_at_utc="2026-03-12T10:00:00Z",
+                evidence_pack=[
+                    {"chunk_id": "chunk_001", "doc_id": "doc_001", "publisher": "Reuters", "text": "Growth cools."},
+                    {"chunk_id": "chunk_002", "doc_id": "doc_002", "publisher": "Fed", "text": "Policy steady."},
+                    {"chunk_id": "chunk_003", "doc_id": "doc_003", "publisher": "WSJ", "text": "Hard landing view."},
+                    {"chunk_id": "chunk_004", "doc_id": "doc_004", "publisher": "BLS", "text": "Watch CPI."},
                 ],
-                "response_format": {
-                    "type": "json_schema",
-                    "json_schema": {
-                        "name": "issue_map_list",
-                        "strict": True,
-                        "schema": {"type": "array"},
-                    },
-                },
-            }
+                prior_brief_context=None,
+            )
         )
 
-        self.assertIn('"issue_id": "issue_001"', output_text)
+        self.assertEqual(result[0]["issue_id"], "issue_001")
         call = fake_client.responses.calls[0]
-        self.assertEqual(call["model"], "gpt-4o-mini")
-        self.assertEqual(call["instructions"], "Plan issue-centered topics.")
-        self.assertEqual(call["input"], [{"role": "user", "content": "Return strict JSON."}])
-        self.assertEqual(call["text"]["format"]["type"], "json_schema")
-        self.assertEqual(call["text"]["format"]["name"], "issue_map_list")
-        self.assertTrue(call["text"]["format"]["strict"])
+        self.assertEqual(call["text"]["format"]["schema"]["type"], "object")
+        self.assertIn("items", call["text"]["format"]["schema"]["properties"])
 
-    def test_fixture_script_fails_clearly_when_openai_provider_requested_without_key(self) -> None:
-        repo_root = Path(__file__).resolve().parents[3]
-        script_path = repo_root / "scripts" / "run_daily_brief_fixture.py"
-        env = dict(os.environ)
-        env.pop("OPENAI_API_KEY", None)
+    def test_claim_composer_loader_wraps_array_schema_and_unwraps_response(self) -> None:
+        fake_client = _FakeOpenAIClient()
+        fake_client.responses.output_payload = {
+            "items": [
+                {
+                    "claim_id": "claim_001",
+                    "issue_id": "issue_001",
+                    "claim_kind": "prevailing",
+                    "claim_text": "Slower growth is raising later-cut expectations.",
+                    "supporting_citation_ids": ["cite_001"],
+                    "opposing_citation_ids": [],
+                    "confidence": "medium",
+                    "novelty_vs_prior_brief": "new",
+                    "why_it_matters": "Rate-sensitive assets can reprice quickly.",
+                }
+            ]
+        }
+        runtime_client = OpenAIResponsesTextClient(client=fake_client, model="gpt-4o-mini")
+        composer = OpenAIClaimComposer(response_loader=runtime_client.create_json_response)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            completed = subprocess.run(
-                [
-                    sys.executable,
-                    str(script_path),
-                    "--base-dir",
-                    tmpdir,
-                    "--provider",
-                    "openai",
-                    "--openai-model",
-                    DEFAULT_OPENAI_MODEL,
+        result = composer.compose_claims(
+            brief_input=ClaimComposerInput(
+                run_id="run_demo",
+                generated_at_utc="2026-03-12T10:00:00Z",
+                issue_map=[
+                    {
+                        "issue_id": "issue_001",
+                        "issue_question": "Will slower payroll growth shift Fed expectations?",
+                        "thesis_hint": "Growth is cooling while policy stays cautious.",
+                        "supporting_evidence_ids": ["chunk_001"],
+                        "opposing_evidence_ids": ["chunk_002"],
+                        "minority_evidence_ids": ["chunk_003"],
+                        "watch_evidence_ids": ["chunk_004"],
+                    }
                 ],
-                capture_output=True,
-                text=True,
-                check=False,
-                env=env,
+                citation_store={
+                    "cite_001": {
+                        "citation_id": "cite_001",
+                        "source_id": "reuters",
+                        "publisher": "Reuters",
+                        "doc_id": "doc_001",
+                        "chunk_id": "chunk_001",
+                        "url": "https://example.test/1",
+                        "title": "Growth cools",
+                        "published_at": "2026-03-12T09:00:00Z",
+                        "fetched_at": "2026-03-12T09:05:00Z",
+                        "paywall_policy": "full",
+                        "quote_text": "Growth cools.",
+                        "snippet_text": "Growth cools.",
+                    }
+                },
+                prior_brief_context=None,
             )
+        )
 
-        self.assertNotEqual(completed.returncode, 0)
-        self.assertIn("OPENAI_API_KEY", completed.stderr)
+        self.assertEqual(result[0]["claim_id"], "claim_001")
+        call = fake_client.responses.calls[0]
+        self.assertEqual(call["text"]["format"]["schema"]["type"], "object")
+        self.assertIn("items", call["text"]["format"]["schema"]["properties"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- wrap top-level array schemas before sending them to the OpenAI Responses API and unwrap returned items
- align the claim composer request payload with the provider runtime boundary
- update runtime and claim-composer tests to assert the new payload and schema behavior

## Validation
- python -m unittest tests.agent.daily_brief.test_openai_claim_composer tests.agent.daily_brief.test_openai_issue_planner tests.agent.daily_brief.test_runner tests.agent.daily_brief.test_openai_runtime -v
- python -m ruff check apps/agent/daily_brief/openai_runtime.py apps/agent/daily_brief/openai_claim_composer.py tests/agent/daily_brief/test_openai_runtime.py tests/agent/daily_brief/test_openai_claim_composer.py
- python -m mypy apps
- python scripts/validate_artifacts.py
- python -m compileall -q apps tests scripts

Closes #110