### PR TITLE
feat: add daily brief provider registry for Codex OAuth

### DIFF
--- a/apps/agent/daily_brief/provider_registry.py
+++ b/apps/agent/daily_brief/provider_registry.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Literal, TypeAlias
+
+from apps.agent.daily_brief.model_interfaces import ClaimComposerProvider, IssuePlannerProvider
+
+DailyBriefProviderName: TypeAlias = Literal["deterministic", "openai", "codex-oauth"]
+
+
+def build_daily_brief_providers(
+    *,
+    provider: DailyBriefProviderName | str,
+    openai_model: str | None = None,
+    codex_runner: Callable[..., Any] | None = None,
+    login_checker: Callable[[], bool] | None = None,
+) -> tuple[IssuePlannerProvider | None, ClaimComposerProvider | None]:
+    if provider == "deterministic":
+        return (None, None)
+    if provider == "openai":
+        return _build_openai_providers(openai_model=openai_model)
+    if provider == "codex-oauth":
+        return _build_codex_oauth_providers(
+            codex_runner=codex_runner,
+            login_checker=login_checker,
+        )
+    raise ValueError(f"Unsupported provider: {provider}")
+
+
+def _build_openai_providers(
+    *,
+    openai_model: str | None = None,
+) -> tuple[IssuePlannerProvider, ClaimComposerProvider]:
+    from apps.agent.daily_brief.openai_runtime import build_openai_daily_brief_providers
+
+    builder_kwargs: dict[str, Any] = {}
+    if openai_model is not None:
+        builder_kwargs["model"] = openai_model
+    return build_openai_daily_brief_providers(**builder_kwargs)
+
+
+def _build_codex_oauth_providers(
+    *,
+    codex_runner: Callable[..., Any] | None = None,
+    login_checker: Callable[[], bool] | None = None,
+) -> tuple[IssuePlannerProvider, ClaimComposerProvider]:
+    try:
+        from apps.agent.daily_brief.codex_runtime import build_codex_daily_brief_providers
+    except ImportError as exc:
+        raise ValueError("codex-oauth provider requires apps.agent.daily_brief.codex_runtime.") from exc
+
+    builder_kwargs: dict[str, Any] = {}
+    if codex_runner is not None:
+        builder_kwargs["codex_runner"] = codex_runner
+    if login_checker is not None:
+        builder_kwargs["login_checker"] = login_checker
+    return build_codex_daily_brief_providers(**builder_kwargs)

--- a/scripts/run_daily_brief.py
+++ b/scripts/run_daily_brief.py
@@ -30,7 +30,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--provider",
-        choices=("deterministic", "openai"),
+        choices=("deterministic", "openai", "codex-oauth"),
         default="deterministic",
         help="Daily-brief synthesis provider mode.",
     )
@@ -43,19 +43,19 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
-    from apps.agent.daily_brief.openai_runtime import build_openai_daily_brief_providers
+    from apps.agent.daily_brief.provider_registry import build_daily_brief_providers
     from apps.agent.daily_brief.runner import run_daily_brief
     from apps.agent.delivery.email_sender import EmailDeliveryConfig
     from apps.agent.delivery.scheduler import DailyBriefSchedule
 
     args = parse_args()
-    issue_planner = None
-    claim_composer = None
-    if args.provider == "openai":
-        try:
-            issue_planner, claim_composer = build_openai_daily_brief_providers(model=args.openai_model)
-        except ValueError as exc:
-            raise SystemExit(str(exc)) from exc
+    try:
+        issue_planner, claim_composer = build_daily_brief_providers(
+            provider=args.provider,
+            openai_model=args.openai_model,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     email_config = None
     if args.smtp_host or args.sender_email or args.recipient_email:
         if not args.smtp_host or not args.sender_email or not args.recipient_email:

--- a/scripts/run_daily_brief_fixture.py
+++ b/scripts/run_daily_brief_fixture.py
@@ -31,7 +31,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--provider",
-        choices=("deterministic", "openai"),
+        choices=("deterministic", "openai", "codex-oauth"),
         default="deterministic",
         help="Daily-brief synthesis provider mode.",
     )
@@ -44,19 +44,19 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
-    from apps.agent.daily_brief.openai_runtime import build_openai_daily_brief_providers
+    from apps.agent.daily_brief.provider_registry import build_daily_brief_providers
     from apps.agent.daily_brief.runner import run_fixture_daily_brief
     from apps.agent.delivery.email_sender import EmailDeliveryConfig
     from apps.agent.delivery.scheduler import DailyBriefSchedule
 
     args = parse_args()
