### PR TITLE
docs: redesign daily brief provider runtime for Codex OAuth

### DIFF
--- a/artifacts/PRD.md
+++ b/artifacts/PRD.md
@@ -32,7 +32,9 @@ The product goal is not to summarize sources one by one. It should identify the 
 - **Major event alerts:** notify on significant events with rate limiting.
 - **Cite everything:** every delivered claim must have valid evidence coverage.
 - **Local-first evidence layer:** runs on the user's machine; portfolio data stored locally.
-- **Model-assisted synthesis:** provider-agnostic interface with OpenAI as the first supported provider.
+- **Model-assisted synthesis:** provider-agnostic interface with two first-class runtime paths:
+  - OpenAI API via project-scoped API key
+  - Codex OAuth via local `codex login` / ChatGPT sign-in
 - **Lightweight UI:**
   - local daily analysis page (static HTML)
   - email delivery for daily brief and alerts
@@ -183,7 +185,25 @@ The claim composer must output JSON objects similar to:
 
 Free-form prose generation without structured JSON is out of scope for the model interface.
 
-### 6.7 Daily brief delivery
+### 6.7 Provider Runtime Modes
+The model layer must stay provider-agnostic above the transport/runtime boundary.
+
+Supported runtime modes:
+- `deterministic`
+  - no model calls; legacy local fallback for fixtures and abstain-safe paths
+- `openai`
+  - uses OpenAI API credentials and quota via the Responses API
+- `codex-oauth`
+  - uses the locally authenticated Codex CLI runtime backed by ChatGPT sign-in
+  - must not require `OPENAI_API_KEY`
+
+Provider invariants:
+- issue planner and claim composer still consume the same internal typed inputs
+- issue planner and claim composer still return the same schema-valid JSON
+- renderer, validator, and decision record layers must not care which provider runtime produced the JSON
+- provider switching must not weaken citation, paywall, or budget constraints
+
+### 6.8 Daily brief delivery
 - Generate once per day in user timezone.
 - Deliver via:
   - email
@@ -191,7 +211,7 @@ Free-form prose generation without structured JSON is out of scope for the model
 - Show exact evidence supporting each argument.
 - Show what changed since the prior brief through claim-level delta, not a renderer-only heuristic.
 
-### 6.8 Major event alerts
+### 6.9 Major event alerts
 Trigger categories (v1):
 - **Policy (Tier 1):** new central bank statement/minutes/speech/press release
 - **Macro releases (Tier 1):** CPI/jobs/GDP and other major official releases
@@ -205,7 +225,7 @@ Rate limiting:
 - enforce cooldown + daily cap
 - bundle minor items into next daily brief
 
-### 6.9 Portfolio input & relevance
+### 6.10 Portfolio input & relevance
 UI allows manual input:
 - tickers + weights (required)
 
@@ -231,11 +251,13 @@ Outputs:
 ### 7.3 Privacy & security
 - Portfolio stored locally.
 - API keys stored locally in environment variables / `.env` (never committed).
+- Codex OAuth credentials remain under the user's local Codex auth store and must not be copied into repo artifacts.
 
 ### 7.4 Maintainability
 - Source registry is config-driven.
 - Modular components: ingestion, extraction, indexing, evidence, issue planning, claim composition, validation, delivery.
 - Provider integrations must be replaceable without changing renderer or validation contracts.
+- CLI-backed providers must be bounded, deterministic at the transport layer, and safe to disable when auth is missing.
 
 ## 8. Content & UX Requirements
 - Calm, concise, evidence-based tone.
@@ -295,6 +317,7 @@ Outputs:
 - **Paywalls / crawling restrictions:** metadata/snippet + link-out; prefer RSS and official sources.
 - **Alert noise:** thresholds + rate limiting + bundling.
 - **Source quality drift:** credibility tiers and allowlist/blocklist.
+- **Provider/runtime drift:** keep a shared JSON contract above provider adapters and validate provider outputs before rendering.
 
 ## 12. Phased Delivery Plan
 

--- a/artifacts/modelling/TODO.md
+++ b/artifacts/modelling/TODO.md
@@ -4,6 +4,12 @@ Last updated: 2026-03-12
 
 ## Priority Queue
 
+- [ ] P0: Define Codex OAuth runtime adapter contract for daily brief providers
+  - Acceptance: auth discovery, command boundary, output parsing, and failure modes documented for `codex-oauth`.
+
+- [ ] P0: Define provider selection and registry contract for daily brief runner scripts
+  - Acceptance: one spec covers `deterministic`, `openai`, and `codex-oauth` selection plus provider-specific config validation.
+
 - [x] P0: Define `decision_record` artifact schema and storage location
   - Acceptance: markdown spec + JSON example + field-level validation rules.
 

