### PR TITLE
fix: stabilize Codex OAuth runtime on Windows

### DIFF
--- a/apps/agent/daily_brief/codex_runtime.py
+++ b/apps/agent/daily_brief/codex_runtime.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import shutil
 import subprocess
 from collections.abc import Callable, Mapping
 from json import JSONDecodeError
+from pathlib import Path
 from typing import Any, cast
 
 from apps.agent.daily_brief.model_interfaces import ClaimComposerInput, ClaimComposerProvider, IssuePlannerProvider
@@ -42,9 +42,10 @@ class CodexExecJsonClient:
         )
         try:
             completed = self._runner(
-                [resolved_executable, "exec", "--json", "--output-last-message", prompt],
+                [resolved_executable, "exec", "--json", "-"],
                 capture_output=True,
                 text=True,
+                input=prompt,
                 timeout=self._timeout_seconds,
                 check=False,
             )
@@ -171,6 +172,20 @@ def _build_exec_prompt(*, request_payload: Mapping[str, Any]) -> str:
 
 
 def _extract_last_message(stdout: str) -> str:
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if len(lines) > 1:
+        for line in reversed(lines):
+            try:
+                parsed_line = json.loads(line)
+            except JSONDecodeError:
+                continue
+            if isinstance(parsed_line, Mapping) and parsed_line.get("type") == "item.completed":
+                item = parsed_line.get("item")
+                if isinstance(item, Mapping) and item.get("type") == "agent_message":
+                    text = item.get("text")
+                    if isinstance(text, str) and text.strip():
+                        return text.strip()
+
     try:
         parsed = json.loads(stdout)
     except JSONDecodeError:

--- a/tests/agent/daily_brief/test_codex_runtime.py
+++ b/tests/agent/daily_brief/test_codex_runtime.py
@@ -55,7 +55,15 @@ class CodexRuntimeTests(unittest.TestCase):
         def _runner(command, **kwargs):
             captured["command"] = command
             captured["kwargs"] = kwargs
-            return SimpleNamespace(returncode=0, stdout='[{"issue_id":"issue_001"}]\n', stderr="")
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    '{"type":"thread.started","thread_id":"thread_001"}\n'
+                    '{"type":"item.completed","item":{"id":"item_001","type":"agent_message","text":"[{\\"issue_id\\":\\"issue_001\\"}]"}}\n'
+                    '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}\n'
+                ),
+                stderr="",
+            )
 
         runtime = CodexExecJsonClient(
             runner=_runner,
@@ -89,10 +97,10 @@ class CodexRuntimeTests(unittest.TestCase):
         self.assertEqual(payload, '[{"issue_id":"issue_001"}]')
         self.assertEqual(
             captured["command"][:4],
-            [r"C:\Users\Lenovo\AppData\Roaming\npm\codex.cmd", "exec", "--json", "--output-last-message"],
+            [r"C:\Users\Lenovo\AppData\Roaming\npm\codex.cmd", "exec", "--json", "-"],
         )
-        self.assertIn("daily_brief_issue_planner", captured["command"][4])
-        self.assertIn("json_schema", captured["command"][4])
+        self.assertIn("daily_brief_issue_planner", captured["kwargs"]["input"])
+        self.assertIn("json_schema", captured["kwargs"]["input"])
         self.assertEqual(captured["kwargs"]["timeout"], 12.5)
         self.assertTrue(captured["kwargs"]["text"])
         self.assertTrue(captured["kwargs"]["capture_output"])


### PR DESCRIPTION
## Summary
- resolve the actual Codex launcher path on Windows before calling subprocess
- switch Codex exec invocation to use stdin for the prompt and parse JSONL stdout for the final assistant message
- add regression tests for launcher resolution and provider-specific missing-executable handling

## Validation
- python -m unittest tests.agent.daily_brief.test_codex_runtime -v
- python -m ruff check apps/agent/daily_brief/codex_runtime.py tests/agent/daily_brief/test_codex_runtime.py
- python -m mypy apps
- python -m compileall -q apps tests scripts
- python scripts/run_daily_brief_fixture.py --provider codex-oauth --base-dir .tmp_codex_oauth_demo_121 --run-id run_codex_oauth_demo_121 --generated-at-utc 2026-03-12T10:00:00Z

Closes #121
Related: #118
