### PR TITLE
fix: enforce structured output for Codex OAuth daily brief

### DIFF
--- a/apps/agent/daily_brief/codex_runtime.py
+++ b/apps/agent/daily_brief/codex_runtime.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+import tempfile
 from collections.abc import Callable, Mapping
-from json import JSONDecodeError
 from pathlib import Path
 from typing import Any, cast
 
@@ -15,6 +15,8 @@ from apps.agent.daily_brief.openai_issue_planner import OpenAIIssuePlanner
 CODEX_EXECUTABLE = "codex"
 CODEX_CLI_REQUIRED_MESSAGE = "Codex runtime requires the `codex` CLI to be installed."
 CODEX_LOGIN_REQUIRED_MESSAGE = "Codex runtime requires an active `codex login` session."
+CODEX_OUTPUT_WRAPPER_KEY = "result"
+DEFAULT_CODEX_TIMEOUT_SECONDS = 300.0
 
 CodexRunner = Callable[..., subprocess.CompletedProcess[str] | Any]
 WhichResolver = Callable[[str], str | None]
@@ -27,7 +29,7 @@ class CodexExecJsonClient:
         runner: CodexRunner | None = None,
         executable: str = CODEX_EXECUTABLE,
         which_resolver: WhichResolver | None = None,
-        timeout_seconds: float = 60.0,
+        timeout_seconds: float = DEFAULT_CODEX_TIMEOUT_SECONDS,
     ) -> None:
         self._runner = runner or subprocess.run
         self._executable = executable
@@ -36,29 +38,39 @@ class CodexExecJsonClient:
 
     def create_json_response(self, request_payload: Mapping[str, Any]) -> str:
         prompt = _build_exec_prompt(request_payload=request_payload)
+        output_schema, output_wrapper_key = _build_output_schema(request_payload=request_payload)
         resolved_executable = resolve_codex_executable(
             executable=self._executable,
             which_resolver=self._which_resolver,
         )