--- a/artifacts/modelling/citation_contract.md
+++ b/artifacts/modelling/citation_contract.md
@@ -105,6 +105,7 @@ Each issue must include evidence pointers similar to:
 - `issue_question` must be specific enough to anchor a debate
 - evidence IDs must resolve to known chunks/documents
 - supporting/opposing/minority/watch evidence sets must belong to the same issue context
+- provider transport (`openai`, `codex-oauth`, future adapters) must not change the issue-map schema
 
 ---
 
@@ -132,6 +133,7 @@ Each claim must include fields similar to:
 - every claim has at least one supporting citation
 - `counter` and `minority` claims must still reference the same `issue_id`
 - `why_it_matters` and `novelty_vs_prior_brief` are also grounded outputs and may be removed if unsupported
+- provider transport (`openai`, `codex-oauth`, future adapters) must not change the claim-object schema
 
 ---
 
@@ -197,6 +199,18 @@ Before delivering any synthesis output, the system MUST run a deterministic vali
 | Citation missing required fields | Remove citation; if no valid citations remain, drop claim |
 | Paywalled source cited with full-text quote | Strip `quote_span`, keep metadata-only citation |
 | Claim drift across one issue | Mark issue invalid and retry or abstain |
+
+---
+
+## 7.1 Provider Runtime Invariants
+
+The citation contract sits above the provider runtime boundary.
+
+That means:
+- a provider may use API calls, local CLI execution, or another bounded transport
+- but it must still return the same schema-valid issue-map and claim-object payloads
+- provider-specific auth state must never be copied into artifacts, citations, or decision records
+- provider failures must be recorded as runtime errors, not silently converted into unsupported claims
 
 **Validator output:**
 

--- a/artifacts/modelling/pipeline.md
+++ b/artifacts/modelling/pipeline.md
@@ -118,6 +118,9 @@ Failure handling:
 
 Actions:
 - call provider-agnostic issue planner with bounded `evidence_pack` and optional `prior_brief_context`
+- resolve provider runtime before the model call:
+  - `openai` -> API-backed runtime with explicit API billing/quota
+  - `codex-oauth` -> local `codex exec` runtime using `codex login` credentials
 - require schema-valid JSON output only
 - identify 2-3 important issues when evidence supports them
 - assign support/opposition/minority/watch evidence groups per issue
@@ -127,12 +130,14 @@ Outputs:
 
 Failure handling:
 - timeout or invalid JSON -> retry once with same inputs
+- missing provider auth -> fail fast with provider-specific guidance
 - second failure -> brief-level abstain
 
 ### Stage 8: Claim Composition (Model Layer)
 
 Actions:
 - call provider-agnostic claim composer with `issue_map`, `citation_store`, and `prior_brief_context`
+- use the same resolved provider runtime family as Stage 7 for one run
 - require schema-valid JSON output only
 - produce structured claims for `prevailing`, `counter`, `minority`, and `watch`
 - include `why_it_matters`, `confidence`, and `novelty_vs_prior_brief`
@@ -142,6 +147,7 @@ Outputs:
 
 Failure handling:
 - timeout or invalid JSON -> retry once with same inputs
+- provider transport failure after issue planning -> fail the run or brief-level abstain with explicit provider error
 - second failure -> brief-level abstain
 
 ### Stage 9: Validation + Critic
@@ -192,6 +198,8 @@ Failure handling:
 - issue planner: max 1 retry
 - claim composer: max 1 retry
 - validation-triggered composer retry: max 1 additional composer retry
+- provider-auth failures: 0 retries
+- provider-misconfiguration failures: 0 retries
 - no infinite retries; all retries are deterministic and bounded
 
 ## 6. Abstain Policy
@@ -218,3 +226,4 @@ Each run must persist:
 - incremental run behavior is defined
 - hard limits and budget stop conditions are explicit
 - daily brief architecture is issue-centered rather than one-query / one-bucket synthesis
+- provider runtime can switch between API-key and Codex-OAuth transports without changing downstream contracts