-    issue_planner = None
-    claim_composer = None
-    if args.provider == "openai":
-        try:
-            issue_planner, claim_composer = build_openai_daily_brief_providers(model=args.openai_model)
-        except ValueError as exc:
-            raise SystemExit(str(exc)) from exc
+    try:
+        issue_planner, claim_composer = build_daily_brief_providers(
+            provider=args.provider,
+            openai_model=args.openai_model,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     email_config = None
     if args.smtp_host or args.sender_email or args.recipient_email:
         if not args.smtp_host or not args.sender_email or not args.recipient_email:

--- a/tests/agent/daily_brief/test_provider_registry.py
+++ b/tests/agent/daily_brief/test_provider_registry.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from unittest.mock import patch
+
+
+class ProviderRegistryTests(unittest.TestCase):
+    def test_build_daily_brief_providers_returns_none_for_deterministic(self):
+        from apps.agent.daily_brief.provider_registry import build_daily_brief_providers
+
+        issue_planner, claim_composer = build_daily_brief_providers(provider="deterministic")
+
+        self.assertIsNone(issue_planner)
+        self.assertIsNone(claim_composer)
+
+    def test_build_daily_brief_providers_delegates_openai_builder(self):
+        from apps.agent.daily_brief import provider_registry
+
+        planner = object()
+        composer = object()
+
+        with patch.object(
+            provider_registry,
+            "_build_openai_providers",
+            return_value=(planner, composer),
+        ) as openai_mock:
+            issue_planner, claim_composer = provider_registry.build_daily_brief_providers(
+                provider="openai",
+                openai_model="gpt-test",
+            )
+
+        openai_mock.assert_called_once_with(openai_model="gpt-test")
+        self.assertIs(issue_planner, planner)
+        self.assertIs(claim_composer, composer)
+
+    def test_build_daily_brief_providers_delegates_codex_oauth_builder(self):
+        from apps.agent.daily_brief import provider_registry
+
+        planner = object()
+        composer = object()
+        fake_runner = object()
+
+        with patch.object(
+            provider_registry,
+            "_build_codex_oauth_providers",
+            return_value=(planner, composer),
+        ) as codex_mock:
+            issue_planner, claim_composer = provider_registry.build_daily_brief_providers(
+                provider="codex-oauth",
+                codex_runner=fake_runner,
+            )
+
+        codex_mock.assert_called_once_with(codex_runner=fake_runner, login_checker=None)
+        self.assertIs(issue_planner, planner)
+        self.assertIs(claim_composer, composer)
+
+    def test_build_daily_brief_providers_rejects_unknown_provider(self):
+        from apps.agent.daily_brief.provider_registry import build_daily_brief_providers
+
+        with self.assertRaisesRegex(ValueError, "Unsupported provider"):
+            build_daily_brief_providers(provider="unsupported")
+
+
+class RunnerScriptProviderWiringTests(unittest.TestCase):
+    def test_fixture_script_accepts_codex_oauth_provider(self):
+        from scripts import run_daily_brief_fixture
+
+        with patch.object(sys, "argv", ["run_daily_brief_fixture.py", "--provider", "codex-oauth"]):
+            args = run_daily_brief_fixture.parse_args()
+
+        self.assertEqual(args.provider, "codex-oauth")
+
+    def test_fixture_script_resolves_providers_through_registry(self):
+        from scripts import run_daily_brief_fixture
+
+        planner = object()
+        composer = object()
+
+        with (
+            patch(
+                "apps.agent.daily_brief.provider_registry.build_daily_brief_providers",
+                return_value=(planner, composer),
+            ) as registry_mock,
+            patch(
+                "apps.agent.daily_brief.runner.run_fixture_daily_brief",
+                return_value={"status": "ok", "run_id": "run_fixture"},
+            ) as runner_mock,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "run_daily_brief_fixture.py",
+                    "--provider",
+                    "openai",
+                    "--openai-model",
+                    "gpt-test",
+                ],
+            ),
+        ):
+            run_daily_brief_fixture.main()
+
+        registry_mock.assert_called_once_with(provider="openai", openai_model="gpt-test")
+        self.assertIs(runner_mock.call_args.kwargs["issue_planner"], planner)
+        self.assertIs(runner_mock.call_args.kwargs["claim_composer"], composer)
+
+    def test_live_script_accepts_codex_oauth_provider(self):
+        from scripts import run_daily_brief
+
+        with patch.object(sys, "argv", ["run_daily_brief.py", "--provider", "codex-oauth"]):
+            args = run_daily_brief.parse_args()
+
+        self.assertEqual(args.provider, "codex-oauth")
+
+    def test_live_script_resolves_providers_through_registry(self):
+        from scripts import run_daily_brief
+
+        planner = object()
+        composer = object()
+
+        with (
+            patch(
+                "apps.agent.daily_brief.provider_registry.build_daily_brief_providers",
+                return_value=(planner, composer),
+            ) as registry_mock,
+            patch(
+                "apps.agent.daily_brief.runner.run_daily_brief",
+                return_value={"status": "ok", "run_id": "run_live"},
+            ) as runner_mock,
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "run_daily_brief.py",
+                    "--provider",
+                    "openai",
+                    "--openai-model",
+                    "gpt-live",
+                ],
+            ),
+        ):
+            run_daily_brief.main()
+
+        registry_mock.assert_called_once_with(provider="openai", openai_model="gpt-live")
+        self.assertIs(runner_mock.call_args.kwargs["issue_planner"], planner)
+        self.assertIs(runner_mock.call_args.kwargs["claim_composer"], composer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a shared daily-brief provider registry for deterministic, openai, and codex-oauth modes
- switch the fixture and live runner scripts to resolve providers through the registry
- add focused tests for provider dispatch and script wiring

## Validation
- python -m unittest tests.agent.daily_brief.test_provider_registry tests.agent.daily_brief.test_codex_runtime tests.agent.daily_brief.test_runner.DailyBriefRunnerTests.test_script_entrypoint_runs_fixture_slice -v
- python -m ruff check apps/agent/daily_brief/provider_registry.py scripts/run_daily_brief.py scripts/run_daily_brief_fixture.py tests/agent/daily_brief/test_provider_registry.py
- python -m mypy apps

Closes #116
Related: #114