-        try:
-            completed = self._runner(
-                [resolved_executable, "exec", "--json", "-"],
-                capture_output=True,
-                text=True,
-                input=prompt,
-                timeout=self._timeout_seconds,
-                check=False,
-            )
-        except FileNotFoundError as exc:
-            raise ValueError(CODEX_CLI_REQUIRED_MESSAGE) from exc
-        if int(getattr(completed, "returncode", 1)) != 0:
-            error_text = str(getattr(completed, "stderr", "") or getattr(completed, "stdout", "")).strip()
-            raise ValueError(error_text or "Codex exec failed.")
-
-        stdout = str(getattr(completed, "stdout", "")).strip()
-        if not stdout:
-            raise ValueError("Codex exec did not return output.")
-        return _extract_last_message(stdout)
+        with tempfile.TemporaryDirectory(prefix="codex-runtime-") as temp_dir:
+            temp_dir_path = Path(temp_dir)
+            schema_path = temp_dir_path / "output-schema.json"
+            output_path = temp_dir_path / "output-last-message.json"
+            _write_json_file(path=schema_path, payload=output_schema)
+            try:
+                completed = self._runner(
+                    [
+                        resolved_executable,
+                        "exec",
+                        "--output-schema",
+                        str(schema_path),
+                        "--output-last-message",
+                        str(output_path),
+                        "-",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    input=prompt,
+                    timeout=self._timeout_seconds,
+                    check=False,
+                )
+            except FileNotFoundError as exc:
+                raise ValueError(CODEX_CLI_REQUIRED_MESSAGE) from exc
+            if int(getattr(completed, "returncode", 1)) != 0:
+                error_text = str(getattr(completed, "stderr", "") or getattr(completed, "stdout", "")).strip()
+                raise ValueError(error_text or "Codex exec failed.")
+            return _read_output_payload(output_path=output_path, output_wrapper_key=output_wrapper_key)
 
 
 def build_codex_daily_brief_providers(
@@ -68,7 +80,7 @@ def build_codex_daily_brief_providers(
     login_checker: Callable[[], bool] | None = None,
     executable: str = CODEX_EXECUTABLE,
     which_resolver: WhichResolver | None = None,
-    timeout_seconds: float = 60.0,
+    timeout_seconds: float = DEFAULT_CODEX_TIMEOUT_SECONDS,
 ) -> tuple[IssuePlannerProvider, ClaimComposerProvider]:
     resolved_runner = codex_runner or subprocess.run
     resolved_which_resolver = which_resolver or shutil.which
@@ -152,60 +164,63 @@ def _codex_login_available(*, runner: CodexRunner, executable: str, which_resolv
 
 def _build_exec_prompt(*, request_payload: Mapping[str, Any]) -> str:
     messages = request_payload.get("messages")
-    response_format = request_payload.get("response_format")
     if not isinstance(messages, list) or not messages:
         raise ValueError("Codex runtime requires at least one message.")
-    if not isinstance(response_format, Mapping):
-        raise ValueError("Codex runtime requires response_format.")
 
     prompt_payload = {
         "task": request_payload.get("task"),
         "messages": [dict(message) for message in messages if isinstance(message, Mapping)],
-        "response_format": dict(response_format),
         "input": dict(request_payload.get("input", {})) if isinstance(request_payload.get("input"), Mapping) else {},
     }
     return (
-        "Return only valid JSON that matches the provided response_format. "
+        "Return only valid JSON that matches the attached output schema. "
         "Do not wrap the answer in markdown or commentary.\n\n"
         f"{json.dumps(prompt_payload, indent=2, sort_keys=True)}"
     )
 
 
-def _extract_last_message(stdout: str) -> str:
-    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
-    if len(lines) > 1:
-        for line in reversed(lines):
-            try:
-                parsed_line = json.loads(line)
-            except JSONDecodeError:
-                continue
-            if isinstance(parsed_line, Mapping) and parsed_line.get("type") == "item.completed":
-                item = parsed_line.get("item")
-                if isinstance(item, Mapping) and item.get("type") == "agent_message":
-                    text = item.get("text")
-                    if isinstance(text, str) and text.strip():
-                        return text.strip()
+def _build_output_schema(*, request_payload: Mapping[str, Any]) -> tuple[dict[str, Any], str | None]:
+    response_format = request_payload.get("response_format")
+    if not isinstance(response_format, Mapping):
+        raise ValueError("Codex runtime requires response_format.")
+    if response_format.get("type") != "json_schema":
+        raise ValueError("Codex runtime requires a json_schema response_format.")
 
-    try:
-        parsed = json.loads(stdout)
-    except JSONDecodeError:
-        return stdout.strip()
+    json_schema = response_format.get("json_schema")
+    if not isinstance(json_schema, Mapping):
+        raise ValueError("Codex runtime requires response_format.json_schema.")
 
-    if isinstance(parsed, Mapping):
-        for key in ("output_text", "last_message", "content", "message"):
-            value = parsed.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-        return stdout.strip()
+    schema = json_schema.get("schema")
+    if not isinstance(schema, Mapping):
+        raise ValueError("Codex runtime requires response_format.json_schema.schema.")
+    schema_dict = dict(schema)
+    if schema_dict.get("type") == "object":
+        return schema_dict, None
+    return (
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "required": [CODEX_OUTPUT_WRAPPER_KEY],
+            "properties": {CODEX_OUTPUT_WRAPPER_KEY: schema_dict},
+        },
+        CODEX_OUTPUT_WRAPPER_KEY,
+    )
 
-    if isinstance(parsed, list):
-        for item in reversed(parsed):
-            if not isinstance(item, Mapping):
-                continue
-            for key in ("output_text", "last_message", "content", "message"):
-                value = item.get(key)
-                if isinstance(value, str) and value.strip():
-                    return value.strip()
-        return stdout.strip()
 
-    return stdout.strip()
+def _write_json_file(*, path: Path, payload: Mapping[str, Any]) -> None:
+    path.write_text(json.dumps(dict(payload), indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _read_output_payload(*, output_path: Path, output_wrapper_key: str | None) -> str:
+    if not output_path.exists():
+        raise ValueError("Codex exec did not return output.")
+    payload = output_path.read_text(encoding="utf-8").strip()
+    if not payload:
+        raise ValueError("Codex exec did not return output.")
+    if output_wrapper_key is None:
+        return payload
+
+    parsed_payload = json.loads(payload)
+    if not isinstance(parsed_payload, Mapping) or output_wrapper_key not in parsed_payload:
+        raise ValueError("Codex exec did not return output.")
+    return json.dumps(parsed_payload[output_wrapper_key], separators=(",", ":"))

--- a/tests/agent/daily_brief/test_codex_runtime.py
+++ b/tests/agent/daily_brief/test_codex_runtime.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 
 from apps.agent.daily_brief.codex_runtime import (
@@ -55,13 +57,13 @@ class CodexRuntimeTests(unittest.TestCase):
         def _runner(command, **kwargs):
             captured["command"] = command
             captured["kwargs"] = kwargs
+            schema_path = Path(command[3])
+            output_path = Path(command[5])
+            captured["schema"] = json.loads(schema_path.read_text(encoding="utf-8"))
+            output_path.write_text('{"result":[{"issue_id":"issue_001"}]}', encoding="utf-8")
             return SimpleNamespace(
                 returncode=0,
-                stdout=(
-                    '{"type":"thread.started","thread_id":"thread_001"}\n'
-                    '{"type":"item.completed","item":{"id":"item_001","type":"agent_message","text":"[{\\"issue_id\\":\\"issue_001\\"}]"}}\n'
-                    '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}\n'
-                ),
+                stdout="planner completed",
                 stderr="",
             )
 
@@ -96,14 +98,79 @@ class CodexRuntimeTests(unittest.TestCase):
 
         self.assertEqual(payload, '[{"issue_id":"issue_001"}]')
         self.assertEqual(
-            captured["command"][:4],
-            [r"C:\Users\Lenovo\AppData\Roaming\npm\codex.cmd", "exec", "--json", "-"],
+            captured["command"][:7],
+            [
+                r"C:\Users\Lenovo\AppData\Roaming\npm\codex.cmd",
+                "exec",
+                "--output-schema",
+                captured["command"][3],
+                "--output-last-message",
+                captured["command"][5],
+                "-",
+            ],
         )
         self.assertIn("daily_brief_issue_planner", captured["kwargs"]["input"])
-        self.assertIn("json_schema", captured["kwargs"]["input"])
+        self.assertNotIn("json_schema", captured["kwargs"]["input"])
+        self.assertEqual(
+            captured["schema"],
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["result"],
+                "properties": {"result": {"type": "array"}},
+            },
+        )
         self.assertEqual(captured["kwargs"]["timeout"], 12.5)
         self.assertTrue(captured["kwargs"]["text"])
         self.assertTrue(captured["kwargs"]["capture_output"])
+
+    def test_codex_exec_runtime_rejects_missing_output_file(self) -> None:
+        runtime = CodexExecJsonClient(
+            runner=lambda *_args, **_kwargs: SimpleNamespace(returncode=0, stdout="planner completed", stderr=""),
+            which_resolver=lambda _name: r"C:\Users\Lenovo\AppData\Roaming\npm\codex.cmd",
+        )
+
+        with self.assertRaisesRegex(ValueError, "Codex exec did not return output."):
+            runtime.create_json_response(
+                {
+                    "task": "daily_brief_issue_planner",
+                    "response_format": {
+                        "type": "json_schema",
+                        "json_schema": {"name": "issue_map_list", "schema": {"type": "array"}},
+                    },
+                    "messages": [{"role": "user", "content": "Plan issues."}],
+                    "input": {"evidence_pack": []},
+                }
+            )
+
+    def test_codex_exec_runtime_uses_extended_default_timeout(self) -> None:
+        captured: dict[str, object] = {}
+
+        def _runner(command, **kwargs):
+            captured["command"] = command
+            captured["timeout"] = kwargs["timeout"]
+            Path(command[5]).write_text('{"result":[{"issue_id":"issue_001"}]}', encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="planner completed", stderr="")
+
+        runtime = CodexExecJsonClient(
+            runner=_runner,
+            which_resolver=lambda _name: r"C:\Users\Lenovo\AppData\Roaming\npm\codex.cmd",
+        )
+
+        payload = runtime.create_json_response(
+            {
+                "task": "daily_brief_issue_planner",
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {"name": "issue_map_list", "schema": {"type": "array"}},
+                },
+                "messages": [{"role": "user", "content": "Plan issues."}],
+                "input": {"evidence_pack": []},
+            }
+        )
+
+        self.assertEqual(payload, '[{"issue_id":"issue_001"}]')
+        self.assertEqual(captured["timeout"], 300.0)
 
     def test_codex_exec_runtime_raises_provider_specific_error_on_file_not_found(self) -> None:
         runtime = CodexExecJsonClient(


### PR DESCRIPTION
## Summary
- enforce real structured-output constraints for Codex daily brief calls by passing a schema file to `codex exec`
- wrap array-shaped schemas so Codex can emit a stable object payload and unwrap it after execution
- add regression tests for schema-file invocation, missing output handling, and default timeout behavior

## Validation
- python -m unittest tests.agent.daily_brief.test_codex_runtime -v
- python -m ruff check apps/agent/daily_brief/codex_runtime.py tests/agent/daily_brief/test_codex_runtime.py
- python -m mypy apps
- python scripts/run_daily_brief_fixture.py --provider codex-oauth --base-dir .tmp_codex_oauth_demo_123 --run-id run_codex_oauth_demo_123 --generated-at-utc 2026-03-12T10:00:00Z

Closes #123
Related: #118