--- a/docs/plans/2026-03-12-codex-oauth-provider-redesign-design.md
+++ b/docs/plans/2026-03-12-codex-oauth-provider-redesign-design.md
@@ -1,0 +1,168 @@
+# Codex OAuth Provider Redesign
+
+Issue: `#112`
+
+Date: `2026-03-12`
+
+## Problem
+
+The current daily-brief model path assumes the provider is either:
+- fully deterministic, or
+- OpenAI API-backed through `OPENAI_API_KEY` and the Responses API.
+
+That design cannot use ChatGPT subscription-backed Codex authentication. Even after fixing OpenAI transport bugs, a fixture demo can still fail because API billing/quota is separate from ChatGPT subscription billing.
+
+The product requirement is now:
+- keep the deterministic evidence layer unchanged
+- preserve provider-agnostic issue planner and claim composer contracts
+- add a runtime path that can use local `codex login` credentials without requiring `OPENAI_API_KEY`
+
+## Observed Runtime Reality
+
+Local validation on this machine shows:
+- `codex login status` returns `Logged in using ChatGPT`
+- `codex exec --json --output-last-message ... "Reply with exactly: []"` succeeds under the current local ChatGPT-backed login state
+
+That makes `codex exec` the viable local runtime boundary for subscription-backed synthesis.
+
+## Options Considered
+
+### 1. Keep only the OpenAI API provider
+
+Pros:
+- simplest code path
+- no new transport abstraction
+
+Cons:
+- does not solve the subscription-backed runtime requirement
+- keeps demos blocked on API quota and project billing
+
+Rejected.
+
+### 2. Add a `codex-oauth` provider backed by `codex exec`
+
+Pros:
+- matches the locally available subscription-backed auth path
+- keeps provider logic outside the deterministic evidence layer
+- can preserve the same issue planner / claim composer JSON contracts
+
+Cons:
+- introduces a CLI transport boundary
+- requires careful output parsing, timeout handling, and auth checks
+
+Chosen.
+
+### 3. Replace the provider layer with a Codex-only transport
+
+Pros:
+- smallest mental model once migrated
+
+Cons:
+- would regress provider-agnostic design
+- would throw away the OpenAI API path that is still useful for project-key deployments
+
+Rejected.
+
+## Chosen Design
+
+Keep the current provider-agnostic model contracts:
+- `IssuePlannerProvider`
+- `ClaimComposerProvider`
+
+Add a second runtime family:
+- `openai`: API key + Responses API
+- `codex-oauth`: local `codex exec` + ChatGPT/Codex login
+
+The deterministic evidence layer, validator, critic, renderer, and decision record layers do not change their contracts.
+
+## Runtime Boundary
+
+### Shared invariant
+
+Every provider runtime must:
+- consume the same typed internal payloads
+- return schema-valid JSON only
+- preserve bounded inputs from the evidence layer
+- surface transport/auth failures explicitly
+
+### `codex-oauth` transport
+
+The `codex-oauth` provider will:
+- verify local Codex auth before running
+- invoke `codex exec` non-interactively
+- pass a strict prompt that asks for JSON only
+- parse the final message or structured output file
+- hand the parsed JSON to the existing issue planner / claim composer validation logic
+
+It must not:
+- read or copy auth tokens into repo files
+- bypass validator/citation enforcement
+- change the issue-map or claim-object schema
+
+## Provider Selection
+
+Runner scripts should move from ad hoc `if provider == "openai"` wiring to an explicit provider registry.
+
+Target modes:
+- `deterministic`
+- `openai`
+- `codex-oauth`
+
+Provider selection rules:
+- `deterministic` requires no external auth
+- `openai` requires API credentials
+- `codex-oauth` requires successful local `codex login status`
+
+Provider-specific failure messages should be immediate and explicit.
+
+## Security and Credential Handling
+
+The repo must treat Codex auth as local machine state, not project configuration.
+
+Rules:
+- never persist OAuth tokens in repo files or artifacts
+- never mirror Codex auth into `.env`
+- decision records and runtime artifacts may record provider name and transport errors, but not secrets
+
+## Failure Handling
+
+`codex-oauth` failures should classify as:
+- auth missing
+- CLI unavailable
+- timeout
+- malformed JSON
+- provider execution failure
+
+Retry policy:
+- no retry for auth-missing or CLI-missing failures
+- one retry for timeout or malformed-JSON failures, matching existing model-layer policy
+
+## Testing Strategy
+
+Required coverage:
+- provider auth check behavior
+- command payload construction
+- JSON output parsing
+- malformed output rejection
+- script/provider selection wiring
+- one end-to-end fixture run using a fake Codex transport
+
+Live subscription-backed demo runs remain optional verification, not unit-test requirements.
+
+## Out of Scope
+
+This redesign does not:
+- change issue-planner or claim-composer schemas
+- relax citation rules
+- replace the OpenAI API provider
+- make the live evidence layer depend on Codex
+
+## Delivery Sequence
+
+1. Merge redesign docs and product-file updates.
+2. Create a planning issue/PR for implementation breakdown.
+3. Split child implementation issues for:
+   - provider registry and CLI wiring
+   - Codex runtime adapter
+   - tests and README/runtime docs
+4. Implement and merge child issues.


### PR DESCRIPTION
## Summary
- redesign the daily brief provider runtime so model-layer transport stays provider-agnostic above a shared JSON contract
- document Codex OAuth as a first-class runtime path alongside the OpenAI API path
- add a dedicated redesign design doc for issue #112

## Validation
- python scripts/validate_artifacts.py
- local Codex runtime smoke-check: `codex exec --json --output-last-message ... "Reply with exactly: []"`

Closes #112
