### PR TITLE
feat(daily-brief): redesign issue planning and delivery pipeline

### DIFF
--- a/apps/agent/daily_brief/delta.py
+++ b/apps/agent/daily_brief/delta.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from apps.agent.pipeline.types import (
+    ClaimDelta,
+    DailyBriefBullet,
+    DailyBriefNoveltyLabel,
+    StructuredClaim,
+)
+
+CHANGED_LABELS = {"new", "reframed", "weakened", "strengthened", "reversed"}
+
+
+def build_claim_deltas(
+    *,
+    structured_claims: Iterable[StructuredClaim],
+    prior_brief_context: Mapping[str, Any] | None,
+) -> list[ClaimDelta]:
+    prior_claims = []
+    if isinstance(prior_brief_context, Mapping):
+        prior_claims = [
+            str(value)
+            for value in prior_brief_context.get("claim_summaries", [])
+            if isinstance(value, str)
+        ]
+
+    deltas: list[ClaimDelta] = []
+    for claim in structured_claims:
+        best_match, overlap = _best_prior_match(
+            claim_text=str(claim["claim_text"]),
+            prior_claims=prior_claims,
+        )
+        novelty: DailyBriefNoveltyLabel = claim.get("novelty_vs_prior_brief", "unknown")
+        if novelty == "unknown":
+            novelty = "continued" if overlap >= 0.55 else "new"
+        deltas.append(
+            ClaimDelta(
+                claim_id=str(claim["claim_id"]),
+                prior_claim_ref=best_match,
+                novelty_label=novelty,
+                delta_explanation=_delta_explanation(
+                    novelty_label=novelty,
+                    claim_text=str(claim["claim_text"]),
+                    prior_claim_ref=best_match,
+                ),
+                supporting_prior_overlap={
+                    "citation_overlap": round(overlap, 2),
+                    "thesis_overlap": _overlap_label(overlap),
+                },
+            )
+        )
+    return deltas
+
+
+def build_changed_section_from_deltas(
+    *,
+    structured_claims: Iterable[StructuredClaim],
+    claim_deltas: Iterable[ClaimDelta],
+    limit: int = 3,
+) -> list[DailyBriefBullet]:
+    claims_by_id = {str(claim["claim_id"]): claim for claim in structured_claims}
+    changed: list[DailyBriefBullet] = []
+    for delta in claim_deltas:
+        novelty_label = delta["novelty_label"]
+        if novelty_label not in CHANGED_LABELS:
+            continue
+        claim = claims_by_id.get(str(delta["claim_id"]))
+        if claim is None:
+            continue
+        changed.append(
+            DailyBriefBullet(
+                claim_id=str(claim["claim_id"]),
+                claim_kind=claim["claim_kind"],
+                text=f"{novelty_label.capitalize()}: {claim['claim_text']}",
+                citation_ids=[str(citation_id) for citation_id in claim.get("supporting_citation_ids", [])],
+                confidence_label=str(claim.get("confidence", "medium")),
+                why_it_matters=str(claim.get("why_it_matters") or ""),
+                novelty_vs_prior_brief=novelty_label,
+                delta_label=novelty_label,
+                delta_explanation=str(delta["delta_explanation"]),
+            )
+        )
+        if len(changed) >= limit:
+            break
+    return changed
+
+
+def _best_prior_match(*, claim_text: str, prior_claims: Iterable[str]) -> tuple[str | None, float]:
+    best_match: str | None = None
+    best_overlap = 0.0
+    claim_tokens = _tokens(claim_text)
+    for prior_claim in prior_claims:
+        overlap = _jaccard(claim_tokens, _tokens(prior_claim))
+        if overlap > best_overlap:
+            best_overlap = overlap
+            best_match = prior_claim
+    return best_match, best_overlap
+
+
+def _delta_explanation(*, novelty_label: str, claim_text: str, prior_claim_ref: str | None) -> str:
+    if prior_claim_ref is None:
+        return f"{novelty_label.capitalize()} claim with no close prior analogue: {claim_text}"
+    return (
+        f"{novelty_label.capitalize()} versus prior brief. "
+        f"Closest prior claim: {prior_claim_ref}"
+    )
+
+
+def _overlap_label(overlap: float) -> str:
+    if overlap >= 0.65:
+        return "high"
+    if overlap >= 0.35:
+        return "medium"
+    return "low"
+
+
+def _tokens(value: str) -> set[str]:
+    return {token for token in re.findall(r"[a-z0-9]+", value.lower()) if len(token) > 2}
+
+
+def _jaccard(left: set[str], right: set[str]) -> float:
+    if not left and not right:
+        return 0.0
+    return len(left & right) / len(left | right)

--- a/apps/agent/daily_brief/editorial_planner.py
+++ b/apps/agent/daily_brief/editorial_planner.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from apps.agent.daily_brief.model_interfaces import BriefPlannerInput, BriefPlannerProvider
+from apps.agent.pipeline.types import (
+    BriefPlan,
+    DailyBriefRenderMode,
+    EvidencePackItem,
+    RuntimeDocumentRecord,
+    SourceScarcityMode,
+)
+
+STOPWORDS = {
+    "a",
+    "about",
+    "and",
+    "are",
+    "as",
+    "at",
+    "for",
+    "from",
+    "in",
+    "into",
+    "is",
+    "latest",
+    "market",
+    "markets",
+    "of",
+    "on",
+    "or",
+    "over",
+    "the",
+    "this",
+    "today",
+    "what",
+    "will",
+    "with",
+}
+WATCH_TERMS = ("ahead", "monitor", "next", "risk", "watch")
+
+
+class LocalBriefPlanner(BriefPlannerProvider):
+    def plan_brief(self, *, brief_input: BriefPlannerInput) -> BriefPlan:
+        return plan_brief_locally(
+            run_id=brief_input["run_id"],
+            generated_at_utc=brief_input["generated_at_utc"],
+            corpus_summary=brief_input["corpus_summary"],
+            source_diversity_stats=brief_input["source_diversity_stats"],
+            prior_brief_context=brief_input.get("prior_brief_context"),
+        )
+
+
+def build_corpus_summary(
+    *,
+    corpus_items: Iterable[EvidencePackItem],
+    documents_by_id: Mapping[str, RuntimeDocumentRecord],
+    limit: int = 4,
+) -> list[str]:
+    summary: list[str] = []
+    for item in corpus_items:
+        document = documents_by_id.get(str(item["doc_id"]))
+        if document is None:
+            continue
+        candidate = str(document.get("rss_snippet") or document.get("title") or "").strip()
+        if not candidate or candidate in summary:
+            continue
+        summary.append(candidate)
+        if len(summary) >= limit:
+            break
+    return summary
+
+
+def plan_brief_locally(
+    *,
+    run_id: str,
+    generated_at_utc: str,
+    corpus_summary: list[str],
+    source_diversity_stats: Mapping[str, Any],
+    prior_brief_context: Mapping[str, Any] | None,
+) -> BriefPlan:
+    candidate_issue_seeds = _candidate_issue_seeds(corpus_summary=corpus_summary)
+    unique_publishers = int(source_diversity_stats.get("unique_publishers", 0) or 0)
+    sparse_corpus = unique_publishers < 3 or len(candidate_issue_seeds) < 2
+    issue_budget = 1 if sparse_corpus else 2
+    render_mode: DailyBriefRenderMode = "compressed" if sparse_corpus else "full"
+    scarcity_mode: SourceScarcityMode = "scarce" if sparse_corpus else "normal"
+    watchlist = _watchlist(corpus_summary=corpus_summary)
+
+    brief_thesis = _brief_thesis(
+        corpus_summary=corpus_summary,
+        candidate_issue_seeds=candidate_issue_seeds,
+        prior_brief_context=prior_brief_context,
+    )
+    reason_codes = ["source_scarcity_detected"] if sparse_corpus else ["two_distinct_debates_supported"]
+    if not sparse_corpus and len(candidate_issue_seeds) > issue_budget:
+        reason_codes.append("third_issue_below_information_gain_threshold")
+
+    top_takeaways = corpus_summary[:3] or ["Insufficient distinct evidence for a full daily brief."]
+    issue_order = [f"seed_{index:03d}" for index in range(1, min(len(candidate_issue_seeds), issue_budget + 1) + 1)]
+    return BriefPlan(
+        brief_id=f"brief_{generated_at_utc[:10]}_{run_id}",
+        brief_thesis=brief_thesis,
+        top_takeaways=top_takeaways,
+        issue_budget=issue_budget,
+        render_mode=render_mode,
+        source_scarcity_mode=scarcity_mode,
+        candidate_issue_seeds=candidate_issue_seeds[:3],
+        issue_order=issue_order,
+        watchlist=watchlist,
+        reason_codes=reason_codes,
+    )
+
+
+def _candidate_issue_seeds(*, corpus_summary: Iterable[str]) -> list[str]:
+    seeds: list[str] = []
+    counts: Counter[str] = Counter()
+    for summary in corpus_summary:
+        counts.update(_tokens(summary))
+
+    ranked_terms = [term for term, _count in counts.most_common() if term not in STOPWORDS and len(term) > 3]
+    while ranked_terms and len(seeds) < 3:
+        current = ranked_terms.pop(0)
+        related = [current]
+        while ranked_terms and len(related) < 3:
+            candidate = ranked_terms[0]
+            if candidate[:4] == current[:4]:
+                ranked_terms.pop(0)
+                continue
+            related.append(ranked_terms.pop(0))
+        seeds.append(" ".join(related))
+
+    if not seeds:
+        return ["market narrative"]
+    return seeds
+
+
+def _watchlist(*, corpus_summary: Iterable[str]) -> list[str]:
+    watchlist: list[str] = []
+    for summary in corpus_summary:
+        lowered = summary.lower()
+        if any(term in lowered for term in WATCH_TERMS):
+            watchlist.append(summary)
+    return watchlist[:3]
+
+
+def _brief_thesis(
+    *,
+    corpus_summary: list[str],
+    candidate_issue_seeds: list[str],
+    prior_brief_context: Mapping[str, Any] | None,
+) -> str:
+    if len(candidate_issue_seeds) >= 2:
+        thesis = (
+            f"{candidate_issue_seeds[0].capitalize()} is shaping the day, while "
+            f"{candidate_issue_seeds[1]} defines the secondary debate."
+        )
+    elif candidate_issue_seeds:
+        thesis = f"{candidate_issue_seeds[0].capitalize()} is the main thesis of today's brief."
+    elif corpus_summary:
+        thesis = corpus_summary[0]
+    else:
+        thesis = "The brief is constrained by limited distinct evidence today."
+
+    previous_issue_count = 0
+    if isinstance(prior_brief_context, Mapping):
+        previous_issue_count = int(prior_brief_context.get("issue_count", 0) or 0)
+    if previous_issue_count > 0:
+        return f"{thesis} Prior context suggests continuity, but today's evidence mix remains distinct."
+    return thesis
+
+
+def _tokens(value: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", value.lower())

--- a/apps/agent/daily_brief/issue_dedup.py
+++ b/apps/agent/daily_brief/issue_dedup.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any, cast
+
+from apps.agent.pipeline.types import (
+    BriefPlan,
+    IssueInformationGain,
+    IssueInformationGainDecision,
+    IssueMap,
+    IssueOverlapDecision,
+    IssueOverlapReport,
+)
+
+HIGH_OVERLAP_THRESHOLD = 0.65
+MIN_INFORMATION_GAIN_SCORE = 0.55
+
+
+def dedupe_issues(
+    *,
+    issue_map: Iterable[IssueMap],
+    brief_plan: BriefPlan,
+) -> tuple[list[IssueMap], list[IssueOverlapReport], list[IssueInformationGain]]:
+    ordered_issues = [cast(IssueMap, dict(issue)) for issue in issue_map]
+    kept: list[IssueMap] = []
+    overlap_reports: list[IssueOverlapReport] = []
+    information_gain_reports: list[IssueInformationGain] = []
+
+    for issue in ordered_issues:
+        if len(kept) >= int(brief_plan["issue_budget"]):
+            information_gain_reports.append(
+                IssueInformationGain(
+                    issue_id=str(issue["issue_id"]),
+                    information_gain_score=0.0,
+                    decision="drop",
+                    reason_codes=["issue_budget_exceeded"],
+                )
+            )
+            continue
+        duplicate_target: IssueMap | None = None
+        max_overlap_score = 0.0
+        for kept_issue in kept:
+            report = _overlap_report(left_issue=kept_issue, right_issue=issue)
+            overlap_reports.append(report)
+            report_score = max(
+                float(report["question_token_overlap"]),
+                float(report["citation_overlap"]),
+                float(report["source_overlap"]),
+            )
+            max_overlap_score = max(max_overlap_score, report_score)
+            if report["decision"] == "merge":
+                duplicate_target = kept_issue
+                break
+        if duplicate_target is not None:
+            _merge_into(target=duplicate_target, issue=issue)
+            information_gain_reports.append(
+                IssueInformationGain(
+                    issue_id=str(issue["issue_id"]),
+                    information_gain_score=round(1.0 - max_overlap_score, 2),
+                    decision="drop",
+                    reason_codes=["restates_existing_issue", "low_incremental_value"],
+                )
+            )
+            continue
+
+        info_gain_score = round(1.0 - max_overlap_score, 2)
+        decision: IssueInformationGainDecision = "keep"
+        reason_codes = ["distinct_issue"]
+        if kept and info_gain_score < MIN_INFORMATION_GAIN_SCORE:
+            decision = "drop"
+            reason_codes = ["low_incremental_value", "restates_existing_issue"]
+        information_gain_reports.append(
+            IssueInformationGain(
+                issue_id=str(issue["issue_id"]),
+                information_gain_score=info_gain_score,
+                decision=decision,
+                reason_codes=reason_codes,
+            )
+        )
+        if decision == "keep":
+            kept.append(issue)
+
+    return kept, overlap_reports, information_gain_reports
+
+
+def _overlap_report(*, left_issue: Mapping[str, Any], right_issue: Mapping[str, Any]) -> IssueOverlapReport:
+    question_overlap = _jaccard(
+        _tokens(str(left_issue.get("issue_question") or "")),
+        _tokens(str(right_issue.get("issue_question") or "")),
+    )
+    citation_overlap = _evidence_overlap(left_issue=left_issue, right_issue=right_issue)
+    source_overlap = _source_overlap(left_issue=left_issue, right_issue=right_issue)
+    thesis_overlap_score = _jaccard(
+        _tokens(str(left_issue.get("thesis_hint") or "")),
+        _tokens(str(right_issue.get("thesis_hint") or "")),
+    )
+    decision: IssueOverlapDecision = "keep"
+    reason_codes: list[str] = []
+    if max(question_overlap, citation_overlap, source_overlap, thesis_overlap_score) >= HIGH_OVERLAP_THRESHOLD:
+        decision = "merge"
+        if citation_overlap >= HIGH_OVERLAP_THRESHOLD:
+            reason_codes.append("high_citation_overlap")
+        if question_overlap >= HIGH_OVERLAP_THRESHOLD or thesis_overlap_score >= HIGH_OVERLAP_THRESHOLD:
+            reason_codes.append("same_underlying_thesis")
+
+    thesis_overlap = "low"
+    if thesis_overlap_score >= HIGH_OVERLAP_THRESHOLD:
+        thesis_overlap = "high"
+    elif thesis_overlap_score >= 0.35:
+        thesis_overlap = "medium"
+
+    return IssueOverlapReport(
+        left_issue_id=str(left_issue["issue_id"]),
+        right_issue_id=str(right_issue["issue_id"]),
+        question_token_overlap=round(question_overlap, 2),
+        citation_overlap=round(citation_overlap, 2),
+        source_overlap=round(source_overlap, 2),
+        thesis_overlap=thesis_overlap,
+        decision=decision,
+        reason_codes=reason_codes,
+    )
+
+
+def _merge_into(*, target: IssueMap, issue: Mapping[str, Any]) -> None:
+    for field in (
+        "supporting_evidence_ids",
+        "opposing_evidence_ids",
+        "minority_evidence_ids",
+        "watch_evidence_ids",
+    ):
+        merged: list[str] = []
+        target_values = target.get(field, [])
+        issue_values = issue.get(field, [])
+        if not isinstance(target_values, list) or not isinstance(issue_values, list):
+            continue
+        for value in target_values + issue_values:
+            if value not in merged:
+                merged.append(str(value))
+        target[field] = merged
+
+
+def _evidence_overlap(*, left_issue: Mapping[str, Any], right_issue: Mapping[str, Any]) -> float:
+    left_ids = _issue_evidence_ids(left_issue)
+    right_ids = _issue_evidence_ids(right_issue)
+    return _jaccard(left_ids, right_ids)
+
+
+def _source_overlap(*, left_issue: Mapping[str, Any], right_issue: Mapping[str, Any]) -> float:
+    left_prefixes = {chunk_id.rsplit("_chunk_", 1)[0] for chunk_id in _issue_evidence_ids(left_issue)}
+    right_prefixes = {chunk_id.rsplit("_chunk_", 1)[0] for chunk_id in _issue_evidence_ids(right_issue)}
+    return _jaccard(left_prefixes, right_prefixes)
+
+
+def _issue_evidence_ids(issue: Mapping[str, Any]) -> set[str]:
+    evidence_ids: set[str] = set()
+    for field in (
+        "supporting_evidence_ids",
+        "opposing_evidence_ids",
+        "minority_evidence_ids",
+        "watch_evidence_ids",
+    ):
+        values = issue.get(field, [])
+        if not isinstance(values, list):
+            continue
+        evidence_ids.update(str(value) for value in values if isinstance(value, str))
+    return evidence_ids
+
+
+def _tokens(value: str) -> set[str]:
+    return {token for token in re.findall(r"[a-z0-9]+", value.lower()) if len(token) > 2}
+
+
+def _jaccard(left: Iterable[str], right: Iterable[str]) -> float:
+    left_set = set(left)
+    right_set = set(right)
+    if not left_set and not right_set:
+        return 0.0
+    return len(left_set & right_set) / len(left_set | right_set)

--- a/apps/agent/daily_brief/issue_retrieval.py
+++ b/apps/agent/daily_brief/issue_retrieval.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from apps.agent.pipeline.types import (
+    BriefPlan,
+    EvidencePackItem,
+    IssueEvidenceCoverageSummary,
+    IssueEvidenceScope,
+)
+
+OPPOSING_TERMS = ("against", "challenge", "despite", "however", "question", "push back")
+MINORITY_TERMS = ("contrarian", "dissent", "few", "minority", "outlier")
+WATCH_TERMS = ("ahead", "monitor", "next", "risk", "watch")
+
+
+def build_brief_corpus_report(
+    *,
+    fts_rows: Iterable[Mapping[str, Any]],
+    pack_size: int = 30,
+) -> dict[str, Any]:
+    rows = [_normalized_row(row) for row in fts_rows]
+    if not rows or pack_size <= 0:
+        return {
+            "items": [],
+            "diversity_check": "fail",
+            "diversity_stats": _coverage_summary([], rows_by_chunk_id={}),
+            "notes": ["No eligible rows were available for corpus-first retrieval."],
+        }
+
+    rows.sort(
+        key=lambda row: (
+            -float(row["retrieval_score"]),
+            -float(row["_published_timestamp"]),
+            str(row["chunk_id"]),
+        )
+    )
+    selected = _select_diverse_rows(rows=rows, pack_size=pack_size)
+    items = [_public_item(row=row, rank=index) for index, row in enumerate(selected, start=1)]
+    stats = _coverage_summary(
+        [item["chunk_id"] for item in items],
+        rows_by_chunk_id={row["chunk_id"]: row for row in rows},
+    )
+    notes: list[str] = []
+    if int(stats["unique_publishers"]) < 3:
+        notes.append("Corpus diversity is thin; brief may need compressed render mode.")
+    return {
+        "items": items,
+        "diversity_check": "pass" if int(stats["unique_publishers"]) >= 3 else "warn",
+        "diversity_stats": stats,
+        "notes": notes,
+    }
+
+
+def build_issue_evidence_scopes(
+    *,
+    brief_plan: BriefPlan,
+    corpus_items: Iterable[EvidencePackItem],
+    fts_rows: Iterable[Mapping[str, Any]],
+    registry: Mapping[str, Mapping[str, Any]],
+) -> list[IssueEvidenceScope]:
+    corpus_list = list(corpus_items)
+    rows_by_chunk_id = {str(row["chunk_id"]): row for row in fts_rows}
+    used_chunk_ids: set[str] = set()
+    scopes: list[IssueEvidenceScope] = []
+
+    for index, seed in enumerate(brief_plan["candidate_issue_seeds"], start=1):
+        scored_chunk_ids = _rank_chunks_for_seed(seed=seed, corpus_items=corpus_list, rows_by_chunk_id=rows_by_chunk_id)
+        primary_chunk_ids = [chunk_id for chunk_id in scored_chunk_ids if chunk_id not in used_chunk_ids][:3]
+        if not primary_chunk_ids:
+            primary_chunk_ids = [chunk_id for chunk_id in scored_chunk_ids[:2]]
+        used_chunk_ids.update(primary_chunk_ids)
+
+        opposing_chunk_ids = _bucket_chunk_ids(
+            chunk_ids=scored_chunk_ids,
+            rows_by_chunk_id=rows_by_chunk_id,
+            terms=OPPOSING_TERMS,
+            used_chunk_ids=used_chunk_ids,
+            limit=2,
+        )
+        minority_chunk_ids = _bucket_chunk_ids(
+            chunk_ids=scored_chunk_ids,
+            rows_by_chunk_id=rows_by_chunk_id,
+            terms=MINORITY_TERMS,
+            used_chunk_ids=used_chunk_ids,
+            limit=2,
+        )
+        watch_chunk_ids = _bucket_chunk_ids(
+            chunk_ids=scored_chunk_ids,
+            rows_by_chunk_id=rows_by_chunk_id,
+            terms=WATCH_TERMS,
+            used_chunk_ids=set(),
+            limit=2,
+        )
+        all_chunk_ids = primary_chunk_ids + opposing_chunk_ids + minority_chunk_ids + watch_chunk_ids
+        scopes.append(
+            IssueEvidenceScope(
+                issue_id=f"issue_{index:03d}",
+                issue_seed=str(seed),
+                primary_chunk_ids=primary_chunk_ids,
+                opposing_chunk_ids=opposing_chunk_ids,
+                minority_chunk_ids=minority_chunk_ids,
+                watch_chunk_ids=watch_chunk_ids,
+                coverage_summary=_issue_coverage_summary(
+                    chunk_ids=all_chunk_ids,
+                    rows_by_chunk_id=rows_by_chunk_id,
+                    registry=registry,
+                ),
+            )
+        )
+    return scopes[: max(1, int(brief_plan["issue_budget"]) + 1)]
+
+
+def _normalized_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    published_timestamp = _published_timestamp(row.get("published_at"))
+    credibility_tier = int(row.get("credibility_tier", 4) or 4)
+    recency_score = 1.0 if published_timestamp > 0 else 0.4
+    credibility_score = max(0.2, (5 - credibility_tier) / 4)
+    token_richness = min(1.0, len(_tokens(str(row.get("text") or ""))) / 40.0)
+    retrieval_score = round(recency_score * 0.45 + credibility_score * 0.35 + token_richness * 0.20, 6)
+    return {
+        "chunk_id": str(row["chunk_id"]),
+        "doc_id": str(row["doc_id"]),
+        "source_id": str(row["source_id"]),
+        "publisher": str(row["publisher"]),
+        "credibility_tier": credibility_tier,
+        "retrieval_score": retrieval_score,
+        "semantic_score": round(token_richness, 6),
+        "recency_score": recency_score,
+        "credibility_score": credibility_score,
+        "_published_timestamp": published_timestamp,
+    }
+
+
+def _select_diverse_rows(*, rows: list[dict[str, Any]], pack_size: int) -> list[dict[str, Any]]:
+    publisher_limit = max(1, int(math.ceil(min(pack_size, len(rows)) * 0.4)))
+    selected: list[dict[str, Any]] = []
+    publisher_counts: Counter[str] = Counter()
+    for row in rows:
+        if len(selected) >= pack_size:
+            break
+        if publisher_counts[str(row["publisher"])] >= publisher_limit:
+            continue
+        selected.append(row)
+        publisher_counts[str(row["publisher"])] += 1
+    for row in rows:
+        if len(selected) >= pack_size:
+            break
+        if row in selected:
+            continue
+        selected.append(row)
+    return selected
+
+
+def _public_item(*, row: Mapping[str, Any], rank: int) -> EvidencePackItem:
+    return cast(
+        EvidencePackItem,
+        {
+            "chunk_id": row["chunk_id"],
+            "source_id": row["source_id"],
+            "publisher": row["publisher"],
+            "credibility_tier": row["credibility_tier"],
+            "retrieval_score": row["retrieval_score"],
+            "semantic_score": row["semantic_score"],
+            "recency_score": row["recency_score"],
+            "credibility_score": row["credibility_score"],
+            "rank_in_pack": rank,
+            "doc_id": row["doc_id"],
+        },
+    )
+
+
+def _rank_chunks_for_seed(
+    *,
+    seed: str,
+    corpus_items: Iterable[EvidencePackItem],
+    rows_by_chunk_id: Mapping[str, Mapping[str, Any]],
+) -> list[str]:
+    seed_tokens = set(_tokens(seed))
+    scored: list[tuple[float, str]] = []
+    for item in corpus_items:
+        chunk_id = str(item["chunk_id"])
+        row = rows_by_chunk_id.get(chunk_id)
+        text = str(row.get("text") if isinstance(row, Mapping) else "")
+        text_tokens = set(_tokens(text))
+        overlap = len(seed_tokens & text_tokens)
+        score = overlap * 1.0 + float(item.get("semantic_score") or 0.0) + float(item.get("retrieval_score") or 0.0)
+        scored.append((score, chunk_id))
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    return [chunk_id for _score, chunk_id in scored]
+
+
+def _bucket_chunk_ids(
+    *,
+    chunk_ids: Iterable[str],
+    rows_by_chunk_id: Mapping[str, Mapping[str, Any]],
+    terms: tuple[str, ...],
+    used_chunk_ids: set[str],
+    limit: int,
+) -> list[str]:
+    bucket: list[str] = []
+    for chunk_id in chunk_ids:
+        if chunk_id in used_chunk_ids:
+            continue
+        row = rows_by_chunk_id.get(chunk_id)
+        text = str(row.get("text") if isinstance(row, Mapping) else "").lower()
+        if not any(term in text for term in terms):
+            continue
+        bucket.append(chunk_id)
+        if len(bucket) >= limit:
+            break
+    return bucket
+
+
+def _issue_coverage_summary(
+    *,
+    chunk_ids: Iterable[str],
+    rows_by_chunk_id: Mapping[str, Mapping[str, Any]],
+    registry: Mapping[str, Mapping[str, Any]],
+) -> IssueEvidenceCoverageSummary:
+    rows = [rows_by_chunk_id[chunk_id] for chunk_id in chunk_ids if chunk_id in rows_by_chunk_id]
+    source_roles: set[str] = set()
+    publishers: set[str] = set()
+    timestamps: list[float] = []
+    for row in rows:
+        source_id = str(row.get("source_id") or "")
+        publishers.add(str(row.get("publisher") or ""))
+        timestamps.append(_published_timestamp(row.get("published_at")))
+        registry_entry = registry.get(source_id, {})
+        tags = registry_entry.get("tags", []) if isinstance(registry_entry, Mapping) else []
+        for tag in tags:
+            if isinstance(tag, str):
+                source_roles.add(_source_role(tag))
+    nonzero_timestamps = [timestamp for timestamp in timestamps if timestamp > 0]
+    time_span_hours = 0
+    if nonzero_timestamps:
+        time_span_hours = int(round((max(nonzero_timestamps) - min(nonzero_timestamps)) / 3600))
+    return {
+        "unique_publishers": len([publisher for publisher in publishers if publisher]),
+        "source_roles": sorted(source_roles),
+        "time_span_hours": time_span_hours,
+    }
+
+
+def _coverage_summary(
+    chunk_ids: Iterable[str],
+    *,
+    rows_by_chunk_id: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    rows = [rows_by_chunk_id[chunk_id] for chunk_id in chunk_ids if chunk_id in rows_by_chunk_id]
+    publishers = {str(row.get("publisher") or "") for row in rows if row.get("publisher")}
+    tier_counts = Counter(int(row.get("credibility_tier", 4) or 4) for row in rows)
+    total = len(rows)
+    return {
+        "selected_count": total,
+        "unique_publishers": len(publishers),
+        "tier_1_pct": round((tier_counts[1] / total) * 100, 2) if total else 0.0,
+        "tier_2_pct": round((tier_counts[2] / total) * 100, 2) if total else 0.0,
+        "tier_3_pct": round((tier_counts[3] / total) * 100, 2) if total else 0.0,
+        "tier_4_pct": round((tier_counts[4] / total) * 100, 2) if total else 0.0,
+        "tier_1_2_pct": round(((tier_counts[1] + tier_counts[2]) / total) * 100, 2) if total else 0.0,
+        "max_publisher_pct": round(
+            (max(Counter(str(row.get("publisher") or "") for row in rows).values()) / total) * 100,
+            2,
+        )
+        if total
+        else 0.0,
+    }
+
+
+def _source_role(tag: str) -> str:
+    if tag.startswith("policy_") or tag.startswith("macro_"):
+        return "official"
+    if "market" in tag:
+        return "market_media"
+    return tag
+
+
+def _tokens(value: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", value.lower())
+
+
+def _published_timestamp(value: Any) -> float:
+    if not isinstance(value, str) or not value:
+        return 0.0
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return datetime.now(timezone.utc).timestamp()

--- a/apps/agent/daily_brief/model_interfaces.py
+++ b/apps/agent/daily_brief/model_interfaces.py
@@ -2,13 +2,28 @@ from __future__ import annotations
 
 from typing import Any, Protocol, TypedDict
 
-from apps.agent.pipeline.types import CriticReport, IssueMap, StructuredClaim
+from apps.agent.pipeline.types import (
+    BriefPlan,
+    CriticReport,
+    IssueEvidenceScope,
+    IssueMap,
+    StructuredClaim,
+)
+
+
+class BriefPlannerInput(TypedDict):
+    run_id: str
+    generated_at_utc: str
+    corpus_summary: list[str]
+    source_diversity_stats: dict[str, Any]
+    prior_brief_context: dict[str, Any] | None
 
 
 class IssuePlannerInput(TypedDict):
     run_id: str
     generated_at_utc: str
-    evidence_pack: list[dict[str, Any]]
+    brief_plan: BriefPlan
+    issue_evidence_scopes: list[IssueEvidenceScope]
     prior_brief_context: dict[str, Any] | None
 
 
@@ -40,4 +55,9 @@ class ClaimComposerProvider(Protocol):
 
 class CriticProvider(Protocol):
     def review_brief(self, *, brief_input: CriticInput) -> CriticReport:
+        ...
+
+
+class BriefPlannerProvider(Protocol):
+    def plan_brief(self, *, brief_input: BriefPlannerInput) -> BriefPlan:
         ...

--- a/apps/agent/daily_brief/openai_issue_planner.py
+++ b/apps/agent/daily_brief/openai_issue_planner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from json import JSONDecodeError
 from typing import Any, cast
 
@@ -13,8 +13,9 @@ MAX_EVIDENCE_TEXT_CHARS = 280
 MAX_PRIOR_CONTEXT_TEXT_CHARS = 240
 REQUEST_TASK = "daily_brief_issue_planner"
 ISSUE_PLANNER_SYSTEM_PROMPT = (
-    "You are planning 2-3 issue-centered literature review topics for a daily brief. "
-    "Use only the provided evidence pack. Return strict JSON matching the issue map schema."
+    "You are planning issue-centered literature review topics for a daily brief. "
+    "Use only the provided brief plan and issue-aware evidence scopes. "
+    "Return strict JSON matching the issue map schema."
 )
 ISSUE_MAP_JSON_SCHEMA: dict[str, Any] = {
     "name": "issue_map_list",
@@ -80,9 +81,10 @@ def _build_request_payload(brief_input: IssuePlannerInput) -> dict[str, Any]:
     bounded_input = {
         "run_id": brief_input["run_id"],
         "generated_at_utc": brief_input["generated_at_utc"],
-        "evidence_pack": [
-            _normalize_evidence_item(item)
-            for item in brief_input["evidence_pack"][:MAX_EVIDENCE_PACK_ITEMS]
+        "brief_plan": dict(brief_input["brief_plan"]),
+        "issue_evidence_scopes": [
+            _normalize_issue_scope(scope)
+            for scope in brief_input["issue_evidence_scopes"][:MAX_EVIDENCE_PACK_ITEMS]
         ],
         "prior_brief_context": _normalize_prior_brief_context(brief_input.get("prior_brief_context")),
     }
@@ -96,7 +98,7 @@ def _build_request_payload(brief_input: IssuePlannerInput) -> dict[str, Any]:
             {
                 "role": "user",
                 "content": (
-                    "Plan 2-3 issue-centered daily brief topics from the bounded evidence pack. "
+                    "Plan issue-centered daily brief topics from the brief plan and issue-aware evidence scopes. "
                     "Return only strict JSON matching the provided schema."
                 ),
             },
@@ -105,16 +107,24 @@ def _build_request_payload(brief_input: IssuePlannerInput) -> dict[str, Any]:
     }
 
 
-def _normalize_evidence_item(item: dict[str, Any]) -> dict[str, Any]:
+def _normalize_issue_scope(item: Mapping[str, Any]) -> dict[str, Any]:
     normalized: dict[str, Any] = {}
-    for field in ("chunk_id", "doc_id", "publisher", "title", "retrieval_score"):
+    for field in (
+        "issue_id",
+        "primary_chunk_ids",
+        "opposing_chunk_ids",
+        "minority_chunk_ids",
+        "watch_chunk_ids",
+        "coverage_summary",
+    ):
         if field in item:
             normalized[field] = item[field]
-    normalized["text"] = _truncate_text(item.get("text"))
     return normalized
 
 
-def _normalize_prior_brief_context(prior_brief_context: dict[str, Any] | None) -> dict[str, Any] | None:
+def _normalize_prior_brief_context(
+    prior_brief_context: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
     if prior_brief_context is None:
         return None
 
@@ -163,10 +173,19 @@ def _parse_response_payload(payload: Any) -> Any:
 
 def _extract_evidence_ids(brief_input: IssuePlannerInput) -> set[str]:
     evidence_ids: set[str] = set()
-    for item in brief_input["evidence_pack"]:
-        chunk_id = item.get("chunk_id")
-        if isinstance(chunk_id, str) and chunk_id:
-            evidence_ids.add(chunk_id)
+    for scope in brief_input["issue_evidence_scopes"]:
+        for field in (
+            "primary_chunk_ids",
+            "opposing_chunk_ids",
+            "minority_chunk_ids",
+            "watch_chunk_ids",
+        ):
+            values = scope.get(field)
+            if not isinstance(values, list):
+                continue
+            for chunk_id in values:
+                if isinstance(chunk_id, str) and chunk_id:
+                    evidence_ids.add(chunk_id)
     return evidence_ids
 
 

--- a/apps/agent/daily_brief/prior_brief_context.py
+++ b/apps/agent/daily_brief/prior_brief_context.py
@@ -23,7 +23,9 @@ def build_prior_brief_context(
     return {
         "previous_generated_at_utc": previous_generated_at_utc,
         "issue_count": len(issues),
+        "issue_questions": [issue["issue_question"] for issue in issues],
         "issues": issues,
+        "claim_texts": claim_summaries,
         "claim_summaries": claim_summaries,
         "citation_ids": citation_ids,
     }

--- a/apps/agent/daily_brief/provider_registry.py
+++ b/apps/agent/daily_brief/provider_registry.py
@@ -1,30 +1,115 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, TypeAlias, TypedDict
 
 from apps.agent.daily_brief.model_interfaces import ClaimComposerProvider, IssuePlannerProvider
 
 DailyBriefProviderName: TypeAlias = Literal["deterministic", "openai", "codex-oauth"]
+RequestedDailyBriefProviderName: TypeAlias = Literal["auto", "deterministic", "openai", "codex-oauth"]
+DailyBriefProviderMode: TypeAlias = Literal["deterministic", "model-assisted"]
+
+
+class DailyBriefProviderResolution(TypedDict):
+    requested_provider: RequestedDailyBriefProviderName | str
+    resolved_provider: DailyBriefProviderName
+    provider_mode: DailyBriefProviderMode
+    provider_fallback_used: bool
+    issue_planner: IssuePlannerProvider | None
+    claim_composer: ClaimComposerProvider | None
 
 
 def build_daily_brief_providers(
     *,
-    provider: DailyBriefProviderName | str,
+    provider: RequestedDailyBriefProviderName | str,
     openai_model: str | None = None,
     codex_runner: Callable[..., Any] | None = None,
     login_checker: Callable[[], bool] | None = None,
 ) -> tuple[IssuePlannerProvider | None, ClaimComposerProvider | None]:
-    if provider == "deterministic":
-        return (None, None)
-    if provider == "openai":
-        return _build_openai_providers(openai_model=openai_model)
-    if provider == "codex-oauth":
-        return _build_codex_oauth_providers(
+    resolution = resolve_daily_brief_provider(
+        provider=provider,
+        openai_model=openai_model,
+        codex_runner=codex_runner,
+        login_checker=login_checker,
+    )
+    return (resolution["issue_planner"], resolution["claim_composer"])
+
+
+def resolve_daily_brief_provider(
+    *,
+    provider: RequestedDailyBriefProviderName | str,
+    openai_model: str | None = None,
+    codex_runner: Callable[..., Any] | None = None,
+    login_checker: Callable[[], bool] | None = None,
+) -> DailyBriefProviderResolution:
+    if provider == "auto":
+        return _resolve_auto_provider(
+            openai_model=openai_model,
             codex_runner=codex_runner,
             login_checker=login_checker,
         )
+    if provider == "deterministic":
+        return {
+            "requested_provider": str(provider),
+            "resolved_provider": "deterministic",
+            "provider_mode": "deterministic",
+            "provider_fallback_used": False,
+            "issue_planner": None,
+            "claim_composer": None,
+        }
+    if provider == "openai":
+        issue_planner, claim_composer = _build_openai_providers(openai_model=openai_model)
+        return {
+            "requested_provider": str(provider),
+            "resolved_provider": "openai",
+            "provider_mode": "model-assisted",
+            "provider_fallback_used": False,
+            "issue_planner": issue_planner,
+            "claim_composer": claim_composer,
+        }
+    if provider == "codex-oauth":
+        issue_planner, claim_composer = _build_codex_oauth_providers(
+            codex_runner=codex_runner,
+            login_checker=login_checker,
+        )
+        return {
+            "requested_provider": str(provider),
+            "resolved_provider": "codex-oauth",
+            "provider_mode": "model-assisted",
+            "provider_fallback_used": False,
+            "issue_planner": issue_planner,
+            "claim_composer": claim_composer,
+        }
     raise ValueError(f"Unsupported provider: {provider}")
+
+
+def _resolve_auto_provider(
+    *,
+    openai_model: str | None,
+    codex_runner: Callable[..., Any] | None,
+    login_checker: Callable[[], bool] | None,
+) -> DailyBriefProviderResolution:
+    provider_errors: list[str] = []
+    providers_to_try: tuple[DailyBriefProviderName, ...] = ("codex-oauth", "openai")
+    for index, candidate in enumerate(providers_to_try):
+        try:
+            resolution = resolve_daily_brief_provider(
+                provider=candidate,
+                openai_model=openai_model,
+                codex_runner=codex_runner,
+                login_checker=login_checker,
+            )
+        except ValueError as exc:
+            provider_errors.append(f"{candidate}: {exc}")
+            continue
+        return {
+            **resolution,
+            "requested_provider": "auto",
+            "provider_fallback_used": index > 0,
+        }
+
+    joined_errors = "; ".join(provider_errors) if provider_errors else "no provider checks ran"
+    raise ValueError(f"Auto provider resolution failed. Tried {joined_errors}.")
 
 
 def _build_openai_providers(

--- a/apps/agent/daily_brief/runner.py
+++ b/apps/agent/daily_brief/runner.py
@@ -9,7 +9,18 @@ from pathlib import Path
 from smtplib import SMTP
 from typing import Any, cast
 
+from apps.agent.daily_brief.delta import build_changed_section_from_deltas, build_claim_deltas
+from apps.agent.daily_brief.editorial_planner import (
+    LocalBriefPlanner,
+    build_corpus_summary,
+)
+from apps.agent.daily_brief.issue_dedup import dedupe_issues
+from apps.agent.daily_brief.issue_retrieval import (
+    build_brief_corpus_report,
+    build_issue_evidence_scopes,
+)
 from apps.agent.daily_brief.model_interfaces import (
+    BriefPlannerProvider,
     ClaimComposerInput,
     ClaimComposerProvider,
     CriticInput,
@@ -20,7 +31,6 @@ from apps.agent.daily_brief.model_interfaces import (
 from apps.agent.daily_brief.prior_brief_context import build_prior_brief_context
 from apps.agent.daily_brief.synthesis import (
     SynthesisRetryPlan,
-    build_changed_section,
     build_citation_store,
     build_synthesis,
     build_synthesis_from_structured_claims,
@@ -42,9 +52,11 @@ from apps.agent.pipeline.identifiers import build_document_id, build_synthesis_i
 from apps.agent.pipeline.stage8_validation import run_stage8_citation_validation
 from apps.agent.pipeline.stage10_decision_record import build_and_persist_decision_record
 from apps.agent.pipeline.types import (
+    BriefPlan,
     BulletCitationRow,
     CitationStoreEntry,
     CitationValidationResult,
+    ClaimDelta,
     CriticReport,
     DailyBriefCorpusStageData,
     DailyBriefInputStageData,
@@ -52,9 +64,15 @@ from apps.agent.pipeline.types import (
     DailyBriefSectionBulletRow,
     DailyBriefSynthesis,
     DailyBriefSynthesisStageData,
+    DeliveryMode,
     EvidencePackItem,
     FtsRow,
+    IssueEvidenceScope,
+    IssueInformationGain,
     IssueMap,
+    IssueOverlapReport,
+    PublishDecision,
+    PublishDecisionStatus,
     RunStatus,
     RuntimeChunkRow,
     RuntimeDocumentRecord,
@@ -68,11 +86,11 @@ from apps.agent.portfolio.input_store import load_portfolio_positions
 from apps.agent.portfolio.relevance import build_portfolio_relevance_flags
 from apps.agent.retrieval.chunker import build_chunk_rows
 from apps.agent.retrieval.evidence_pack import build_evidence_pack_report
-from apps.agent.retrieval.fts_index import build_fts_rows
+from apps.agent.retrieval.fts_index import build_fts_rows, search_runtime_fts_rows
 from apps.agent.runtime.budget_guard import BudgetCaps
 from apps.agent.runtime.cost_ledger import BudgetWindowSnapshot
 from apps.agent.runtime.source_scope import load_active_source_subset, load_source_registry
-from apps.agent.storage.sqlite_runtime import persist_daily_brief_runtime
+from apps.agent.storage.sqlite_runtime import persist_daily_brief_runtime, persist_runtime_corpus
 from apps.agent.synthesis.postprocess import finalize_validation_outcome
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -146,6 +164,7 @@ def run_fixture_daily_brief(
     issue_planner: IssuePlannerProvider | None = None,
     claim_composer: ClaimComposerProvider | None = None,
     critic: CriticProvider | None = None,
+    provider_resolution: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     lifecycle: list[dict[str, Any]] = []
     execution: dict[str, Any] = {}
@@ -165,6 +184,7 @@ def run_fixture_daily_brief(
                 issue_planner=issue_planner,
                 claim_composer=claim_composer,
                 critic=critic,
+                provider_resolution=provider_resolution,
             )
         except Exception as exc:
             execution["status"] = "failed"
@@ -193,6 +213,7 @@ def run_fixture_daily_brief(
                 run_id=run_id,
                 generated_at_utc=timestamp,
                 pipeline_result=pipeline_result,
+                provider_resolution=provider_resolution,
             )
         )
     execution.setdefault("status", pipeline_result["status"])
@@ -222,6 +243,7 @@ def run_daily_brief(
     issue_planner: IssuePlannerProvider | None = None,
     claim_composer: ClaimComposerProvider | None = None,
     critic: CriticProvider | None = None,
+    provider_resolution: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     lifecycle: list[dict[str, Any]] = []
     execution: dict[str, Any] = {}
@@ -242,6 +264,7 @@ def run_daily_brief(
                 issue_planner=issue_planner,
                 claim_composer=claim_composer,
                 critic=critic,
+                provider_resolution=provider_resolution,
             )
         except Exception as exc:
             execution["status"] = "failed"
@@ -270,6 +293,7 @@ def run_daily_brief(
                 run_id=run_id,
                 generated_at_utc=timestamp,
                 pipeline_result=pipeline_result,
+                provider_resolution=provider_resolution,
             )
         )
     execution.setdefault("status", pipeline_result["status"])
@@ -301,6 +325,7 @@ def _execute_daily_brief_slice(
     issue_planner: IssuePlannerProvider | None = None,
     claim_composer: ClaimComposerProvider | None = None,
     critic: CriticProvider | None = None,
+    provider_resolution: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     report_date = generated_at_utc[:10]
     schedule = delivery_schedule or DailyBriefSchedule()
@@ -322,8 +347,16 @@ def _execute_daily_brief_slice(
         run_id=run_id,
         context=context,
     )
+    persist_runtime_corpus(
+        base_dir=base_dir,
+        source_rows=corpus_data.source_rows,
+        documents=corpus_data.documents,
+        chunks=corpus_data.chunks,
+        fts_rows=corpus_data.fts_rows,
+    )
     synthesis_data = build_daily_brief_synthesis(
         stage_data=corpus_data,
+        base_dir=base_dir,
         registry=input_data.registry,
         run_id=run_id,
         generated_at_utc=generated_at_utc,
@@ -347,7 +380,14 @@ def _execute_daily_brief_slice(
         final_status=synthesis_data.final_result["status"],
         budget_snapshot=budget_snapshot,
         diversity_report=synthesis_data.evidence_pack_report,
+        critic_report=synthesis_data.critic_report,
     )
+    publish_summary = _publish_summary(
+        stage8_result=synthesis_data.stage8_result,
+        critic_report=synthesis_data.critic_report,
+        email_requested=email_config is not None,
+    )
+    guardrail_checks = {**guardrail_checks, **publish_summary}
     render_daily_brief_html(
         output_path=output_path,
         report_date=report_date,
@@ -357,13 +397,17 @@ def _execute_daily_brief_slice(
         guardrail_checks=guardrail_checks,
     )
     email_delivery = None
-    if email_config is not None:
+    if email_config is not None and publish_summary["publish_decision"] == "publish":
         email_delivery = send_daily_brief_email(
             config=email_config,
             report_date=local_report_date,
             run_id=run_id,
             html_body=output_path.read_text(encoding="utf-8"),
-            status_title="Abstained" if synthesis_data.final_result["status"] == "abstained" else "Validated",
+            status_title="Abstained" if synthesis_data.final_result["status"] == "abstained" else "Ready",
+            synthesis=cast(dict[str, Any], synthesis_data.final_result["synthesis"]),
+            citation_status=publish_summary["citation_status"],
+            analytical_status=publish_summary["analytical_status"],
+            publish_decision=publish_summary["publish_decision"],
             smtp_class=smtp_class,
         )
 
@@ -376,6 +420,10 @@ def _execute_daily_brief_slice(
         removed_bullets=int(synthesis_data.stage8_result["report"]["removed_bullets"]),
         budget_snapshot=budget_snapshot,
         guardrail_checks=guardrail_checks,
+        citation_status=publish_summary["citation_status"],
+        analytical_status=publish_summary["analytical_status"],
+        publish_decision=publish_summary["publish_decision"],
+        reason_codes=publish_summary["reason_codes"],
         output_path=output_path,
         generated_at_utc=generated_at_utc,
     )
@@ -385,9 +433,15 @@ def _execute_daily_brief_slice(
     _write_json(artifact_dir / "documents.json", corpus_data.documents)
     _write_json(artifact_dir / "chunks.json", corpus_data.chunks)
     _write_json(artifact_dir / "fts_rows.json", corpus_data.fts_rows)
+    _write_json(artifact_dir / "brief_plan.json", synthesis_data.brief_plan)
+    _write_json(artifact_dir / "brief_corpus_items.json", synthesis_data.brief_corpus_items)
     _write_json(artifact_dir / "evidence_pack_items.json", synthesis_data.evidence_pack_items)
+    _write_json(artifact_dir / "issue_evidence_scopes.json", synthesis_data.issue_evidence_scopes)
     _write_json(artifact_dir / "issue_map.json", synthesis_data.issue_map)
+    _write_json(artifact_dir / "issue_overlap_reports.json", synthesis_data.issue_overlap_reports)
+    _write_json(artifact_dir / "information_gain_reports.json", synthesis_data.information_gain_reports)
     _write_json(artifact_dir / "claim_objects.json", synthesis_data.structured_claims)
+    _write_json(artifact_dir / "claim_deltas.json", synthesis_data.claim_deltas)
     _write_json(artifact_dir / "critic_report.json", synthesis_data.critic_report)
     _write_json(artifact_dir / "citations.json", synthesis_data.citation_rows)
     _write_json(artifact_dir / "synthesis.json", synthesis_data.final_result["synthesis"])
@@ -410,6 +464,7 @@ def _execute_daily_brief_slice(
             "issue_count": len(synthesis_data.issue_map),
             "claim_count": len(synthesis_data.structured_claims),
             "critic_status": None if synthesis_data.critic_report is None else synthesis_data.critic_report["status"],
+            "render_mode": synthesis_data.brief_plan["render_mode"],
             "docs_fetched": context.counters.docs_fetched,
             "docs_ingested": context.counters.docs_ingested,
             "chunks_indexed": context.counters.chunks_indexed,
@@ -427,6 +482,12 @@ def _execute_daily_brief_slice(
             "diversity_stats": synthesis_data.evidence_pack_report["diversity_stats"],
             "portfolio_positions_count": len(portfolio_positions),
             "portfolio_relevance_count": len(portfolio_relevance_flags),
+            "citation_status": publish_summary["citation_status"],
+            "analytical_status": publish_summary["analytical_status"],
+            "publish_decision": publish_summary["publish_decision"],
+            "reason_codes": publish_summary["reason_codes"],
+            "delivery_mode": publish_summary["delivery_mode"],
+            **_provider_summary(provider_resolution=provider_resolution),
         },
     )
 
@@ -440,6 +501,12 @@ def _execute_daily_brief_slice(
         "scheduled_for_local_date": local_report_date,
         "next_scheduled_run_at_utc": next_scheduled_run_at_utc,
         "email_delivery": email_delivery,
+        "citation_status": publish_summary["citation_status"],
+        "analytical_status": publish_summary["analytical_status"],
+        "publish_decision": publish_summary["publish_decision"],
+        "reason_codes": publish_summary["reason_codes"],
+        "delivery_mode": publish_summary["delivery_mode"],
+        **_provider_summary(provider_resolution=provider_resolution),
     }
 
 
@@ -526,22 +593,27 @@ def build_daily_brief_corpus(
     context.counters.docs_fetched = len(stage_data.planned_items)
     context.counters.docs_ingested = len(documents)
     context.counters.chunks_indexed = len(chunks)
+    corpus_report = build_brief_corpus_report(fts_rows=fts_rows, pack_size=30)
 
     return DailyBriefCorpusStageData(
         source_rows=stage_data.source_rows,
         documents=documents,
         chunks=chunks,
         fts_rows=fts_rows,
+        corpus_items=corpus_report["items"],
+        diversity_stats=corpus_report["diversity_stats"],
     )
 
 
 def build_daily_brief_synthesis(
     *,
     stage_data: DailyBriefCorpusStageData,
+    base_dir: Path | None = None,
     registry: Mapping[str, SourceRegistryEntry],
     run_id: str,
     generated_at_utc: str | None = None,
     previous_synthesis: Mapping[str, Any] | None = None,
+    brief_planner: BriefPlannerProvider | None = None,
     issue_planner: IssuePlannerProvider | None = None,
     claim_composer: ClaimComposerProvider | None = None,
     critic: CriticProvider | None = None,
@@ -550,17 +622,47 @@ def build_daily_brief_synthesis(
         raise ValueError("Daily brief synthesis requires both issue_planner and claim_composer together.")
 
     synthesis_generated_at_utc = generated_at_utc or _utc_now_iso()
-    query_text = build_daily_brief_query(documents=stage_data.documents)
-    evidence_pack_report = build_evidence_pack_report(
-        fts_rows=stage_data.fts_rows,
-        query_text=query_text,
-        pack_size=30,
-    )
-    evidence_pack_items = evidence_pack_report["items"]
-    evidence_pack_items = _attach_doc_ids(
-        evidence_pack_items=evidence_pack_items,
-        fts_rows=stage_data.fts_rows,
-    )
+    use_structured_orchestration = issue_planner is not None and claim_composer is not None
+    brief_corpus_items = list(stage_data.corpus_items)
+    if not brief_corpus_items:
+        corpus_report = build_brief_corpus_report(fts_rows=stage_data.fts_rows, pack_size=30)
+        brief_corpus_items = list(corpus_report["items"])
+        diversity_stats = dict(corpus_report["diversity_stats"])
+    else:
+        diversity_stats = dict(stage_data.diversity_stats)
+    evidence_pack_report = {
+        "items": brief_corpus_items,
+        "diversity_check": "pass" if int(diversity_stats.get("unique_publishers", 0) or 0) >= 3 else "warn",
+        "diversity_stats": diversity_stats,
+        "notes": [],
+    }
+    query_text = ""
+    if use_structured_orchestration:
+        evidence_pack_items = brief_corpus_items
+    else:
+        query_text = build_daily_brief_query(documents=stage_data.documents)
+        retrieval_rows: list[Mapping[str, Any]] = list(stage_data.fts_rows)
+        if base_dir is not None and query_text:
+            runtime_matches = search_runtime_fts_rows(
+                base_dir=base_dir,
+                query_text=query_text,
+                limit=60,
+            )
+            match_chunk_ids = {str(row["chunk_id"]) for row in runtime_matches}
+            retrieval_rows = [
+                row
+                for row in stage_data.fts_rows
+                if str(row["chunk_id"]) in match_chunk_ids
+            ] or list(stage_data.fts_rows)
+        evidence_pack_report = build_evidence_pack_report(
+            fts_rows=retrieval_rows,
+            query_text=query_text,
+            pack_size=30,
+        )
+        evidence_pack_items = _attach_doc_ids(
+            evidence_pack_items=cast(list[Mapping[str, Any]], evidence_pack_report["items"]),
+            fts_rows=cast(list[FtsRow], retrieval_rows),
+        )
 
     documents_by_id = {str(document["doc_id"]): document for document in stage_data.documents}
     chunks_by_id = {str(chunk["chunk_id"]): chunk for chunk in stage_data.chunks}
@@ -573,18 +675,38 @@ def build_daily_brief_synthesis(
         previous_synthesis=previous_synthesis,
         previous_generated_at_utc=None,
     )
-    use_structured_orchestration = issue_planner is not None and claim_composer is not None
+    brief_plan = _build_brief_plan(
+        brief_corpus_items=brief_corpus_items,
+        documents_by_id=documents_by_id,
+        diversity_stats=diversity_stats,
+        prior_brief_context=prior_brief_context,
+        brief_planner=brief_planner,
+        run_id=run_id,
+        generated_at_utc=synthesis_generated_at_utc,
+    )
+    issue_evidence_scopes = build_issue_evidence_scopes(
+        brief_plan=brief_plan,
+        corpus_items=brief_corpus_items,
+        fts_rows=stage_data.fts_rows,
+        registry=registry,
+    )
     issue_map: list[IssueMap] = []
+    issue_overlap_reports: list[IssueOverlapReport] = []
+    information_gain_reports: list[IssueInformationGain] = []
     structured_claims: list[StructuredClaim] = []
     if use_structured_orchestration:
         issue_map = _build_issue_map(
-            query_text=query_text,
-            evidence_pack_items=evidence_pack_items,
+            brief_plan=brief_plan,
+            issue_evidence_scopes=issue_evidence_scopes,
             issue_planner=issue_planner,
             prior_brief_context=prior_brief_context,
             run_id=run_id,
             generated_at_utc=synthesis_generated_at_utc,
         )
+    issue_map, issue_overlap_reports, information_gain_reports = dedupe_issues(
+        issue_map=issue_map,
+        brief_plan=brief_plan,
+    )
     validation_registry = _build_validation_registry(
         registry=registry,
         documents=stage_data.documents,
@@ -605,7 +727,9 @@ def build_daily_brief_synthesis(
                 generated_at_utc=synthesis_generated_at_utc,
             )
             synthesis = build_synthesis_from_structured_claims(
+                brief_plan=brief_plan,
                 issue_map=issue_map,
+                issue_evidence_scopes=issue_evidence_scopes,
                 structured_claims=structured_claims,
                 citation_store=citation_store,
             )
@@ -616,20 +740,20 @@ def build_daily_brief_synthesis(
                 citation_store=citation_store,
                 retry_plan=retry_plan,
             )
-            issue_map = _build_issue_map(
+            issue_map = _build_legacy_issue_map(
                 query_text=query_text,
                 evidence_pack_items=evidence_pack_items,
-                issue_planner=None,
-                prior_brief_context=prior_brief_context,
-                run_id=run_id,
-                generated_at_utc=synthesis_generated_at_utc,
             )
+            issue_overlap_reports = []
+            information_gain_reports = []
             structured_claims = _build_structured_claims_from_synthesis(
                 issue_map=issue_map,
                 synthesis=flat_synthesis,
             )
             synthesis = build_synthesis_from_structured_claims(
+                brief_plan=brief_plan,
                 issue_map=issue_map,
+                issue_evidence_scopes=issue_evidence_scopes,
                 structured_claims=structured_claims,
                 citation_store=citation_store,
             )
@@ -662,9 +786,13 @@ def build_daily_brief_synthesis(
         raise ValueError("Daily brief synthesis did not produce a validation result.")
 
     final_result = finalize_validation_outcome(validation_result=stage8_result)
-    changed_section = build_changed_section(
-        current_synthesis=final_result["synthesis"],
-        previous_synthesis=previous_synthesis,
+    claim_deltas = build_claim_deltas(
+        structured_claims=structured_claims,
+        prior_brief_context=prior_brief_context,
+    )
+    changed_section = build_changed_section_from_deltas(
+        structured_claims=structured_claims,
+        claim_deltas=claim_deltas,
     )
     if changed_section:
         final_synthesis = dict(final_result["synthesis"])
@@ -684,13 +812,33 @@ def build_daily_brief_synthesis(
                 prior_brief_context=prior_brief_context,
             )
         )
+    publish_decision = _build_publish_decision(
+        stage8_status=str(stage8_result["status"]),
+        critic_report=critic_report,
+    )
+    final_synthesis = _decorate_synthesis_meta(
+        synthesis=final_result["synthesis"],
+        publish_decision=publish_decision,
+        claim_deltas=claim_deltas,
+    )
+    final_result = {
+        **final_result,
+        "synthesis": cast(ValidatedDailyBriefSynthesis, final_synthesis),
+    }
     synthesis_id = build_synthesis_id(run_id=run_id)
     return DailyBriefSynthesisStageData(
         query_text=query_text,
+        brief_plan=brief_plan,
+        brief_corpus_items=brief_corpus_items,
         evidence_pack_items=evidence_pack_items,
         evidence_pack_report=evidence_pack_report,
+        issue_evidence_scopes=issue_evidence_scopes,
         issue_map=issue_map,
+        issue_overlap_reports=issue_overlap_reports,
+        information_gain_reports=information_gain_reports,
         structured_claims=structured_claims,
+        claim_deltas=claim_deltas,
+        publish_decision=publish_decision,
         citation_store=stage8_result["citation_store"],
         stage8_result=stage8_result,
         final_result=final_result,
@@ -764,10 +912,36 @@ def _build_retry_plan(
     )
 
 
+def _build_brief_plan(
+    *,
+    brief_corpus_items: list[EvidencePackItem],
+    documents_by_id: Mapping[str, RuntimeDocumentRecord],
+    diversity_stats: Mapping[str, Any],
+    prior_brief_context: Mapping[str, Any] | None,
+    brief_planner: BriefPlannerProvider | None,
+    run_id: str,
+    generated_at_utc: str,
+) -> BriefPlan:
+    corpus_summary = build_corpus_summary(
+        corpus_items=brief_corpus_items,
+        documents_by_id=documents_by_id,
+    )
+    planner = brief_planner or LocalBriefPlanner()
+    return planner.plan_brief(
+        brief_input={
+            "run_id": run_id,
+            "generated_at_utc": generated_at_utc,
+            "corpus_summary": corpus_summary,
+            "source_diversity_stats": dict(diversity_stats),
+            "prior_brief_context": None if prior_brief_context is None else dict(prior_brief_context),
+        }
+    )
+
+
 def _build_issue_map(
     *,
-    query_text: str,
-    evidence_pack_items: list[EvidencePackItem],
+    brief_plan: BriefPlan,
+    issue_evidence_scopes: list[IssueEvidenceScope],
     issue_planner: IssuePlannerProvider | None,
     prior_brief_context: dict[str, Any] | None,
     run_id: str,
@@ -778,11 +952,35 @@ def _build_issue_map(
             brief_input=IssuePlannerInput(
                 run_id=run_id,
                 generated_at_utc=generated_at_utc,
-                evidence_pack=[dict(item) for item in evidence_pack_items],
+                brief_plan=brief_plan,
+                issue_evidence_scopes=issue_evidence_scopes,
                 prior_brief_context=prior_brief_context,
             )
         )
 
+    issue_map: list[IssueMap] = []
+    seeds = list(brief_plan.get("candidate_issue_seeds", []))
+    for index, scope in enumerate(issue_evidence_scopes):
+        issue_seed = seeds[index] if index < len(seeds) else "market narrative"
+        issue_map.append(
+            IssueMap(
+                issue_id=str(scope["issue_id"]),
+                issue_question=f"What changed in {issue_seed}?",
+                thesis_hint=f"{issue_seed.capitalize()} is one of the main editorial threads in today's brief.",
+                supporting_evidence_ids=list(scope.get("primary_chunk_ids", [])),
+                opposing_evidence_ids=list(scope.get("opposing_chunk_ids", [])),
+                minority_evidence_ids=list(scope.get("minority_chunk_ids", [])),
+                watch_evidence_ids=list(scope.get("watch_chunk_ids", [])),
+            )
+        )
+    return issue_map[: max(1, int(brief_plan["issue_budget"]) + 1)]
+
+
+def _build_legacy_issue_map(
+    *,
+    query_text: str,
+    evidence_pack_items: list[EvidencePackItem],
+) -> list[IssueMap]:
     fallback_topic = query_text or "today's dominant narrative"
     issue_question = (
         f"What is the latest debate around {query_text}?"
@@ -966,6 +1164,65 @@ def _build_validation_registry(
     return normalized_registry
 
 
+def _build_publish_decision(
+    *,
+    stage8_status: str,
+    critic_report: CriticReport | None,
+) -> PublishDecision:
+    if stage8_status == "ok":
+        citation_status = "ok"
+    elif stage8_status == "partial":
+        citation_status = "partial"
+    else:
+        citation_status = "abstained"
+
+    analytical_status = "pass"
+    reason_codes: list[str] = []
+    if critic_report is not None:
+        analytical_status = str(critic_report["status"])
+        reason_codes.extend(str(code) for code in critic_report.get("reason_codes", []))
+
+    publish_decision: PublishDecisionStatus = "publish"
+    delivery_mode: DeliveryMode = "email_and_html"
+    if citation_status == "abstained" or analytical_status == "fail":
+        publish_decision = "hold"
+        delivery_mode = "html_only"
+    elif citation_status == "partial":
+        delivery_mode = "html_only"
+
+    if citation_status == "abstained":
+        reason_codes.append("citation_validation_abstained")
+
+    deduped_reason_codes: list[str] = []
+    for code in reason_codes:
+        if code not in deduped_reason_codes:
+            deduped_reason_codes.append(code)
+    return {
+        "citation_status": citation_status,
+        "analytical_status": analytical_status,
+        "publish_decision": publish_decision,
+        "reason_codes": deduped_reason_codes,
+        "delivery_mode": delivery_mode,
+    }
+
+
+def _decorate_synthesis_meta(
+    *,
+    synthesis: Mapping[str, Any],
+    publish_decision: PublishDecision,
+    claim_deltas: list[ClaimDelta],
+) -> dict[str, Any]:
+    final_synthesis = dict(synthesis)
+    meta = dict(final_synthesis.get("meta", {})) if isinstance(final_synthesis.get("meta"), Mapping) else {}
+    meta["citation_status"] = publish_decision["citation_status"]
+    meta["analytical_status"] = publish_decision["analytical_status"]
+    meta["publish_decision"] = publish_decision["publish_decision"]
+    meta["reason_codes"] = list(publish_decision["reason_codes"])
+    final_synthesis["meta"] = meta
+    final_synthesis["claim_deltas"] = [dict(delta) for delta in claim_deltas]
+    return final_synthesis
+
+
 def _attach_doc_ids(
     *,
     evidence_pack_items: Iterable[Mapping[str, Any]],
@@ -1069,6 +1326,7 @@ def _guardrail_checks(
     final_status: str,
     budget_snapshot: Mapping[str, Any],
     diversity_report: Mapping[str, Any] | None,
+    critic_report: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     citation_level = "warn" if stage8_result is None else "pass"
     if stage8_result is not None and stage8_result["status"] == "partial":
@@ -1109,7 +1367,29 @@ def _guardrail_checks(
         "paywall_check": "pass",
         "diversity_check": diversity_level,
         "budget_check": "pass" if budget_allowed else "fail",
+        "analytical_status": "pass" if critic_report is None else str(critic_report.get("status", "pass")),
         "notes": notes,
+    }
+
+
+def _publish_summary(
+    *,
+    stage8_result: Mapping[str, Any] | None,
+    critic_report: Mapping[str, Any] | None,
+    email_requested: bool,
+) -> dict[str, Any]:
+    decision = _build_publish_decision(
+        stage8_status="retry" if stage8_result is None else str(stage8_result.get("status", "retry")),
+        critic_report=cast(CriticReport | None, critic_report),
+    )
+    delivery_mode = decision["delivery_mode"]
+    if decision["publish_decision"] == "publish" and email_requested and delivery_mode == "html_only":
+        delivery_mode = "email_and_html"
+    if not email_requested and delivery_mode == "email_and_html":
+        delivery_mode = "html_only"
+    return {
+        **decision,
+        "delivery_mode": delivery_mode,
     }
 
 
@@ -1168,6 +1448,7 @@ def _persist_budget_stop_outputs(
     run_id: str,
     generated_at_utc: str,
     pipeline_result: Mapping[str, Any],
+    provider_resolution: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     report_date = generated_at_utc[:10]
     artifact_dir = _artifact_dir(base_dir=base_dir, report_date=report_date, run_id=run_id)
@@ -1205,6 +1486,12 @@ def _persist_budget_stop_outputs(
             "budget_ledger_rows": list(pipeline_result.get("budget_ledger_rows", [])),
             "guardrail_checks": guardrail_checks,
             "diversity_stats": {},
+            "citation_status": "abstained",
+            "analytical_status": "pass",
+            "publish_decision": "hold",
+            "reason_codes": ["budget_preflight_blocked"],
+            "delivery_mode": "hold",
+            **_provider_summary(provider_resolution=provider_resolution),
         },
     )
     return {
@@ -1214,6 +1501,12 @@ def _persist_budget_stop_outputs(
         "artifact_dir": str(artifact_dir),
         "query_text": None,
         "abstain_reason": pipeline_result.get("error_summary"),
+        "citation_status": "abstained",
+        "analytical_status": "pass",
+        "publish_decision": "hold",
+        "reason_codes": ["budget_preflight_blocked"],
+        "delivery_mode": "hold",
+        **_provider_summary(provider_resolution=provider_resolution),
     }
 
 
@@ -1241,6 +1534,8 @@ def _persist_run_state(
                 chunks=[],
                 evidence_pack_items=[],
                 evidence_pack_report={"diversity_stats": {}},
+                issue_map_rows=[],
+                structured_claim_rows=[],
                 citation_rows=[],
                 synthesis_rows=[],
                 bullet_citation_rows=[],
@@ -1253,6 +1548,8 @@ def _persist_run_state(
         evidence_pack_items = json.loads(
             (artifact_dir / "evidence_pack_items.json").read_text(encoding="utf-8")
         )
+        issue_map_rows = json.loads((artifact_dir / "issue_map.json").read_text(encoding="utf-8"))
+        structured_claim_rows = json.loads((artifact_dir / "claim_objects.json").read_text(encoding="utf-8"))
         citations = json.loads((artifact_dir / "citations.json").read_text(encoding="utf-8"))
         synthesis_bullets = json.loads(
             (artifact_dir / "synthesis_bullets.json").read_text(encoding="utf-8")
@@ -1274,6 +1571,8 @@ def _persist_run_state(
             chunks=chunks,
             evidence_pack_items=evidence_pack_items,
             evidence_pack_report={"diversity_stats": run_summary.get("diversity_stats", {})},
+            issue_map_rows=issue_map_rows,
+            structured_claim_rows=structured_claim_rows,
             citation_rows=citations,
             synthesis_rows=synthesis_bullets,
             bullet_citation_rows=bullet_citations,
@@ -1292,12 +1591,30 @@ def _persist_run_state(
         chunks=[],
         evidence_pack_items=[],
         evidence_pack_report={"diversity_stats": {}},
+        issue_map_rows=[],
+        structured_claim_rows=[],
         citation_rows=[],
         synthesis_rows=[],
         bullet_citation_rows=[],
         run_row=run_row,
         budget_ledger_rows=pipeline_result.get("budget_ledger_rows", []),
     )
+
+
+def _provider_summary(*, provider_resolution: Mapping[str, Any] | None) -> dict[str, Any]:
+    if isinstance(provider_resolution, Mapping):
+        return {
+            "requested_provider": provider_resolution.get("requested_provider"),
+            "resolved_provider": provider_resolution.get("resolved_provider"),
+            "provider_mode": provider_resolution.get("provider_mode"),
+            "provider_fallback_used": bool(provider_resolution.get("provider_fallback_used", False)),
+        }
+    return {
+        "requested_provider": None,
+        "resolved_provider": None,
+        "provider_mode": None,
+        "provider_fallback_used": False,
+    }
 
 
 def _utc_now_iso() -> str:

--- a/apps/agent/daily_brief/synthesis.py
+++ b/apps/agent/daily_brief/synthesis.py
@@ -2,18 +2,24 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from apps.agent.pipeline.types import (
     DAILY_BRIEF_CORE_OUTPUT_SECTIONS,
+    BriefPlan,
     CitationStoreEntry,
     ClaimEvidenceItem,
     DailyBriefBullet,
+    DailyBriefClaimKind,
     DailyBriefIssue,
+    DailyBriefNoveltyLabel,
     DailyBriefOutputSection,
+    DailyBriefOverview,
     DailyBriefSynthesis,
     DailyBriefSynthesisV2,
     EvidencePackItem,
+    IssueEvidenceCoverageSummary,
+    IssueEvidenceScope,
     IssueMap,
     RuntimeChunkRow,
     RuntimeDocumentRecord,
@@ -200,18 +206,33 @@ def build_changed_section(
 
 def build_synthesis_from_structured_claims(
     *,
+    brief_plan: BriefPlan,
     issue_map: Iterable[IssueMap],
+    issue_evidence_scopes: Iterable[IssueEvidenceScope],
     structured_claims: Iterable[StructuredClaim],
     citation_store: Mapping[str, CitationStoreEntry],
 ) -> DailyBriefSynthesisV2:
     claims_by_issue_id: dict[str, list[StructuredClaim]] = {}
     for claim in structured_claims:
         claims_by_issue_id.setdefault(str(claim["issue_id"]), []).append(claim)
+    scopes_by_issue_id = {
+        str(scope["issue_id"]): scope
+        for scope in issue_evidence_scopes
+    }
 
     issues: list[DailyBriefIssue] = []
     for issue in issue_map:
         issue_id = str(issue["issue_id"])
         issue_claims = claims_by_issue_id.get(issue_id, [])
+        scope = scopes_by_issue_id.get(issue_id)
+        coverage_summary = (
+            scope["coverage_summary"]
+            if scope is not None
+            else cast(
+                IssueEvidenceCoverageSummary,
+                {"unique_publishers": 0, "source_roles": [], "time_span_hours": 0.0},
+            )
+        )
         issues.append(
             DailyBriefIssue(
                 issue_id=issue_id,
@@ -222,10 +243,18 @@ def build_synthesis_from_structured_claims(
                 counter=_bullets_for_issue(issue_claims, "counter", citation_store),
                 minority=_bullets_for_issue(issue_claims, "minority", citation_store),
                 watch=_bullets_for_issue(issue_claims, "watch", citation_store),
+                coverage_summary=coverage_summary,
             )
         )
 
     return DailyBriefSynthesisV2(
+        brief=DailyBriefOverview(
+            bottom_line=str(brief_plan.get("brief_thesis") or ""),
+            top_takeaways=list(brief_plan.get("top_takeaways", [])),
+            watchlist=list(brief_plan.get("watchlist", [])),
+            render_mode=brief_plan.get("render_mode", "full"),
+            source_scarcity_mode=brief_plan.get("source_scarcity_mode", "normal"),
+        ),
         issues=issues,
         meta={"status": "validated"},
     )
@@ -242,9 +271,16 @@ def _bullets_for_issue(
             continue
         supporting_citation_ids = list(claim["supporting_citation_ids"])
         bullet: DailyBriefBullet = {
+            "claim_id": str(claim["claim_id"]),
+            "claim_kind": cast(DailyBriefClaimKind, str(claim["claim_kind"])),
             "text": str(claim["claim_text"]),
             "citation_ids": supporting_citation_ids,
             "confidence_label": str(claim["confidence"]),
+            "why_it_matters": str(claim.get("why_it_matters") or ""),
+            "novelty_vs_prior_brief": cast(
+                DailyBriefNoveltyLabel,
+                str(claim.get("novelty_vs_prior_brief") or "unknown"),
+            ),
         }
         evidence = _build_evidence_items(
             citation_ids=supporting_citation_ids,

--- a/apps/agent/delivery/email_sender.py
+++ b/apps/agent/delivery/email_sender.py
@@ -23,23 +23,36 @@ def send_daily_brief_email(
     report_date: str,
     run_id: str,
     html_body: str,
-    status_title: str,
+    status_title: str = "Ready",
+    synthesis: dict[str, Any] | None = None,
+    citation_status: str = "ok",
+    analytical_status: str = "pass",
+    publish_decision: str = "publish",
     smtp_class: Any = SMTP,
 ) -> dict[str, Any]:
     if not config.recipient_emails:
         raise ValueError("recipient_emails must include at least one address.")
 
     subject = f"{config.subject_prefix}: {report_date}"
+    if publish_decision != "publish":
+        subject = f"{config.subject_prefix} [{publish_decision.upper()}]: {report_date}"
+    elif citation_status != "ok" or analytical_status != "pass":
+        subject = f"{config.subject_prefix} [{citation_status.upper()}/{analytical_status.upper()}]: {report_date}"
     message = EmailMessage()
     message["From"] = config.sender_email
     message["To"] = ", ".join(config.recipient_emails)
     message["Subject"] = subject
+    summary_lines = _build_plain_text_summary(synthesis=synthesis)
     message.set_content(
         "\n".join(
             [
                 f"Daily Brief status: {status_title}",
+                f"Citation status: {citation_status}",
+                f"Analytical quality: {analytical_status}",
+                f"Publish decision: {publish_decision}",
                 f"Report date: {report_date}",
                 f"Run: {run_id}",
+                *summary_lines,
             ]
         )
     )
@@ -54,4 +67,51 @@ def send_daily_brief_email(
         "recipient_count": len(config.recipient_emails),
         "subject": subject,
         "smtp_host": config.smtp_host,
+        "publish_decision": publish_decision,
     }
+
+
+def _build_plain_text_summary(*, synthesis: dict[str, Any] | None) -> list[str]:
+    if not isinstance(synthesis, dict):
+        return []
+
+    lines: list[str] = []
+    brief = synthesis.get("brief")
+    if isinstance(brief, dict):
+        bottom_line = str(brief.get("bottom_line") or "").strip()
+        if bottom_line:
+            lines.append(f"Bottom line: {bottom_line}")
+        takeaways = brief.get("top_takeaways", [])
+        if isinstance(takeaways, list):
+            for takeaway in takeaways[:3]:
+                if isinstance(takeaway, str) and takeaway.strip():
+                    lines.append(f"- {takeaway.strip()}")
+
+    issues = synthesis.get("issues", [])
+    if not isinstance(issues, list):
+        return lines
+
+    for issue in issues[:1]:
+        if not isinstance(issue, dict):
+            continue
+        issue_title = str(issue.get("title") or issue.get("issue_question") or "").strip()
+        if issue_title:
+            lines.append(f"Issue: {issue_title}")
+        for section in ("prevailing", "counter", "minority", "watch"):
+            bullets = issue.get(section, [])
+            if not isinstance(bullets, list) or not bullets:
+                continue
+            bullet = bullets[0]
+            if not isinstance(bullet, dict):
+                continue
+            novelty = str(bullet.get("novelty_vs_prior_brief") or "").strip()
+            claim_text = str(bullet.get("text") or "").strip()
+            why_it_matters = str(bullet.get("why_it_matters") or "").strip()
+            if claim_text:
+                prefix = f"{section}: "
+                if novelty:
+                    prefix = f"{section} [{novelty}]: "
+                lines.append(prefix + claim_text)
+            if why_it_matters:
+                lines.append(f"Why it matters: {why_it_matters}")
+    return lines

--- a/apps/agent/delivery/html_report.py
+++ b/apps/agent/delivery/html_report.py
@@ -25,8 +25,12 @@ def render_daily_brief_html(
 ) -> Path:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     abstained = _is_abstained(synthesis)
-    status_title = "Abstained" if abstained else "Validated"
+    brief = synthesis.get("brief", {}) if isinstance(synthesis.get("brief"), Mapping) else {}
+    citation_status = str((guardrail_checks or {}).get("citation_status") or ("abstained" if abstained else "ok"))
+    analytical_status = str((guardrail_checks or {}).get("analytical_status") or "pass")
+    publish_decision = str((guardrail_checks or {}).get("publish_decision") or ("hold" if abstained else "publish"))
     issues = _normalized_issues(synthesis)
+    overview_html = _render_overview(brief)
 
     issues_html = "".join(_render_issue(issue) for issue in issues if isinstance(issue, Mapping))
     changed_html = _render_changed_section(synthesis.get("changed"))
@@ -158,9 +162,12 @@ def render_daily_brief_html(
       <div class="meta">
         <span>Date: {escape(report_date)}</span>
         <span>Run: {escape(run_id)}</span>
-        <span>Status: {escape(status_title)}</span>
+        <span>Citation status: {escape(_label(citation_status))}</span>
+        <span>Analytical quality: {escape(_label(analytical_status))}</span>
+        <span>Publish decision: {escape(_label(publish_decision))}</span>
       </div>
     </header>
+    {overview_html}
     <section class="issues">
       {issues_html}
     </section>
@@ -180,6 +187,7 @@ def render_daily_brief_html(
 def _render_issue(issue: Mapping[str, Any]) -> str:
     title = escape(str(issue.get("title") or issue.get("issue_question") or "Key issue"))
     summary = escape(str(issue.get("summary", "")))
+    coverage_html = _render_coverage(issue.get("coverage_summary"))
     sections_html = "".join(
         _render_issue_section(title=title_text, bullets=issue.get(section, []))
         for section, title_text in SECTION_TITLES.items()
@@ -188,6 +196,7 @@ def _render_issue(issue: Mapping[str, Any]) -> str:
         '<article class="issue">'
         f"<h2>{title}</h2>"
         f'<p class="summary">{summary}</p>'
+        f"{coverage_html}"
         f'<div class="arguments">{sections_html}</div>'
         "</article>"
     )
@@ -211,10 +220,16 @@ def _render_bullet(bullet: Mapping[str, Any]) -> str:
         f' <a class="citation-link" href="#{escape(citation_id)}">[{escape(citation_id)}]</a>'
         for citation_id in citation_ids
     )
+    novelty = str(bullet.get("novelty_vs_prior_brief") or bullet.get("delta_label") or "").strip()
+    novelty_html = f' <strong>({escape(_label(novelty))})</strong>' if novelty else ""
+    why_it_matters = str(bullet.get("why_it_matters") or "").strip()
+    delta_explanation = str(bullet.get("delta_explanation") or "").strip()
     evidence_html = _render_evidence_block(bullet.get("evidence"))
     return (
         "<li>"
-        f"{escape(str(bullet.get('text', '')))}{citation_links}"
+        f"{escape(str(bullet.get('text', '')))}{novelty_html}{citation_links}"
+        f"{_render_callout('Why it matters', why_it_matters)}"
+        f"{_render_callout('Delta', delta_explanation)}"
         f"{evidence_html}"
         "</li>"
     )
@@ -249,7 +264,7 @@ def _render_changed_section(changed_bullets: Any) -> str:
     items = "".join(_render_bullet(bullet) for bullet in changed_bullets if isinstance(bullet, Mapping))
     return (
         '<section class="changed">'
-        "<h2>Changed Since Yesterday</h2>"
+        "<h2>What Changed</h2>"
         f"<ul>{items}</ul>"
         "</section>"
     )
@@ -276,9 +291,63 @@ def _render_guardrails(guardrail_checks: Mapping[str, Any] | None) -> str:
         f"<li>Budget: {escape(_label(str(guardrail_checks.get('budget_check', 'warn'))))}</li>"
         f"<li>Diversity: {escape(_label(str(guardrail_checks.get('diversity_check', 'warn'))))}</li>"
         f"<li>Citations: {escape(_label(str(guardrail_checks.get('citation_check', 'warn'))))}</li>"
+        f"<li>Analytical quality: {escape(_label(str(guardrail_checks.get('analytical_status', 'pass'))))}</li>"
         f"{notes}"
         "</ul>"
         "</section>"
+    )
+
+
+def _render_overview(brief: Mapping[str, Any]) -> str:
+    if not brief:
+        return ""
+    bottom_line = escape(str(brief.get("bottom_line") or ""))
+    takeaways = brief.get("top_takeaways", [])
+    watchlist = brief.get("watchlist", [])
+    render_mode = escape(_label(str(brief.get("render_mode") or "full")))
+    takeaway_items = ""
+    if isinstance(takeaways, list):
+        takeaway_items = "".join(
+            f"<li>{escape(str(item))}</li>"
+            for item in takeaways
+            if isinstance(item, str) and item.strip()
+        )
+    watch_items = ""
+    if isinstance(watchlist, list):
+        watch_items = "".join(
+            f"<li>{escape(str(item))}</li>"
+            for item in watchlist
+            if isinstance(item, str) and item.strip()
+        )
+    return (
+        '<section class="issues">'
+        "<h2>Bottom Line</h2>"
+        f"<p>{bottom_line}</p>"
+        f"<p class=\"summary\">Render mode: {render_mode}</p>"
+        "<h2>Key Takeaways</h2>"
+        f"<ul>{takeaway_items}</ul>"
+        f"{('<h2>Watchlist</h2><ul>' + watch_items + '</ul>') if watch_items else ''}"
+        "</section>"
+    )
+
+
+def _render_callout(title: str, value: str) -> str:
+    if not value:
+        return ""
+    return f'<p><strong>{escape(title)}:</strong> {escape(value)}</p>'
+
+
+def _render_coverage(coverage_summary: Any) -> str:
+    if not isinstance(coverage_summary, Mapping) or not coverage_summary:
+        return ""
+    roles = coverage_summary.get("source_roles", [])
+    roles_label = ", ".join(str(role) for role in roles) if isinstance(roles, list) else ""
+    return (
+        '<p class="summary">'
+        f"Coverage: {escape(str(coverage_summary.get('unique_publishers', 0)))} publishers"
+        f"{'; roles: ' + escape(roles_label) if roles_label else ''}"
+        f"{'; span: ' + escape(str(coverage_summary.get('time_span_hours', 0)))}h"
+        "</p>"
     )
 
 

--- a/apps/agent/ingest/live_fetch.py
+++ b/apps/agent/ingest/live_fetch.py
@@ -4,12 +4,17 @@ import xml.etree.ElementTree as ET
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
+from html.parser import HTMLParser
+from io import StringIO
 from typing import Any
 from urllib.request import Request, urlopen
 
 DEFAULT_REQUEST_HEADERS = {
     "User-Agent": "Mozilla/5.0 (compatible; MVP-Agent/0.1; +https://example.test/local)",
-    "Accept": "application/rss+xml, application/atom+xml, application/xml, text/xml;q=0.9, */*;q=0.8",
+    "Accept": (
+        "application/rss+xml, application/atom+xml, application/xml, text/xml;q=0.9, "
+        "text/html;q=0.8, application/pdf;q=0.8, */*;q=0.7"
+    ),
 }
 
 
@@ -20,16 +25,22 @@ def fetch_live_payloads_for_source(
     timeout_seconds: int = 20,
 ) -> list[dict[str, Any]]:
     source_type = str(source["type"])
-    if source_type != "rss":
+    if source_type not in {"rss", "html", "pdf"}:
         raise ValueError(f"Unsupported live fetch source type: {source_type}")
-
     request = Request(str(source["url"]), headers=DEFAULT_REQUEST_HEADERS)
     with urlopen(request, timeout=timeout_seconds) as response:
-        feed_bytes = response.read()
+        response_bytes = response.read()
 
-    feed_text = feed_bytes.decode("utf-8", errors="replace")
     resolved_fetched_at = fetched_at_utc or _utc_now_iso()
-    return parse_rss_feed(feed_text=feed_text, fetched_at_utc=resolved_fetched_at)
+    if source_type == "rss":
+        feed_text = response_bytes.decode("utf-8", errors="replace")
+        return parse_rss_feed(feed_text=feed_text, fetched_at_utc=resolved_fetched_at)
+    if source_type == "html":
+        html_text = response_bytes.decode("utf-8", errors="replace")
+        return [_html_payload_from_page(source=source, html_text=html_text, fetched_at_utc=resolved_fetched_at)]
+    if source_type == "pdf":
+        return [_pdf_payload_from_bytes(source=source, pdf_bytes=response_bytes, fetched_at_utc=resolved_fetched_at)]
+    raise ValueError(f"Unsupported live fetch source type: {source_type}")
 
 
 def parse_rss_feed(*, feed_text: str, fetched_at_utc: str) -> list[dict[str, Any]]:
@@ -79,6 +90,50 @@ def _atom_entry_to_payload(*, entry: ET.Element, fetched_at_utc: str) -> dict[st
     }
 
 
+def _html_payload_from_page(
+    *,
+    source: Mapping[str, Any],
+    html_text: str,
+    fetched_at_utc: str,
+) -> dict[str, Any]:
+    parser = _HtmlPayloadParser()
+    parser.feed(html_text)
+    parser.close()
+    canonical_url = parser.canonical_url or str(source["url"])
+    return {
+        "canonical_url": canonical_url,
+        "headline": parser.title,
+        "byline": parser.author,
+        "language": parser.language,
+        "published_at": _normalize_timestamp(parser.published_at),
+        "fetched_at": fetched_at_utc,
+        "snippet": parser.description,
+        "text": parser.body_text,
+        "doc_type": "html",
+    }
+
+
+def _pdf_payload_from_bytes(
+    *,
+    source: Mapping[str, Any],
+    pdf_bytes: bytes,
+    fetched_at_utc: str,
+) -> dict[str, Any]:
+    url = str(source["url"])
+    return {
+        "url": url,
+        "canonical_url": url,
+        "title": source.get("name"),
+        "author": None,
+        "language": None,
+        "published_at": None,
+        "fetched_at": fetched_at_utc,
+        "summary": None,
+        "pdf_bytes": pdf_bytes,
+        "doc_type": "pdf",
+    }
+
+
 def _first_text(element: ET.Element, *paths: str) -> str | None:
     for path in paths:
         child = element.find(path)
@@ -108,3 +163,63 @@ def _normalize_timestamp(value: str | None) -> str | None:
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+class _HtmlPayloadParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.title: str | None = None
+        self.author: str | None = None
+        self.description: str | None = None
+        self.published_at: str | None = None
+        self.canonical_url: str | None = None
+        self.language: str | None = None
+        self.body_text: str | None = None
+        self._current_tag: str | None = None
+        self._title_buffer = StringIO()
+        self._body_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = {name.lower(): value for name, value in attrs}
+        if tag == "html":
+            self.language = attributes.get("lang")
+        elif tag == "title":
+            self._current_tag = "title"
+        elif tag == "body":
+            self._body_depth += 1
+        elif tag == "meta":
+            self._capture_meta(attributes)
+        elif tag == "link" and str(attributes.get("rel") or "").lower() == "canonical":
+            self.canonical_url = attributes.get("href")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            title = self._title_buffer.getvalue().strip()
+            if title:
+                self.title = title
+            self._current_tag = None
+        elif tag == "body" and self._body_depth > 0:
+            self._body_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self._current_tag == "title":
+            self._title_buffer.write(data)
+        if self._body_depth > 0:
+            normalized = " ".join(data.split())
+            if normalized:
+                if self.body_text is None:
+                    self.body_text = normalized
+                else:
+                    self.body_text = f"{self.body_text} {normalized}"
+
+    def _capture_meta(self, attributes: Mapping[str, str | None]) -> None:
+        name = (attributes.get("name") or attributes.get("property") or "").lower()
+        content = attributes.get("content")
+        if not content:
+            return
+        if name in {"description", "og:description"}:
+            self.description = content
+        elif name in {"author", "article:author"}:
+            self.author = content
+        elif name in {"article:published_time", "published_time", "pubdate"}:
+            self.published_at = content

--- a/apps/agent/pipeline/stage10_decision_record.py
+++ b/apps/agent/pipeline/stage10_decision_record.py
@@ -86,6 +86,10 @@ def build_and_persist_decision_record(
     removed_bullets: int,
     budget_snapshot: Mapping[str, Any],
     guardrail_checks: Mapping[str, Any],
+    citation_status: str | None = None,
+    analytical_status: str | None = None,
+    publish_decision: str | None = None,
+    reason_codes: list[str] | None = None,
     output_path: Path | None = None,
     generated_at_utc: str | None = None,
 ) -> dict[str, Any]:
@@ -106,6 +110,10 @@ def build_and_persist_decision_record(
             "text": str(bullet.get("text", "")),
             "citation_ids": citation_ids,
             "coverage_status": "supported" if len(citation_ids) >= 1 else "insufficient_evidence",
+            "why_it_matters": str(bullet.get("why_it_matters") or ""),
+            "novelty_vs_prior_brief": str(
+                bullet.get("novelty_vs_prior_brief") or bullet.get("delta_label") or "unknown"
+            ),
         }
         if claim["section"] not in ALLOWED_CLAIM_SECTIONS:
             continue
@@ -164,6 +172,10 @@ def build_and_persist_decision_record(
         "run_type": run_type,
         "generated_at_utc": timestamp,
         "status": status,
+        "citation_status": citation_status or str(guardrail_checks.get("citation_status") or "ok"),
+        "analytical_status": analytical_status or str(guardrail_checks.get("analytical_status") or "pass"),
+        "publish_decision": publish_decision or str(guardrail_checks.get("publish_decision") or "publish"),
+        "reason_codes": list(reason_codes or guardrail_checks.get("reason_codes", [])),
         "claims": claims,
         "rejected_alternatives": rejected_alternatives,
         "risk_flags": risk_flags,

--- a/apps/agent/pipeline/types.py
+++ b/apps/agent/pipeline/types.py
@@ -24,9 +24,15 @@ class RunStatus(str, Enum):
 DailyBriefOutputSection = Literal["prevailing", "counter", "minority", "watch", "changed"]
 DailyBriefClaimKind = Literal["prevailing", "counter", "minority", "watch"]
 DailyBriefNoveltyLabel = Literal["new", "continued", "reframed", "weakened", "strengthened", "reversed", "unknown"]
+DailyBriefRenderMode = Literal["full", "compressed"]
+SourceScarcityMode = Literal["normal", "scarce"]
 CitationValidationStatus = Literal["ok", "partial", "retry"]
 FinalSynthesisStatus = Literal["ok", "partial", "abstained"]
 CriticStatus = Literal["pass", "warn", "fail"]
+IssueOverlapDecision = Literal["keep", "merge", "drop"]
+IssueInformationGainDecision = Literal["keep", "drop"]
+PublishDecisionStatus = Literal["publish", "hold"]
+DeliveryMode = Literal["email_and_html", "html_only", "none"]
 
 
 DAILY_BRIEF_OUTPUT_SECTIONS: tuple[DailyBriefOutputSection, ...] = (
@@ -142,6 +148,66 @@ class EvidencePackItem(TypedDict):
     doc_id: str
 
 
+class BriefCorpusItem(TypedDict, total=False):
+    chunk_id: str
+    doc_id: str
+    source_id: str
+    publisher: str
+    title: str | None
+    text: str
+    published_at: str | None
+    credibility_tier: int
+    source_role: str
+    retrieval_score: float
+
+
+class BriefPlan(TypedDict):
+    brief_id: str
+    brief_thesis: str
+    top_takeaways: list[str]
+    issue_budget: int
+    render_mode: DailyBriefRenderMode
+    source_scarcity_mode: SourceScarcityMode
+    candidate_issue_seeds: list[str]
+    issue_order: list[str]
+    watchlist: list[str]
+    reason_codes: list[str]
+
+
+class IssueEvidenceCoverageSummary(TypedDict):
+    unique_publishers: int
+    source_roles: list[str]
+    time_span_hours: float
+
+
+class IssueEvidenceScope(TypedDict):
+    issue_id: str
+    issue_seed: str
+    primary_chunk_ids: list[str]
+    opposing_chunk_ids: list[str]
+    minority_chunk_ids: list[str]
+    watch_chunk_ids: list[str]
+    coverage_summary: IssueEvidenceCoverageSummary
+
+
+class IssueOverlapReport(TypedDict):
+    left_issue_id: str
+    right_issue_id: str
+    question_token_overlap: float
+    citation_overlap: float
+    source_overlap: float
+    thesis_overlap: str
+    decision: IssueOverlapDecision
+    reason_codes: list[str]
+
+
+class IssueInformationGain(TypedDict):
+    issue_id: str
+    information_gain_score: float
+    decision: IssueInformationGainDecision
+    reason_codes: list[str]
+
+
 class CitationStoreEntry(TypedDict):
     citation_id: str
     source_id: str
@@ -158,16 +224,26 @@ class CitationStoreEntry(TypedDict):
 
 
 class DailyBriefBullet(TypedDict, total=False):
+    claim_id: str
+    claim_kind: DailyBriefClaimKind
     text: str
     citation_ids: list[str]
     confidence_label: str
     validator_action: str
     claim_span_citations: list[list[str]]
     evidence: list["ClaimEvidenceItem"]
+    why_it_matters: str
+    novelty_vs_prior_brief: DailyBriefNoveltyLabel
+    delta_label: DailyBriefNoveltyLabel
+    delta_explanation: str
 
 class DailyBriefMeta(TypedDict, total=False):
     status: str
     reason: str
+    citation_status: str
+    analytical_status: str
+    publish_decision: PublishDecisionStatus
+    reason_codes: list[str]
 
 
 class ClaimEvidenceItem(TypedDict, total=False):
@@ -199,6 +275,23 @@ class StructuredClaim(TypedDict):
     why_it_matters: str
 
 
+class ClaimDelta(TypedDict):
+    claim_id: str
+    prior_claim_ref: str | None
+    novelty_label: DailyBriefNoveltyLabel
+    delta_explanation: str
+    supporting_prior_overlap: dict[str, Any]
+
+
+class DailyBriefOverview(TypedDict, total=False):
+    bottom_line: str
+    top_takeaways: list[str]
+    watchlist: list[str]
+    render_mode: DailyBriefRenderMode
+    source_scarcity_mode: SourceScarcityMode
+    issue_budget: int
+
+
 class DailyBriefIssue(TypedDict, total=False):
     issue_id: str
     issue_question: str
@@ -208,10 +301,21 @@ class DailyBriefIssue(TypedDict, total=False):
     counter: list[DailyBriefBullet]
     minority: list[DailyBriefBullet]
     watch: list[DailyBriefBullet]
+    coverage_summary: IssueEvidenceCoverageSummary
+
+
+class PublishDecision(TypedDict):
+    citation_status: str
+    analytical_status: str
+    publish_decision: PublishDecisionStatus
+    reason_codes: list[str]
+    delivery_mode: DeliveryMode
 
 
 class DailyBriefSynthesisV2(TypedDict, total=False):
+    brief: DailyBriefOverview
     issues: list[DailyBriefIssue]
+    claim_deltas: list[ClaimDelta]
     meta: DailyBriefMeta
     changed: list[DailyBriefBullet]
 
@@ -350,15 +454,24 @@ class DailyBriefCorpusStageData:
     documents: list[RuntimeDocumentRecord]
     chunks: list[RuntimeChunkRow]
     fts_rows: list[FtsRow]
+    corpus_items: list[EvidencePackItem] = field(default_factory=list)
+    diversity_stats: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
 class DailyBriefSynthesisStageData:
     query_text: str
+    brief_plan: BriefPlan
+    brief_corpus_items: list[EvidencePackItem]
     evidence_pack_items: list[EvidencePackItem]
     evidence_pack_report: dict[str, Any]
+    issue_evidence_scopes: list[IssueEvidenceScope]
     issue_map: list[IssueMap]
+    issue_overlap_reports: list[IssueOverlapReport]
+    information_gain_reports: list[IssueInformationGain]
     structured_claims: list[StructuredClaim]
+    claim_deltas: list[ClaimDelta]
+    publish_decision: PublishDecision
     citation_store: dict[str, CitationStoreEntry]
     stage8_result: CitationValidationResult
     final_result: FinalSynthesisResult

--- a/apps/agent/retrieval/evidence_pack.py
+++ b/apps/agent/retrieval/evidence_pack.py
@@ -5,7 +5,10 @@ import re
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
+
+from apps.agent.retrieval.fts_index import search_runtime_fts_rows
 
 
 def build_evidence_pack(
@@ -13,11 +16,13 @@ def build_evidence_pack(
     fts_rows: Iterable[Mapping[str, Any]],
     query_text: str,
     pack_size: int = 30,
+    base_dir: Path | None = None,
 ) -> list[dict[str, Any]]:
     return build_evidence_pack_report(
         fts_rows=fts_rows,
         query_text=query_text,
         pack_size=pack_size,
+        base_dir=base_dir,
     )["items"]
 
 
@@ -26,6 +31,7 @@ def build_evidence_pack_report(
     fts_rows: Iterable[Mapping[str, Any]],
     query_text: str,
     pack_size: int = 30,
+    base_dir: Path | None = None,
 ) -> dict[str, Any]:
     query_terms = _tokenize(query_text)
     if not query_terms or pack_size <= 0:
@@ -36,7 +42,12 @@ def build_evidence_pack_report(
             "notes": ["No matching evidence rows were available for evidence-pack construction."],
         }
 
-    matching_rows = _matching_rows(fts_rows=fts_rows, query_terms=query_terms)
+    matching_rows = _matching_rows(
+        fts_rows=fts_rows,
+        query_terms=query_terms,
+        query_text=query_text,
+        base_dir=base_dir,
+    )
     if not matching_rows:
         return {
             "items": [],
@@ -90,19 +101,43 @@ def _keyword_score(*, text: str, query_terms: list[str]) -> float:
     return float(sum(tokens.count(term) for term in query_terms))
 
 
+def _semantic_score(*, text: str, query_terms: list[str]) -> float:
+    text_tokens = set(_tokenize(text))
+    query_token_set = set(query_terms)
+    if not text_tokens or not query_token_set:
+        return 0.0
+    overlap = len(text_tokens & query_token_set) / len(text_tokens | query_token_set)
+    normalized_text = " ".join(_tokenize(text))
+    normalized_query = " ".join(query_terms)
+    phrase_bonus = 0.25 if normalized_query and normalized_query in normalized_text else 0.0
+    return round(min(1.0, overlap + phrase_bonus), 6)
+
+
 def _matching_rows(
-    *, fts_rows: Iterable[Mapping[str, Any]], query_terms: list[str]
+    *,
+    fts_rows: Iterable[Mapping[str, Any]],
+    query_terms: list[str],
+    query_text: str,
+    base_dir: Path | None,
 ) -> list[dict[str, Any]]:
+    runtime_scores: dict[str, float] = {}
+    if base_dir is not None:
+        runtime_scores = {
+            str(item["chunk_id"]): float(item["score"])
+            for item in search_runtime_fts_rows(base_dir=base_dir, query_text=query_text, limit=100)
+        }
     matching_rows: list[dict[str, Any]] = []
     for row in fts_rows:
         _validate_row(row)
         keyword_score = _keyword_score(text=str(row["text"]), query_terms=query_terms)
-        if keyword_score <= 0:
+        runtime_score = runtime_scores.get(str(row["chunk_id"]), 0.0)
+        if keyword_score <= 0 and runtime_score <= 0:
             continue
         matching_rows.append(
             {
                 "row": row,
-                "keyword_score": keyword_score,
+                "keyword_score": max(keyword_score, runtime_score),
+                "semantic_score": _semantic_score(text=str(row["text"]), query_terms=query_terms),
                 "published_timestamp": _published_timestamp(row),
             }
         )
@@ -118,6 +153,7 @@ def _score_rows(
     scored_rows: list[dict[str, Any]] = []
     for match in matching_rows:
         row = match["row"]
+        semantic_score = float(match.get("semantic_score", 0.0))
         recency_score = _recency_score(
             published_timestamp=float(match["published_timestamp"]),
             oldest_timestamp=oldest_timestamp,
@@ -125,7 +161,11 @@ def _score_rows(
         )
         credibility_score = _credibility_score(int(row["credibility_tier"]))
         retrieval_score = round(
-            float(match["keyword_score"]) * 0.5 + recency_score * 0.3 + credibility_score * 0.2, 6
+            float(match["keyword_score"]) * 0.45
+            + semantic_score * 0.20
+            + recency_score * 0.20
+            + credibility_score * 0.15,
+            6,
         )
         scored_rows.append(
             {
@@ -134,7 +174,7 @@ def _score_rows(
                 "publisher": row["publisher"],
                 "credibility_tier": row["credibility_tier"],
                 "retrieval_score": retrieval_score,
-                "semantic_score": None,
+                "semantic_score": semantic_score,
                 "recency_score": recency_score,
                 "credibility_score": credibility_score,
                 "_published_timestamp": match["published_timestamp"],

--- a/apps/agent/retrieval/fts_index.py
+++ b/apps/agent/retrieval/fts_index.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import Iterable, Mapping
+from pathlib import Path
 from typing import Any
 
 from apps.agent.pipeline.types import FtsRow
+from apps.agent.storage.sqlite_runtime import runtime_db_path
 
 
 def build_fts_rows(
@@ -51,6 +54,52 @@ def search_fts_rows(
     return matches[:limit]
 
 
+def search_runtime_fts_rows(
+    *,
+    base_dir: Path,
+    query_text: str,
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    if not query_text.strip():
+        return []
+
+    connection = sqlite3.connect(runtime_db_path(base_dir=base_dir))
+    try:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(
+            """
+            SELECT
+              chunk_id,
+              doc_id,
+              publisher,
+              source_id,
+              published_at,
+              text,
+              bm25(chunk_fts) AS score
+            FROM chunk_fts
+            WHERE chunk_fts MATCH ?
+            ORDER BY score, chunk_id
+            LIMIT ?
+            """,
+            (_fts_query(query_text), limit),
+        ).fetchall()
+    finally:
+        connection.close()
+
+    return [
+        {
+            "chunk_id": str(row["chunk_id"]),
+            "doc_id": str(row["doc_id"]),
+            "publisher": str(row["publisher"]),
+            "source_id": str(row["source_id"]),
+            "published_at": row["published_at"],
+            "text": str(row["text"]),
+            "score": abs(float(row["score"])),
+        }
+        for row in rows
+    ]
+
+
 def _validate_chunk_row(chunk_row: Mapping[str, Any]) -> None:
     required_fields = ("chunk_id", "doc_id", "text")
     missing_fields = [
@@ -60,3 +109,8 @@ def _validate_chunk_row(chunk_row: Mapping[str, Any]) -> None:
     ]
     if missing_fields:
         raise ValueError(f"Invalid chunk row for FTS indexing: missing {', '.join(missing_fields)}")
+
+
+def _fts_query(query_text: str) -> str:
+    terms = [term.strip() for term in query_text.split() if term.strip()]
+    return " OR ".join(terms)

--- a/apps/agent/storage/sqlite_runtime.py
+++ b/apps/agent/storage/sqlite_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 from collections.abc import Iterable, Mapping
 from pathlib import Path
@@ -25,6 +26,27 @@ def ensure_runtime_db(*, base_dir: Path) -> Path:
     return db_path
 
 
+def persist_runtime_corpus(
+    *,
+    base_dir: Path,
+    source_rows: Iterable[Mapping[str, Any]],
+    documents: Iterable[Mapping[str, Any]],
+    chunks: Iterable[Mapping[str, Any]],
+    fts_rows: Iterable[Mapping[str, Any]],
+) -> Path:
+    db_path = ensure_runtime_db(base_dir=base_dir)
+    connection = sqlite3.connect(db_path)
+    try:
+        _persist_sources(connection, rows=[dict(row) for row in source_rows])
+        _persist_documents(connection, rows=[dict(row) for row in documents])
+        _persist_chunks(connection, rows=[dict(row) for row in chunks])
+        _persist_fts_rows(connection, rows=[dict(row) for row in fts_rows])
+        connection.commit()
+    finally:
+        connection.close()
+    return db_path
+
+
 def persist_daily_brief_runtime(
     *,
     base_dir: Path,
@@ -36,6 +58,8 @@ def persist_daily_brief_runtime(
     chunks: Iterable[Mapping[str, Any]],
     evidence_pack_items: Iterable[Mapping[str, Any]],
     evidence_pack_report: Mapping[str, Any],
+    issue_map_rows: Iterable[Mapping[str, Any]],
+    structured_claim_rows: Iterable[Mapping[str, Any]],
     citation_rows: Iterable[Mapping[str, Any]],
     synthesis_rows: Iterable[Mapping[str, Any]],
     bullet_citation_rows: Iterable[Mapping[str, Any]],
@@ -52,6 +76,8 @@ def persist_daily_brief_runtime(
         document_rows_list = [dict(row) for row in documents]
         chunk_rows_list = [dict(row) for row in chunks]
         evidence_pack_rows_list = [dict(row) for row in evidence_pack_items]
+        issue_map_rows_list = [dict(row) for row in issue_map_rows]
+        structured_claim_rows_list = [dict(row) for row in structured_claim_rows]
         citation_rows_list = [dict(row) for row in citation_rows]
         synthesis_rows_list = [dict(row) for row in synthesis_rows]
         bullet_citation_rows_list = [dict(row) for row in bullet_citation_rows]
@@ -72,6 +98,18 @@ def persist_daily_brief_runtime(
             stats=evidence_pack_report.get("diversity_stats", {}),
         )
         _persist_evidence_pack_items(connection, pack_id=pack_id, rows=evidence_pack_rows_list)
+        _persist_issue_maps(
+            connection,
+            run_id=str(run_row["run_id"]),
+            generated_at_utc=generated_at_utc,
+            rows=issue_map_rows_list,
+        )
+        _persist_structured_claims(
+            connection,
+            run_id=str(run_row["run_id"]),
+            generated_at_utc=generated_at_utc,
+            rows=structured_claim_rows_list,
+        )
         persisted_citation_ids = _persist_citations(
             connection,
             rows=citation_rows_list,
@@ -97,6 +135,21 @@ def persist_daily_brief_runtime(
             synthesis_id=synthesis_id,
             rows=relevance_flag_rows_list,
         )
+        connection.commit()
+    finally:
+        connection.close()
+    return db_path
+
+
+def persist_alert_record(
+    *,
+    base_dir: Path,
+    row: Mapping[str, Any],
+) -> Path:
+    db_path = ensure_runtime_db(base_dir=base_dir)
+    connection = sqlite3.connect(db_path)
+    try:
+        _persist_alerts(connection, rows=[dict(row)])
         connection.commit()
     finally:
         connection.close()
@@ -162,6 +215,16 @@ def _initialize_schema(connection: sqlite3.Connection) -> None:
         )
         """,
         """
+        CREATE VIRTUAL TABLE IF NOT EXISTS chunk_fts USING fts5(
+          chunk_id UNINDEXED,
+          doc_id UNINDEXED,
+          publisher UNINDEXED,
+          source_id UNINDEXED,
+          published_at UNINDEXED,
+          text
+        )
+        """,
+        """
         CREATE TABLE IF NOT EXISTS evidence_packs (
           pack_id TEXT PRIMARY KEY,
           purpose TEXT NOT NULL,
@@ -204,6 +267,36 @@ def _initialize_schema(connection: sqlite3.Connection) -> None:
           retry_count INTEGER NOT NULL DEFAULT 0,
           status TEXT NOT NULL,
           created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS issue_maps (
+          run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+          issue_id TEXT NOT NULL,
+          issue_question TEXT NOT NULL,
+          thesis_hint TEXT NOT NULL,
+          supporting_evidence_ids_json TEXT NOT NULL,
+          opposing_evidence_ids_json TEXT NOT NULL,
+          minority_evidence_ids_json TEXT NOT NULL,
+          watch_evidence_ids_json TEXT NOT NULL,
+          generated_at TEXT NOT NULL,
+          PRIMARY KEY (run_id, issue_id)
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS structured_claims (
+          run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+          claim_id TEXT NOT NULL,
+          issue_id TEXT NOT NULL,
+          claim_kind TEXT NOT NULL,
+          claim_text TEXT NOT NULL,
+          supporting_citation_ids_json TEXT NOT NULL,
+          opposing_citation_ids_json TEXT NOT NULL,
+          confidence TEXT NOT NULL,
+          novelty_vs_prior_brief TEXT NOT NULL,
+          why_it_matters TEXT NOT NULL,
+          generated_at TEXT NOT NULL,
+          PRIMARY KEY (run_id, claim_id)
         )
         """,
         """
@@ -302,6 +395,32 @@ def _initialize_schema(connection: sqlite3.Connection) -> None:
           risk_flag TEXT NOT NULL,
           rationale TEXT,
           created_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS alerts (
+          alert_id TEXT PRIMARY KEY,
+          run_id TEXT NOT NULL,
+          category TEXT NOT NULL,
+          title TEXT NOT NULL,
+          summary TEXT NOT NULL,
+          action TEXT NOT NULL,
+          delivery_status TEXT NOT NULL,
+          score_total REAL NOT NULL,
+          score_importance REAL NOT NULL,
+          score_evidence REAL NOT NULL,
+          score_confidence REAL NOT NULL,
+          score_relevance REAL NOT NULL,
+          score_noise_risk REAL NOT NULL,
+          triggered_at TEXT NOT NULL,
+          delivered_email_at TEXT,
+          delivered_local_page_at TEXT,
+          bundle_for_daily_brief INTEGER NOT NULL DEFAULT 0,
+          suppression_reason TEXT,
+          failure_reason TEXT,
+          html_path TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
         )
         """,
     )
@@ -581,6 +700,26 @@ def _persist_synthesis(
     )
 
 
+def _persist_fts_rows(connection: sqlite3.Connection, *, rows: list[dict[str, Any]]) -> None:
+    chunk_ids = [str(row["chunk_id"]) for row in rows if row.get("chunk_id")]
+    if chunk_ids:
+        placeholders = ", ".join("?" for _ in chunk_ids)
+        connection.execute(
+            f"DELETE FROM chunk_fts WHERE chunk_id IN ({placeholders})",
+            chunk_ids,
+        )
+    connection.executemany(
+        """
+        INSERT INTO chunk_fts (
+          chunk_id, doc_id, publisher, source_id, published_at, text
+        ) VALUES (
+          :chunk_id, :doc_id, :publisher, :source_id, :published_at, :text
+        )
+        """,
+        rows,
+    )
+
+
 def _persist_bullet_citations(
     connection: sqlite3.Connection,
     *,
@@ -678,4 +817,146 @@ def _persist_relevance_flags(
           created_at=excluded.created_at
         """,
         rows,
+    )
+
+
+def _persist_alerts(connection: sqlite3.Connection, *, rows: list[dict[str, Any]]) -> None:
+    connection.executemany(
+        """
+        INSERT INTO alerts (
+          alert_id, run_id, category, title, summary, action, delivery_status,
+          score_total, score_importance, score_evidence, score_confidence,
+          score_relevance, score_noise_risk, triggered_at, delivered_email_at,
+          delivered_local_page_at, bundle_for_daily_brief, suppression_reason,
+          failure_reason, html_path, created_at, updated_at
+        ) VALUES (
+          :alert_id, :run_id, :category, :title, :summary, :action, :delivery_status,
+          :score_total, :score_importance, :score_evidence, :score_confidence,
+          :score_relevance, :score_noise_risk, :triggered_at, :delivered_email_at,
+          :delivered_local_page_at, :bundle_for_daily_brief, :suppression_reason,
+          :failure_reason, :html_path, :created_at, :updated_at
+        )
+        ON CONFLICT(alert_id) DO UPDATE SET
+          run_id=excluded.run_id,
+          category=excluded.category,
+          title=excluded.title,
+          summary=excluded.summary,
+          action=excluded.action,
+          delivery_status=excluded.delivery_status,
+          score_total=excluded.score_total,
+          score_importance=excluded.score_importance,
+          score_evidence=excluded.score_evidence,
+          score_confidence=excluded.score_confidence,
+          score_relevance=excluded.score_relevance,
+          score_noise_risk=excluded.score_noise_risk,
+          triggered_at=excluded.triggered_at,
+          delivered_email_at=excluded.delivered_email_at,
+          delivered_local_page_at=excluded.delivered_local_page_at,
+          bundle_for_daily_brief=excluded.bundle_for_daily_brief,
+          suppression_reason=excluded.suppression_reason,
+          failure_reason=excluded.failure_reason,
+          html_path=excluded.html_path,
+          updated_at=excluded.updated_at
+        """,
+        rows,
+    )
+
+
+def _persist_issue_maps(
+    connection: sqlite3.Connection,
+    *,
+    run_id: str,
+    generated_at_utc: str,
+    rows: list[dict[str, Any]],
+) -> None:
+    connection.execute("DELETE FROM issue_maps WHERE run_id = ?", (run_id,))
+    if not rows:
+        return
+    payload_rows = [
+        {
+            "run_id": run_id,
+            "issue_id": str(row["issue_id"]),
+            "issue_question": str(row.get("issue_question") or ""),
+            "thesis_hint": str(row.get("thesis_hint") or ""),
+            "supporting_evidence_ids_json": json.dumps(list(row.get("supporting_evidence_ids", []))),
+            "opposing_evidence_ids_json": json.dumps(list(row.get("opposing_evidence_ids", []))),
+            "minority_evidence_ids_json": json.dumps(list(row.get("minority_evidence_ids", []))),
+            "watch_evidence_ids_json": json.dumps(list(row.get("watch_evidence_ids", []))),
+            "generated_at": generated_at_utc,
+        }
+        for row in rows
+    ]
+    connection.executemany(
+        """
+        INSERT INTO issue_maps (
+          run_id, issue_id, issue_question, thesis_hint,
+          supporting_evidence_ids_json, opposing_evidence_ids_json,
+          minority_evidence_ids_json, watch_evidence_ids_json, generated_at
+        ) VALUES (
+          :run_id, :issue_id, :issue_question, :thesis_hint,
+          :supporting_evidence_ids_json, :opposing_evidence_ids_json,
+          :minority_evidence_ids_json, :watch_evidence_ids_json, :generated_at
+        )
+        ON CONFLICT(run_id, issue_id) DO UPDATE SET
+          issue_question=excluded.issue_question,
+          thesis_hint=excluded.thesis_hint,
+          supporting_evidence_ids_json=excluded.supporting_evidence_ids_json,
+          opposing_evidence_ids_json=excluded.opposing_evidence_ids_json,
+          minority_evidence_ids_json=excluded.minority_evidence_ids_json,
+          watch_evidence_ids_json=excluded.watch_evidence_ids_json,
+          generated_at=excluded.generated_at
+        """,
+        payload_rows,
+    )
+
+
+def _persist_structured_claims(
+    connection: sqlite3.Connection,
+    *,
+    run_id: str,
+    generated_at_utc: str,
+    rows: list[dict[str, Any]],
+) -> None:
+    connection.execute("DELETE FROM structured_claims WHERE run_id = ?", (run_id,))
+    if not rows:
+        return
+    payload_rows = [
+        {
+            "run_id": run_id,
+            "claim_id": str(row["claim_id"]),
+            "issue_id": str(row.get("issue_id") or ""),
+            "claim_kind": str(row.get("claim_kind") or ""),
+            "claim_text": str(row.get("claim_text") or ""),
+            "supporting_citation_ids_json": json.dumps(list(row.get("supporting_citation_ids", []))),
+            "opposing_citation_ids_json": json.dumps(list(row.get("opposing_citation_ids", []))),
+            "confidence": str(row.get("confidence") or ""),
+            "novelty_vs_prior_brief": str(row.get("novelty_vs_prior_brief") or "unknown"),
+            "why_it_matters": str(row.get("why_it_matters") or ""),
+            "generated_at": generated_at_utc,
+        }
+        for row in rows
+    ]
+    connection.executemany(
+        """
+        INSERT INTO structured_claims (
+          run_id, claim_id, issue_id, claim_kind, claim_text,
+          supporting_citation_ids_json, opposing_citation_ids_json,
+          confidence, novelty_vs_prior_brief, why_it_matters, generated_at
+        ) VALUES (
+          :run_id, :claim_id, :issue_id, :claim_kind, :claim_text,
+          :supporting_citation_ids_json, :opposing_citation_ids_json,
+          :confidence, :novelty_vs_prior_brief, :why_it_matters, :generated_at
+        )
+        ON CONFLICT(run_id, claim_id) DO UPDATE SET
+          issue_id=excluded.issue_id,
+          claim_kind=excluded.claim_kind,
+          claim_text=excluded.claim_text,
+          supporting_citation_ids_json=excluded.supporting_citation_ids_json,
+          opposing_citation_ids_json=excluded.opposing_citation_ids_json,
+          confidence=excluded.confidence,
+          novelty_vs_prior_brief=excluded.novelty_vs_prior_brief,
+          why_it_matters=excluded.why_it_matters,
+          generated_at=excluded.generated_at
+        """,
+        payload_rows,
     )

--- a/artifacts/PRD.md
+++ b/artifacts/PRD.md
@@ -53,7 +53,9 @@ The product goal is not to summarize sources one by one. It should identify the 
 
 ### 5.1 Daily brief
 - **Schedule:** 07:05 Asia/Singapore daily
-- **Important issues per brief:** 2-3
+- **Important issues per brief:** target 2; allow 3 only when evidence diversity and information gain support a third distinct issue
+- **Issue budget rule:** never force 3 issues; if the corpus only supports 1-2 distinct issues, the brief must stay at 1-2
+- **Source-scarcity rule:** if the corpus cannot support 2 distinct issues with adequate diversity, render a compressed brief with 1 main issue + 2-3 key takeaways + a short watchlist instead of padding with thin issues
 - **Per issue structure:**
   - issue title or question
   - short synthesis summary
@@ -132,22 +134,35 @@ The daily brief must follow this pipeline:
 
 1. **Deterministic evidence layer**
    - ingestion / normalize / dedup / chunk / retrieval / citation store / budget guard
-2. **Issue planner (model layer)**
-   - consumes bounded evidence pack and optional prior-brief context
+2. **Brief planner (editorial layer)**
+   - consumes bounded brief corpus, optional prior-brief context, and source-diversity stats
+   - outputs structured `BriefPlan` including brief thesis, issue budget, render mode, candidate issue seeds, and watchlist
+3. **Issue planner (model layer)**
+   - consumes `BriefPlan` plus issue-aware evidence scopes
    - outputs structured `IssueMap[]`
-3. **Claim composer (model layer)**
+4. **Claim composer (model layer)**
    - consumes `IssueMap[]` plus citations
    - outputs structured `ClaimObject[]`
-4. **Validator / critic**
+5. **Validator / critic**
    - deterministic citation and evidence checks are mandatory
    - optional critic pass can reject shallow source-by-source paraphrase
-5. **Renderer**
+6. **Renderer**
    - HTML/email consume structured issue and claim objects
 
-This replaces the earlier single-query, section-bullet synthesis design.
+This replaces the earlier single-query, section-bullet synthesis design and makes editorial issue budgeting explicit before issue generation.
 
 ### 6.5 Required daily brief output shape
-Each daily brief should read like a short literature review across 2-3 issues.
+Each daily brief should read like a short literature review across 2-3 issues when evidence supports that count.
+
+Issue-budget and scarcity rules:
+- default to 2 issues when the corpus supports multiple distinct debates
+- allow 3 issues only when the third issue adds clear incremental information and does not materially overlap the first 2
+- if source scarcity, low diversity, or high overlap prevents 2 distinct issues, render a compressed brief with:
+  - `bottom_line` / brief thesis
+  - `top_takeaways`
+  - 1 main issue block
+  - `watchlist`
+- issues that fail distinctness or information-gain thresholds must be merged, demoted to takeaways/watchlist, or dropped rather than forced into the body
 
 For each issue, the system must produce:
 - `issue_question`
@@ -285,6 +300,9 @@ Outputs:
 ### Issue planning
 - Daily brief generation does not depend on a single top-term query alone.
 - The system produces 2-3 issue candidates when evidence diversity supports it.
+- The system must not force 3 issues when evidence supports fewer distinct debates.
+- When source diversity is insufficient, the system falls back to a compressed brief with 1 main issue plus top takeaways/watchlist.
+- Final issues must be distinct enough to justify separate slots in the issue budget; overlapping issues are merged, demoted, or dropped.
 - `prevailing`, `counter`, and `minority` claims for an issue all address the same issue question.
 
 ### Claim composition
@@ -300,6 +318,7 @@ Outputs:
 - Stable structured output.
 - Includes Tier 1 sources when topic is policy-related (if available).
 - Renderer displays issue summaries plus evidence-backed arguments.
+- Renderer can switch between `full` and `compressed` brief modes based on the `BriefPlan` issue budget and source-scarcity policy.
 
 ### Alerts
 - Max alerts/day enforced.

--- a/artifacts/modelling/data_model.md
+++ b/artifacts/modelling/data_model.md
@@ -176,6 +176,34 @@ CREATE TABLE IF NOT EXISTS synthesis_bullets (
   confidence_label TEXT, -- optional: high, medium, low
   PRIMARY KEY (synthesis_id, section, bullet_index)
 );
+
+CREATE TABLE IF NOT EXISTS issue_maps (
+  run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+  issue_id TEXT NOT NULL,
+  issue_question TEXT NOT NULL,
+  thesis_hint TEXT NOT NULL,
+  supporting_evidence_ids_json TEXT NOT NULL,
+  opposing_evidence_ids_json TEXT NOT NULL,
+  minority_evidence_ids_json TEXT NOT NULL,
+  watch_evidence_ids_json TEXT NOT NULL,
+  generated_at TEXT NOT NULL,
+  PRIMARY KEY (run_id, issue_id)
+);
+
+CREATE TABLE IF NOT EXISTS structured_claims (
+  run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+  claim_id TEXT NOT NULL,
+  issue_id TEXT NOT NULL,
+  claim_kind TEXT NOT NULL,
+  claim_text TEXT NOT NULL,
+  supporting_citation_ids_json TEXT NOT NULL,
+  opposing_citation_ids_json TEXT NOT NULL,
+  confidence TEXT NOT NULL,
+  novelty_vs_prior_brief TEXT NOT NULL,
+  why_it_matters TEXT NOT NULL,
+  generated_at TEXT NOT NULL,
+  PRIMARY KEY (run_id, claim_id)
+);
 ```
 
 ### 4.7 Citations (claim/bullet binding)
@@ -216,8 +244,12 @@ CREATE TABLE IF NOT EXISTS bullet_citations (
 ```sql
 CREATE TABLE IF NOT EXISTS alerts (
   alert_id TEXT PRIMARY KEY,
-  synthesis_id TEXT NOT NULL REFERENCES syntheses(synthesis_id),
+  run_id TEXT NOT NULL,
   category TEXT NOT NULL CHECK (category IN ('policy', 'macro_release', 'corporate_event', 'narrative_shift')),
+  title TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  action TEXT NOT NULL CHECK (action IN ('send', 'bundle', 'suppress')),
+  delivery_status TEXT NOT NULL,
   score_total REAL NOT NULL,
   score_importance REAL NOT NULL,
   score_evidence REAL NOT NULL,
@@ -227,8 +259,12 @@ CREATE TABLE IF NOT EXISTS alerts (
   triggered_at TEXT NOT NULL,
   delivered_email_at TEXT,
   delivered_local_page_at TEXT,
-  suppressed_reason TEXT,
-  created_at TEXT NOT NULL
+  bundle_for_daily_brief INTEGER NOT NULL DEFAULT 0 CHECK (bundle_for_daily_brief IN (0,1)),
+  suppression_reason TEXT,
+  failure_reason TEXT,
+  html_path TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
 );
 ```
 

--- a/docs/plans/2026-03-12-brief-editorial-planner-design.md
+++ b/docs/plans/2026-03-12-brief-editorial-planner-design.md
@@ -1,0 +1,287 @@
+# Brief Editorial Planner, Corpus-First Retrieval, and Issue Quality Gate Design
+
+## Problem Statement
+
+The current daily-brief architecture still starts too close to issue generation. It can identify issue-shaped outputs, but it does not first decide what the brief is trying to say as a whole, how many issue slots the day deserves, or what should happen when the source mix is too thin to justify 2-3 distinct issues.
+
+That creates three recurring failures:
+- the day gets compressed into one global query before the system knows the actual editorial thesis
+- multiple issues can end up sharing the same evidence base and restating one thesis in slightly different wording
+- source-scarce days have no explicit product rule, so the system is incentivized to pad out issue count instead of compressing the brief
+
+This design adds an editorial layer before `IssueMap` generation and makes issue count a deliberate contract instead of an accidental by-product of retrieval.
+
+## Current Repo Gaps
+
+Current gaps in the runtime and product contract are:
+- no brief-level `BriefPlan` object before issue planning
+- retrieval still centers on a single brief-wide query rather than a corpus-first, issue-aware flow
+- no deterministic overlap scoring or information-gain gate between issue planning and final issue selection
+- no source-scarcity contract defining when the brief should compress to one main issue
+
+Issue `#135` adds the product contract in `artifacts/PRD.md`. This document defines the technical shape that will later support `#128`, `#129`, and `#130`.
+
+## Target Pipeline
+
+The target upstream daily-brief flow becomes:
+
+1. **Corpus prep**
+   - Build a bounded `BriefCorpus` from the day's eligible chunks.
+   - Keep recency, credibility, and diversity constraints.
+   - Avoid single-publisher dominance before issue planning starts.
+2. **Brief planning**
+   - Consume `BriefCorpus` summary, prior-brief context, and source-diversity stats.
+   - Produce `BriefPlan` with:
+     - brief thesis
+     - top takeaways
+     - issue budget
+     - render mode (`full` or `compressed`)
+     - candidate issue seeds
+     - watchlist
+3. **Issue-aware retrieval**
+   - For each candidate issue seed, create an `IssueEvidenceScope`.
+   - Separate supporting, opposing, minority, and watch evidence.
+4. **Issue planning**
+   - Generate `IssueMap[]` from `BriefPlan` plus `IssueEvidenceScope[]`.
+5. **Editorial quality gate**
+   - Run overlap scoring, merge/drop decisions, and minimum information-gain checks.
+   - Enforce the final issue budget.
+6. **Claim composition and downstream rendering**
+   - Out of scope for this document, but downstream layers consume the deduplicated issue set and the chosen render mode.
+
+## BriefCorpus Contract
+
+`BriefCorpus` is the deterministic, auditable input to the editorial planner. It is not a single query result and not yet an `IssueMap`.
+
+Example shape:
+
+```json
+{
+  "brief_id": "brief_2026-03-12",
+  "chunk_ids": ["chunk_01", "chunk_02", "chunk_07"],
+  "source_diversity": {
+    "unique_publishers": 5,
+    "source_roles": ["official", "wire", "market_media"],
+    "tier12_ratio": 0.8,
+    "dominant_publisher_ratio": 0.25,
+    "time_span_hours": 18
+  },
+  "corpus_summary": [
+    "Growth-sensitive data softened.",
+    "Policy language remained cautious.",
+    "Market pricing moved faster than official guidance."
+  ]
+}
+```
+
+Design intent:
+- retrieval happens first at the corpus level, not through one synthesized query string
+- corpus prep should retain enough diversity metadata for source-scarcity and issue-budget decisions
+- corpus prep can stay deterministic even if later retrieval ranking uses semantic features
+
+## BriefPlan Contract
+
+`BriefPlan` is the editorial contract for the whole brief. It decides the shape of the output before issue generation.
+
+Example shape:
+
+```json
+{
+  "brief_id": "brief_2026-03-12",
+  "brief_thesis": "Softening macro data is widening the gap between market easing expectations and still-cautious policy language.",
+  "top_takeaways": [
+    "Growth is cooling, but not collapsing.",
+    "The market-policy gap widened more than the policy stance itself changed.",
+    "The next inflation-sensitive release matters more than today's headline churn."
+  ],
+  "issue_budget": 2,
+  "render_mode": "full",
+  "source_scarcity_mode": "normal",
+  "candidate_issue_seeds": [
+    "growth cooling signal",
+    "policy-market gap"
+  ],
+  "issue_order": [
+    "seed_001",
+    "seed_002"
+  ],
+  "watchlist": [
+    "next payroll revision",
+    "next CPI print"
+  ],
+  "reason_codes": [
+    "two_distinct_debates_supported",
+    "third_issue_below_information_gain_threshold"
+  ]
+}
+```
+
+Required fields:
+- `brief_thesis`: the main editorial claim for the whole brief
+- `top_takeaways`: what belongs above the issue list on first screen
+- `issue_budget`: final number of issue slots available to the brief
+- `render_mode`: `full` or `compressed`
+- `source_scarcity_mode`: explains why the brief stayed full or compressed
+- `candidate_issue_seeds`: the issues retrieval and issue planning should investigate
+- `watchlist`: items that matter but do not justify a full issue block
+
+Rules:
+- default target is 2 issues
+- 3 issues require clear incremental value from the third issue
+- 1 issue is valid when source scarcity or overlap prevents 2 distinct issue blocks
+- `compressed` mode is a product decision, not an error path
+
+## IssueEvidenceScope Contract
+
+Each candidate issue gets its own evidence scope. Final issues must not all reuse one shared evidence pack.
+
+Example shape:
+
+```json
+{
+  "issue_id": "issue_001",
+  "primary_chunk_ids": ["chunk_01", "chunk_07"],
+  "opposing_chunk_ids": ["chunk_11"],
+  "minority_chunk_ids": ["chunk_15"],
+  "watch_chunk_ids": ["chunk_20"],
+  "coverage_summary": {
+    "unique_publishers": 4,
+    "source_roles": ["official", "market_media"],
+    "time_span_hours": 18
+  }
+}
+```
+
+Design intent:
+- supporting and opposing material should be explicit, not inferred late from one blended pack
+- each issue should expose enough coverage metadata to justify its slot in the budget
+- a low-coverage issue can still survive as a watch item or takeaway, but not necessarily as a full issue block
+
+## IssueOverlapReport Contract
+
+After `IssueMap[]` generation, the system needs a deterministic overlap report before claims are composed.
+
+Example shape:
+
+```json
+{
+  "left_issue_id": "issue_001",
+  "right_issue_id": "issue_002",
+  "question_token_overlap": 0.71,
+  "citation_overlap": 0.75,
+  "source_overlap": 0.8,
+  "thesis_overlap": "high",
+  "decision": "merge",
+  "reason_codes": [
+    "high_citation_overlap",
+    "same_underlying_thesis"
+  ]
+}
+```
+
+Initial overlap signals should stay deterministic:
+- question token overlap
+- citation overlap ratio
+- publisher / source-role overlap
+- thesis-hint lexical overlap
+
+Decisions:
+- `keep`: issues are sufficiently distinct
+- `merge`: issues are really one thesis with redundant evidence
+- `drop`: lower-value issue adds too little beyond a stronger neighbor
+
+## Information-Gain Policy
+
+Issue count should be limited by incremental value, not by how many candidate issues a planner can produce.
+
+Each issue should receive an `information_gain_score` and a decision:
+
+```json
+{
+  "issue_id": "issue_002",
+  "information_gain_score": 0.18,
+  "decision": "drop",
+  "reason_codes": [
+    "low_incremental_value",
+    "restates_existing_issue"
+  ]
+}
+```
+
+First-pass policy:
+- compute information gain after overlap scoring, not before
+- compare each issue against higher-priority issues already kept in the brief
+- penalize:
+  - shared citations
+  - shared publishers and source roles
+  - near-duplicate thesis wording
+  - summaries that add no new implication for the reader
+- reward:
+  - independent source support
+  - distinct causal or market implications
+  - genuinely new watch items or uncertainty framing
+
+Budget enforcement:
+- keep filling issue slots in priority order until `issue_budget` is reached
+- the third issue is optional and should be dropped by default unless it clears both overlap and information-gain gates
+- when only one issue clears the gate, switch to `compressed` mode instead of manufacturing a weak second issue
+
+## Source-Scarcity Policy
+
+Source scarcity is a normal runtime condition, not an exceptional failure.
+
+Definitions:
+- `normal`: the corpus supports at least 2 distinct issues with adequate diversity
+- `scarce`: only 1 issue clearly clears the issue-quality gate, or source diversity is too thin for a second issue
+
+Rendering policy:
+- `normal` -> `render_mode=full`
+  - show `bottom_line`
+  - show 2-3 key takeaways
+  - show 2 issues by default, 3 only when justified
+- `scarce` -> `render_mode=compressed`
+  - show `bottom_line`
+  - show 2-3 key takeaways
+  - show 1 main issue
+  - move secondary signals into `watchlist`
+
+Editorial policy:
+- do not create a second or third issue only to satisfy a nominal target
+- if a candidate issue mostly repeats the main thesis, merge or demote it
+- if coverage is too thin for a real debate, keep the insight as a takeaway or watch item
+- compressed briefs are acceptable output as long as citation rules still hold
+
+## Rollout Plan
+
+1. Land the product contract in `artifacts/PRD.md`.
+2. Add typed `BriefPlan`, `IssueEvidenceScope`, overlap-report, and information-gain contracts.
+3. Refactor runner orchestration so stages become:
+   - corpus prep
+   - brief planning
+   - issue-aware retrieval
+   - issue planning
+   - dedup / information gain
+4. Update renderer requirements to respect `full` vs `compressed` brief modes.
+5. Add tests and golden cases for source scarcity, issue overlap, and issue-budget enforcement.
+
+This document intentionally does not prescribe provider behavior, claim-level delta, or delivery status gates. Those belong in separate follow-on designs.
+
+## Test Plan
+
+Minimum coverage for the later implementation:
+- unit tests for `BriefPlan` generation
+  - source-rich corpus -> `render_mode=full`, `issue_budget=2` or `3`
+  - source-scarce corpus -> `render_mode=compressed`, `issue_budget=1`
+- retrieval tests for issue-aware evidence scopes
+  - 2 candidate issues receive materially different scope assignments
+  - coverage summaries reflect publisher and source-role diversity
+- dedup tests
+  - high-overlap issues merge
+  - low-information-gain issues drop
+  - the third issue is rejected when it adds too little new information
+- renderer-facing contract tests
+  - compressed brief includes thesis, takeaways, 1 issue, and watchlist
+  - full brief does not exceed the approved issue budget
+
+Acceptance outcome:
+- the system behaves like an editor choosing the right number of issues for the day, not like a template trying to fill fixed slots.

--- a/docs/plans/2026-03-12-claim-delta-and-publish-gate-design.md
+++ b/docs/plans/2026-03-12-claim-delta-and-publish-gate-design.md
@@ -1,0 +1,148 @@
+# Claim Delta, Delivery Fields, and Publish Gate Design
+
+## Problem Statement
+
+The current daily-brief runtime already produces structured claims, but several product-critical fields still stop short of the final output contract:
+
+- `why_it_matters` and `novelty_vs_prior_brief` exist on `StructuredClaim` but can disappear before delivery and persistence.
+- the changed section has historically been a renderer-side text diff rather than a claim-level delta object.
+- the critic can warn or fail, but it has not been treated as a first-class publish gate with split analytical vs citation status.
+
+This design closes those gaps and makes delivery, decision records, and publication decisions consume the same structured objects the model layer emits.
+
+## Current Repo Gaps
+
+- delivery can flatten claims into thin bullets unless the fields are preserved explicitly
+- changed output can be inferred from text changes instead of explicit novelty semantics
+- a single `Validated` label hides the distinction between citation validity and analytical quality
+- decision records and runtime storage are stronger when these fields are preserved as native claim-level data
+
+## Claim View Model Contract
+
+Renderer-facing bullets should preserve the analytical fields that the model layer already generated.
+
+Example:
+
+```json
+{
+  "claim_id": "claim_001",
+  "claim_kind": "prevailing",
+  "text": "Softer growth is raising later-cut expectations.",
+  "citation_ids": ["cite_001", "cite_002"],
+  "confidence_label": "medium",
+  "novelty_vs_prior_brief": "strengthened",
+  "why_it_matters": "Rate-sensitive assets can reprice quickly.",
+  "delta_explanation": "The same thesis now has additional official support.",
+  "evidence": [
+    {
+      "citation_id": "cite_001",
+      "publisher": "Reuters",
+      "published_at": "2026-03-12T08:00:00Z",
+      "support_text": "Growth data softened again."
+    }
+  ]
+}
+```
+
+Required end-to-end surfaces:
+
+- HTML issue cards
+- email plain-text summary and HTML alternative
+- decision record claims
+- runtime artifact JSON
+
+## Delta Contract
+
+Changed output should be derived from `ClaimDelta[]`, not from a bullet text diff.
+
+Example:
+
+```json
+{
+  "claim_id": "claim_001",
+  "prior_claim_ref": "prior_claim_008",
+  "novelty_label": "strengthened",
+  "delta_explanation": "The same soft-landing thesis now has additional official support.",
+  "supporting_prior_overlap": {
+    "citation_overlap": 0.33,
+    "thesis_overlap": "medium"
+  }
+}
+```
+
+Policy:
+
+- `new`, `reframed`, `weakened`, `strengthened`, and `reversed` appear in `What changed`
+- `continued` stays on the issue card but does not need to occupy changed-section space
+- the renderer reads `delta_explanation`; it does not infer changed state by comparing old bullet text
+
+## Critic / Publish Decision Contract
+
+Publication should consume a first-class decision object:
+
+```json
+{
+  "citation_status": "ok",
+  "analytical_status": "warn",
+  "publish_decision": "publish",
+  "reason_codes": ["source_by_source_paraphrase"],
+  "delivery_mode": "html_only"
+}
+```
+
+Policy:
+
+- `citation_status` comes from stage-8 validation and abstain policy
+- `analytical_status` comes from the critic
+- `publish_decision=hold` when citation status is abstained or analytical status is fail
+- `delivery_mode=html_only` when email should not be sent even if artifacts are still written locally
+
+## HTML and Email Rendering Changes
+
+HTML:
+
+- top metadata bar shows `Citation status`, `Analytical quality`, and `Publish decision`
+- first screen shows `Bottom line` and `Key takeaways`
+- issue bullets render novelty and `Why it matters`
+- `What changed` renders delta-driven bullets with `Delta` explanations
+
+Email:
+
+- subject line reflects hold/partial/warn states
+- plain-text body includes split statuses, bottom line, top takeaways, and at least one claim with novelty plus `Why it matters`
+- HTML alternative remains the full report
+
+## Decision Record Changes
+
+Decision records should preserve:
+
+- `citation_status`
+- `analytical_status`
+- `publish_decision`
+- `reason_codes`
+- claim-level `why_it_matters`
+- claim-level `novelty_vs_prior_brief`
+
+This keeps delivery decisions auditable without reconstructing intent from rendered HTML.
+
+## Failure Policy
+
+- citation abstain: hold publication
+- critic fail: hold publication
+- citation partial plus critic pass/warn: publish local artifact, downgrade email delivery to `html_only`
+- missing output artifact hash: keep existing downgrade-to-failed behavior
+
+## Rollout Plan
+
+1. Preserve claim fields in synthesis output and renderer.
+2. Add `ClaimDelta` generation and switch changed rendering to delta-driven output.
+3. Split publish statuses and enforce critic-aware publish gating.
+4. Persist the new fields in decision records and runtime artifacts.
+5. Add golden evals and delivery tests for missing `why_it_matters`, unsupported novelty, and pseudo-analysis.
+
+## Test Plan
+
+- unit tests for `ClaimDelta` generation and changed-section rendering
+- delivery tests for HTML/email rendering of novelty and `Why it matters`
+- decision-record tests for split statuses and preserved claim metadata
+- runner tests for publish gating and changed-section artifacts

--- a/scripts/run_daily_brief.py
+++ b/scripts/run_daily_brief.py
@@ -30,8 +30,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--provider",
-        choices=("deterministic", "openai", "codex-oauth"),
-        default="deterministic",
+        choices=("auto", "deterministic", "openai", "codex-oauth"),
+        default="auto",
         help="Daily-brief synthesis provider mode.",
     )
     parser.add_argument(
@@ -43,14 +43,15 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
-    from apps.agent.daily_brief.provider_registry import build_daily_brief_providers
+    from apps.agent.daily_brief.critic import LocalDailyBriefCritic
+    from apps.agent.daily_brief.provider_registry import resolve_daily_brief_provider
     from apps.agent.daily_brief.runner import run_daily_brief
     from apps.agent.delivery.email_sender import EmailDeliveryConfig
     from apps.agent.delivery.scheduler import DailyBriefSchedule
 
     args = parse_args()
     try:
-        issue_planner, claim_composer = build_daily_brief_providers(
+        provider_resolution = resolve_daily_brief_provider(
             provider=args.provider,
             openai_model=args.openai_model,
         )
@@ -76,8 +77,10 @@ def main() -> None:
             delivery_minute=args.delivery_minute,
         ),
         email_config=email_config,
-        issue_planner=issue_planner,
-        claim_composer=claim_composer,
+        issue_planner=provider_resolution["issue_planner"],
+        claim_composer=provider_resolution["claim_composer"],
+        critic=LocalDailyBriefCritic(),
+        provider_resolution=provider_resolution,
     )
     print(json.dumps(result, indent=2))
     if result["status"] == "failed":

--- a/scripts/run_daily_brief_fixture.py
+++ b/scripts/run_daily_brief_fixture.py
@@ -44,14 +44,14 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
-    from apps.agent.daily_brief.provider_registry import build_daily_brief_providers
+    from apps.agent.daily_brief.provider_registry import resolve_daily_brief_provider
     from apps.agent.daily_brief.runner import run_fixture_daily_brief
     from apps.agent.delivery.email_sender import EmailDeliveryConfig
     from apps.agent.delivery.scheduler import DailyBriefSchedule
 
     args = parse_args()
     try:
-        issue_planner, claim_composer = build_daily_brief_providers(
+        provider_resolution = resolve_daily_brief_provider(
             provider=args.provider,
             openai_model=args.openai_model,
         )
@@ -78,8 +78,9 @@ def main() -> None:
             delivery_minute=args.delivery_minute,
         ),
         email_config=email_config,
-        issue_planner=issue_planner,
-        claim_composer=claim_composer,
+        issue_planner=provider_resolution["issue_planner"],
+        claim_composer=provider_resolution["claim_composer"],
+        provider_resolution=provider_resolution,
     )
     print(json.dumps(result, indent=2))
     if result["status"] == "failed":

--- a/tests/agent/daily_brief/test_delta.py
+++ b/tests/agent/daily_brief/test_delta.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import unittest
+
+from apps.agent.daily_brief.delta import build_changed_section_from_deltas, build_claim_deltas
+
+
+class DailyBriefDeltaTests(unittest.TestCase):
+    def test_build_claim_deltas_preserves_novelty_label_and_prior_match(self) -> None:
+        deltas = build_claim_deltas(
+            structured_claims=[
+                {
+                    "claim_id": "claim_001",
+                    "issue_id": "issue_001",
+                    "claim_kind": "prevailing",
+                    "claim_text": "Softer growth is strengthening later-cut expectations.",
+                    "supporting_citation_ids": ["cite_001"],
+                    "opposing_citation_ids": [],
+                    "confidence": "medium",
+                    "novelty_vs_prior_brief": "strengthened",
+                    "why_it_matters": "Rate-sensitive assets can reprice quickly.",
+                }
+            ],
+            prior_brief_context={"claim_summaries": ["Softer growth was already nudging later-cut expectations."]},
+        )
+
+        self.assertEqual(deltas[0]["novelty_label"], "strengthened")
+        self.assertIsNotNone(deltas[0]["prior_claim_ref"])
+        self.assertEqual(deltas[0]["supporting_prior_overlap"]["thesis_overlap"], "medium")
+
+    def test_build_changed_section_from_deltas_renders_only_changed_labels(self) -> None:
+        changed = build_changed_section_from_deltas(
+            structured_claims=[
+                {
+                    "claim_id": "claim_001",
+                    "issue_id": "issue_001",
+                    "claim_kind": "prevailing",
+                    "claim_text": "Softer growth is strengthening later-cut expectations.",
+                    "supporting_citation_ids": ["cite_001"],
+                    "opposing_citation_ids": [],
+                    "confidence": "medium",
+                    "novelty_vs_prior_brief": "strengthened",
+                    "why_it_matters": "Rate-sensitive assets can reprice quickly.",
+                },
+                {
+                    "claim_id": "claim_002",
+                    "issue_id": "issue_001",
+                    "claim_kind": "counter",
+                    "claim_text": "Policy language remains cautious.",
+                    "supporting_citation_ids": ["cite_002"],
+                    "opposing_citation_ids": [],
+                    "confidence": "medium",
+                    "novelty_vs_prior_brief": "continued",
+                    "why_it_matters": "Cuts are not imminent.",
+                },
+            ],
+            claim_deltas=[
+                {
+                    "claim_id": "claim_001",
+                    "prior_claim_ref": "prior claim",
+                    "novelty_label": "strengthened",
+                    "delta_explanation": "New official release reinforced the thesis.",
+                    "supporting_prior_overlap": {"citation_overlap": 0.5, "thesis_overlap": "medium"},
+                },
+                {
+                    "claim_id": "claim_002",
+                    "prior_claim_ref": "prior claim",
+                    "novelty_label": "continued",
+                    "delta_explanation": "No real change.",
+                    "supporting_prior_overlap": {"citation_overlap": 0.8, "thesis_overlap": "high"},
+                },
+            ],
+        )
+
+        self.assertEqual(len(changed), 1)
+        self.assertEqual(changed[0]["delta_label"], "strengthened")
+        self.assertIn("New official release", changed[0]["delta_explanation"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/daily_brief/test_editorial_planner.py
+++ b/tests/agent/daily_brief/test_editorial_planner.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import unittest
+
+from apps.agent.daily_brief.editorial_planner import build_corpus_summary, plan_brief_locally
+
+
+class EditorialPlannerTests(unittest.TestCase):
+    def test_plan_brief_uses_full_mode_when_diversity_supports_two_issues(self) -> None:
+        plan = plan_brief_locally(
+            run_id="run_demo",
+            generated_at_utc="2026-03-12T07:05:00Z",
+            corpus_summary=[
+                "Growth data softened while payrolls still held up.",
+                "Policy language remained cautious despite the softer data.",
+                "Markets priced cuts more aggressively than officials did.",
+            ],
+            source_diversity_stats={"unique_publishers": 4},
+            prior_brief_context=None,
+        )
+
+        self.assertEqual(plan["render_mode"], "full")
+        self.assertEqual(plan["issue_budget"], 2)
+        self.assertEqual(plan["source_scarcity_mode"], "normal")
+
+    def test_plan_brief_uses_compressed_mode_when_sources_are_sparse(self) -> None:
+        plan = plan_brief_locally(
+            run_id="run_demo",
+            generated_at_utc="2026-03-12T07:05:00Z",
+            corpus_summary=["One official release dominated the day."],
+            source_diversity_stats={"unique_publishers": 1},
+            prior_brief_context=None,
+        )
+
+        self.assertEqual(plan["render_mode"], "compressed")
+        self.assertEqual(plan["issue_budget"], 1)
+        self.assertEqual(plan["source_scarcity_mode"], "scarce")
+
+    def test_build_corpus_summary_prefers_snippets_and_dedupes(self) -> None:
+        summary = build_corpus_summary(
+            corpus_items=[
+                {"doc_id": "doc_001"},
+                {"doc_id": "doc_002"},
+                {"doc_id": "doc_003"},
+            ],
+            documents_by_id={
+                "doc_001": {"rss_snippet": "Growth cooled.", "title": "Growth cooled.", "doc_id": "doc_001"},
+                "doc_002": {
+                    "rss_snippet": "Policy stayed cautious.",
+                    "title": "Policy stayed cautious.",
+                    "doc_id": "doc_002",
+                },
+                "doc_003": {"rss_snippet": "Growth cooled.", "title": "Growth cooled.", "doc_id": "doc_003"},
+            },
+        )
+
+        self.assertEqual(summary, ["Growth cooled.", "Policy stayed cautious."])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/daily_brief/test_issue_dedup.py
+++ b/tests/agent/daily_brief/test_issue_dedup.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import unittest
+
+from apps.agent.daily_brief.issue_dedup import dedupe_issues
+
+
+class IssueDedupTests(unittest.TestCase):
+    def test_merges_high_overlap_issues(self) -> None:
+        final_issues, overlap_reports, information_gain = dedupe_issues(
+            issue_map=[
+                {
+                    "issue_id": "issue_001",
+                    "issue_question": "Will softer growth change Fed expectations?",
+                    "thesis_hint": "Growth is cooling while policy stays cautious.",
+                    "supporting_evidence_ids": ["chunk_001", "chunk_002"],
+                    "opposing_evidence_ids": [],
+                    "minority_evidence_ids": [],
+                    "watch_evidence_ids": [],
+                },
+                {
+                    "issue_id": "issue_002",
+                    "issue_question": "Will weaker growth shift Fed expectations soon?",
+                    "thesis_hint": "Growth is cooling while policy stays cautious.",
+                    "supporting_evidence_ids": ["chunk_001", "chunk_003"],
+                    "opposing_evidence_ids": [],
+                    "minority_evidence_ids": [],
+                    "watch_evidence_ids": [],
+                },
+            ],
+            brief_plan={
+                "brief_id": "brief_2026-03-12",
+                "brief_thesis": "Growth cooling is the main story.",
+                "top_takeaways": [],
+                "issue_budget": 2,
+                "render_mode": "full",
+                "source_scarcity_mode": "normal",
+                "candidate_issue_seeds": [],
+                "issue_order": [],
+                "watchlist": [],
+                "reason_codes": [],
+            },
+        )
+
+        self.assertEqual(len(final_issues), 1)
+        self.assertEqual(overlap_reports[0]["decision"], "merge")
+        self.assertEqual(information_gain[-1]["decision"], "drop")
+
+    def test_drops_low_information_gain_third_issue(self) -> None:
+        final_issues, _overlap_reports, information_gain = dedupe_issues(
+            issue_map=[
+                {
+                    "issue_id": "issue_001",
+                    "issue_question": "Will softer growth change Fed expectations?",
+                    "thesis_hint": "Growth is cooling.",
+                    "supporting_evidence_ids": ["chunk_001"],
+                    "opposing_evidence_ids": [],
+                    "minority_evidence_ids": [],
+                    "watch_evidence_ids": [],
+                },
+                {
+                    "issue_id": "issue_002",
+                    "issue_question": "Will policy language stay cautious?",
+                    "thesis_hint": "Policy remains cautious.",
+                    "supporting_evidence_ids": ["chunk_010"],
+                    "opposing_evidence_ids": [],
+                    "minority_evidence_ids": [],
+                    "watch_evidence_ids": [],
+                },
+                {
+                    "issue_id": "issue_003",
+                    "issue_question": "Will softer growth change Fed expectations again?",
+                    "thesis_hint": "Growth is cooling.",
+                    "supporting_evidence_ids": ["chunk_001"],
+                    "opposing_evidence_ids": [],
+                    "minority_evidence_ids": [],
+                    "watch_evidence_ids": [],
+                },
+            ],
+            brief_plan={
+                "brief_id": "brief_2026-03-12",
+                "brief_thesis": "Two real debates, not three.",
+                "top_takeaways": [],
+                "issue_budget": 2,
+                "render_mode": "full",
+                "source_scarcity_mode": "normal",
+                "candidate_issue_seeds": [],
+                "issue_order": [],
+                "watchlist": [],
+                "reason_codes": [],
+            },
+        )
+
+        self.assertEqual(len(final_issues), 2)
+        self.assertEqual(information_gain[-1]["decision"], "drop")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/daily_brief/test_model_interfaces.py
+++ b/tests/agent/daily_brief/test_model_interfaces.py
@@ -5,6 +5,8 @@ import unittest
 from typing import get_type_hints
 
 from apps.agent.daily_brief.model_interfaces import (
+    BriefPlannerInput,
+    BriefPlannerProvider,
     ClaimComposerInput,
     ClaimComposerProvider,
     CriticInput,
@@ -23,6 +25,12 @@ class DailyBriefModelInterfaceTests(unittest.TestCase):
         self.assertEqual(hints["brief_input"], IssuePlannerInput)
         self.assertEqual(hints["return"], list[IssueMap])
 
+    def test_brief_planner_provider_is_task_specific(self) -> None:
+        signature = inspect.signature(BriefPlannerProvider.plan_brief)
+        self.assertIn("brief_input", signature.parameters)
+        hints = get_type_hints(BriefPlannerProvider.plan_brief)
+        self.assertEqual(hints["brief_input"], BriefPlannerInput)
+
     def test_claim_composer_provider_is_task_specific(self) -> None:
         signature = inspect.signature(ClaimComposerProvider.compose_claims)
         self.assertIn("brief_input", signature.parameters)
@@ -40,7 +48,11 @@ class DailyBriefModelInterfaceTests(unittest.TestCase):
     def test_interface_inputs_use_structured_context(self) -> None:
         self.assertEqual(
             set(IssuePlannerInput.__annotations__),
-            {"run_id", "generated_at_utc", "evidence_pack", "prior_brief_context"},
+            {"run_id", "generated_at_utc", "brief_plan", "issue_evidence_scopes", "prior_brief_context"},
+        )
+        self.assertEqual(
+            set(BriefPlannerInput.__annotations__),
+            {"run_id", "generated_at_utc", "corpus_summary", "source_diversity_stats", "prior_brief_context"},
         )
         self.assertEqual(
             set(ClaimComposerInput.__annotations__),

--- a/tests/agent/daily_brief/test_openai_issue_planner.py
+++ b/tests/agent/daily_brief/test_openai_issue_planner.py
@@ -6,6 +6,40 @@ from apps.agent.daily_brief.model_interfaces import IssuePlannerInput
 from apps.agent.daily_brief.openai_issue_planner import OpenAIIssuePlanner
 
 
+def _planner_input() -> IssuePlannerInput:
+    return IssuePlannerInput(
+        run_id="run_001",
+        generated_at_utc="2026-03-12T00:00:00Z",
+        brief_plan={
+            "brief_id": "brief_2026-03-12",
+            "brief_thesis": "Oil markets are being driven by supply pressure and demand skepticism.",
+            "top_takeaways": ["Supply pressure remains live.", "Demand softness may cap the move."],
+            "issue_budget": 2,
+            "render_mode": "full",
+            "source_scarcity_mode": "normal",
+            "candidate_issue_seeds": ["oil supply pressure", "oil demand slowdown"],
+            "issue_order": ["seed_001", "seed_002"],
+            "watchlist": ["Watch weekly inventories."],
+            "reason_codes": ["two_distinct_debates_supported"],
+        },
+        issue_evidence_scopes=[
+            {
+                "issue_id": "issue_oil",
+                "primary_chunk_ids": ["chunk_1", "chunk_2"],
+                "opposing_chunk_ids": ["chunk_3"],
+                "minority_chunk_ids": ["chunk_4"],
+                "watch_chunk_ids": ["chunk_5"],
+                "coverage_summary": {
+                    "unique_publishers": 5,
+                    "source_roles": ["official", "market_media"],
+                    "time_span_hours": 18,
+                },
+            }
+        ],
+        prior_brief_context=None,
+    )
+
+
 class OpenAIIssuePlannerTests(unittest.TestCase):
     def test_builds_bounded_structured_request_payload_before_parsing(self) -> None:
         captured_request: dict[str, object] = {}
@@ -31,49 +65,7 @@ class OpenAIIssuePlannerTests(unittest.TestCase):
         planner = OpenAIIssuePlanner(response_loader=loader)
 
         result = planner.plan_issues(
-            brief_input=IssuePlannerInput(
-                run_id="run_001",
-                generated_at_utc="2026-03-12T00:00:00Z",
-                evidence_pack=[
-                    {
-                        "chunk_id": "chunk_1",
-                        "doc_id": "doc_1",
-                        "publisher": "Reuters",
-                        "title": "Oil rises on supply concerns",
-                        "text": "Supply concerns kept oil prices supported as traders watched shipping disruptions.",
-                        "retrieval_score": 0.91,
-                    },
-                    {
-                        "chunk_id": "chunk_2",
-                        "doc_id": "doc_2",
-                        "publisher": "WSJ",
-                        "text": "Refiners are watching inventory pressure.",
-                    },
-                    {
-                        "chunk_id": "chunk_3",
-                        "doc_id": "doc_3",
-                        "publisher": "BLS",
-                        "text": "Demand indicators softened.",
-                    },
-                    {
-                        "chunk_id": "chunk_4",
-                        "doc_id": "doc_4",
-                        "publisher": "BEA",
-                        "text": "Long-term consumption remains firm.",
-                    },
-                    {
-                        "chunk_id": "chunk_5",
-                        "doc_id": "doc_5",
-                        "publisher": "EIA",
-                        "text": "Watch inventory data next week.",
-                    },
-                ],
-                prior_brief_context={
-                    "prior_issue_questions": ["Will oil prices keep rising?"],
-                    "prior_generated_at_utc": "2026-03-11T00:00:00Z",
-                    "oversized": "x" * 600,
-                },
-            )
+            brief_input={**_planner_input(), "prior_brief_context": {"oversized": "x" * 600}}
         )
 
         self.assertEqual(result[0]["issue_id"], "issue_oil")
@@ -82,10 +74,17 @@ class OpenAIIssuePlannerTests(unittest.TestCase):
         self.assertEqual(captured_request["generated_at_utc"], "2026-03-12T00:00:00Z")
         self.assertEqual(captured_request["response_format"]["type"], "json_schema")
         self.assertEqual(captured_request["messages"][0]["role"], "system")
-        self.assertEqual(len(captured_request["input"]["evidence_pack"]), 5)
+        self.assertEqual(len(captured_request["input"]["issue_evidence_scopes"]), 1)
         self.assertEqual(
-            set(captured_request["input"]["evidence_pack"][0]),
-            {"chunk_id", "doc_id", "publisher", "title", "text", "retrieval_score"},
+            set(captured_request["input"]["issue_evidence_scopes"][0]),
+            {
+                "issue_id",
+                "primary_chunk_ids",
+                "opposing_chunk_ids",
+                "minority_chunk_ids",
+                "watch_chunk_ids",
+                "coverage_summary",
+            },
         )
         self.assertLessEqual(len(captured_request["input"]["prior_brief_context"]["oversized"]), 240)
 
@@ -107,18 +106,7 @@ class OpenAIIssuePlannerTests(unittest.TestCase):
         )
 
         result = planner.plan_issues(
-            brief_input=IssuePlannerInput(
-                run_id="run_001",
-                generated_at_utc="2026-03-12T00:00:00Z",
-                evidence_pack=[
-                    {"chunk_id": "chunk_1"},
-                    {"chunk_id": "chunk_2"},
-                    {"chunk_id": "chunk_3"},
-                    {"chunk_id": "chunk_4"},
-                    {"chunk_id": "chunk_5"},
-                ],
-                prior_brief_context=None,
-            )
+            brief_input=_planner_input()
         )
 
         self.assertEqual(result[0]["issue_id"], "issue_oil")
@@ -129,12 +117,7 @@ class OpenAIIssuePlannerTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             planner.plan_issues(
-                brief_input=IssuePlannerInput(
-                    run_id="run_001",
-                    generated_at_utc="2026-03-12T00:00:00Z",
-                    evidence_pack=[],
-                    prior_brief_context=None,
-                )
+                brief_input=_planner_input()
             )
 
     def test_rejects_wrong_issue_map_field_types(self) -> None:
@@ -156,12 +139,7 @@ class OpenAIIssuePlannerTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             planner.plan_issues(
-                brief_input=IssuePlannerInput(
-                    run_id="run_001",
-                    generated_at_utc="2026-03-12T00:00:00Z",
-                    evidence_pack=[],
-                    prior_brief_context=None,
-                )
+                brief_input=_planner_input()
             )
 
     def test_rejects_empty_issue_list_output(self) -> None:
@@ -169,12 +147,7 @@ class OpenAIIssuePlannerTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             planner.plan_issues(
-                brief_input=IssuePlannerInput(
-                    run_id="run_001",
-                    generated_at_utc="2026-03-12T00:00:00Z",
-                    evidence_pack=[],
-                    prior_brief_context=None,
-                )
+                brief_input=_planner_input()
             )
 
     def test_rejects_issue_output_that_references_unknown_evidence_ids(self) -> None:
@@ -196,12 +169,7 @@ class OpenAIIssuePlannerTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             planner.plan_issues(
-                brief_input=IssuePlannerInput(
-                    run_id="run_001",
-                    generated_at_utc="2026-03-12T00:00:00Z",
-                    evidence_pack=[{"chunk_id": "chunk_1"}],
-                    prior_brief_context=None,
-                )
+                brief_input=_planner_input()
             )
 
 

--- a/tests/agent/daily_brief/test_openai_runtime.py
+++ b/tests/agent/daily_brief/test_openai_runtime.py
@@ -45,11 +45,32 @@ class OpenAIRuntimeSchemaTests(unittest.TestCase):
             brief_input=IssuePlannerInput(
                 run_id="run_demo",
                 generated_at_utc="2026-03-12T10:00:00Z",
-                evidence_pack=[
-                    {"chunk_id": "chunk_001", "doc_id": "doc_001", "publisher": "Reuters", "text": "Growth cools."},
-                    {"chunk_id": "chunk_002", "doc_id": "doc_002", "publisher": "Fed", "text": "Policy steady."},
-                    {"chunk_id": "chunk_003", "doc_id": "doc_003", "publisher": "WSJ", "text": "Hard landing view."},
-                    {"chunk_id": "chunk_004", "doc_id": "doc_004", "publisher": "BLS", "text": "Watch CPI."},
+                brief_plan={
+                    "brief_id": "brief_2026-03-12",
+                    "brief_thesis": "Growth is cooling while policy stays cautious.",
+                    "top_takeaways": ["Growth cools.", "Policy stays cautious."],
+                    "issue_budget": 2,
+                    "render_mode": "full",
+                    "source_scarcity_mode": "normal",
+                    "candidate_issue_seeds": ["growth cooling", "policy caution"],
+                    "issue_order": ["seed_001", "seed_002"],
+                    "watchlist": ["Watch CPI."],
+                    "reason_codes": ["two_distinct_debates_supported"],
+                },
+                issue_evidence_scopes=[
+                    {
+                        "issue_id": "issue_001",
+                        "issue_seed": "growth cooling",
+                        "primary_chunk_ids": ["chunk_001"],
+                        "opposing_chunk_ids": ["chunk_002"],
+                        "minority_chunk_ids": ["chunk_003"],
+                        "watch_chunk_ids": ["chunk_004"],
+                        "coverage_summary": {
+                            "unique_publishers": 4,
+                            "source_roles": ["official", "market_media"],
+                            "time_span_hours": 12,
+                        },
+                    }
                 ],
                 prior_brief_context=None,
             )

--- a/tests/agent/daily_brief/test_prior_brief_context.py
+++ b/tests/agent/daily_brief/test_prior_brief_context.py
@@ -20,7 +20,9 @@ class PriorBriefContextTests(unittest.TestCase):
 
         self.assertEqual(context["previous_generated_at_utc"], "2026-03-11T00:00:00Z")
         self.assertEqual(context["claim_summaries"], ["Prevailing claim.", "Counter claim."])
+        self.assertEqual(context["claim_texts"], ["Prevailing claim.", "Counter claim."])
         self.assertEqual(context["citation_ids"], ["cite_001", "cite_002"])
+        self.assertEqual(context["issue_questions"], ["Previous daily brief"])
         self.assertEqual(context["issues"][0]["issue_question"], "Previous daily brief")
         self.assertEqual(context["issues"][0]["claim_summaries"], ["Prevailing claim.", "Counter claim."])
 

--- a/tests/agent/daily_brief/test_provider_registry.py
+++ b/tests/agent/daily_brief/test_provider_registry.py
@@ -6,6 +6,18 @@ from unittest.mock import patch
 
 
 class ProviderRegistryTests(unittest.TestCase):
+    def test_resolve_daily_brief_provider_returns_deterministic_metadata(self):
+        from apps.agent.daily_brief.provider_registry import resolve_daily_brief_provider
+
+        resolution = resolve_daily_brief_provider(provider="deterministic")
+
+        self.assertEqual(resolution["requested_provider"], "deterministic")
+        self.assertEqual(resolution["resolved_provider"], "deterministic")
+        self.assertEqual(resolution["provider_mode"], "deterministic")
+        self.assertFalse(resolution["provider_fallback_used"])
+        self.assertIsNone(resolution["issue_planner"])
+        self.assertIsNone(resolution["claim_composer"])
+
     def test_build_daily_brief_providers_returns_none_for_deterministic(self):
         from apps.agent.daily_brief.provider_registry import build_daily_brief_providers
 
@@ -61,8 +73,88 @@ class ProviderRegistryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Unsupported provider"):
             build_daily_brief_providers(provider="unsupported")
 
+    def test_resolve_daily_brief_provider_auto_prefers_codex_oauth(self):
+        from apps.agent.daily_brief import provider_registry
+
+        planner = object()
+        composer = object()
+
+        with (
+            patch.object(
+                provider_registry,
+                "_build_codex_oauth_providers",
+                return_value=(planner, composer),
+            ) as codex_mock,
+            patch.object(provider_registry, "_build_openai_providers") as openai_mock,
+        ):
+            resolution = provider_registry.resolve_daily_brief_provider(provider="auto")
+
+        codex_mock.assert_called_once_with(codex_runner=None, login_checker=None)
+        openai_mock.assert_not_called()
+        self.assertEqual(resolution["requested_provider"], "auto")
+        self.assertEqual(resolution["resolved_provider"], "codex-oauth")
+        self.assertEqual(resolution["provider_mode"], "model-assisted")
+        self.assertFalse(resolution["provider_fallback_used"])
+        self.assertIs(resolution["issue_planner"], planner)
+        self.assertIs(resolution["claim_composer"], composer)
+
+    def test_resolve_daily_brief_provider_auto_falls_back_to_openai(self):
+        from apps.agent.daily_brief import provider_registry
+
+        planner = object()
+        composer = object()
+
+        with (
+            patch.object(
+                provider_registry,
+                "_build_codex_oauth_providers",
+                side_effect=ValueError("codex unavailable"),
+            ) as codex_mock,
+            patch.object(
+                provider_registry,
+                "_build_openai_providers",
+                return_value=(planner, composer),
+            ) as openai_mock,
+        ):
+            resolution = provider_registry.resolve_daily_brief_provider(
+                provider="auto",
+                openai_model="gpt-test",
+            )
+
+        codex_mock.assert_called_once_with(codex_runner=None, login_checker=None)
+        openai_mock.assert_called_once_with(openai_model="gpt-test")
+        self.assertEqual(resolution["resolved_provider"], "openai")
+        self.assertEqual(resolution["provider_mode"], "model-assisted")
+        self.assertTrue(resolution["provider_fallback_used"])
+
+    def test_resolve_daily_brief_provider_auto_fails_closed_when_none_available(self):
+        from apps.agent.daily_brief import provider_registry
+
+        with (
+            patch.object(
+                provider_registry,
+                "_build_codex_oauth_providers",
+                side_effect=ValueError("codex unavailable"),
+            ),
+            patch.object(
+                provider_registry,
+                "_build_openai_providers",
+                side_effect=ValueError("openai unavailable"),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "Auto provider resolution failed"):
+                provider_registry.resolve_daily_brief_provider(provider="auto")
+
 
 class RunnerScriptProviderWiringTests(unittest.TestCase):
+    def test_fixture_script_defaults_to_deterministic(self):
+        from scripts import run_daily_brief_fixture
+
+        with patch.object(sys, "argv", ["run_daily_brief_fixture.py"]):
+            args = run_daily_brief_fixture.parse_args()
+
+        self.assertEqual(args.provider, "deterministic")
+
     def test_fixture_script_accepts_codex_oauth_provider(self):
         from scripts import run_daily_brief_fixture
 
@@ -76,11 +168,19 @@ class RunnerScriptProviderWiringTests(unittest.TestCase):
 
         planner = object()
         composer = object()
+        resolution = {
+            "requested_provider": "openai",
+            "resolved_provider": "openai",
+            "provider_mode": "model-assisted",
+            "provider_fallback_used": False,
+            "issue_planner": planner,
+            "claim_composer": composer,
+        }
 
         with (
             patch(
-                "apps.agent.daily_brief.provider_registry.build_daily_brief_providers",
-                return_value=(planner, composer),
+                "apps.agent.daily_brief.provider_registry.resolve_daily_brief_provider",
+                return_value=resolution,
             ) as registry_mock,
             patch(
                 "apps.agent.daily_brief.runner.run_fixture_daily_brief",
@@ -103,6 +203,15 @@ class RunnerScriptProviderWiringTests(unittest.TestCase):
         registry_mock.assert_called_once_with(provider="openai", openai_model="gpt-test")
         self.assertIs(runner_mock.call_args.kwargs["issue_planner"], planner)
         self.assertIs(runner_mock.call_args.kwargs["claim_composer"], composer)
+        self.assertEqual(runner_mock.call_args.kwargs["provider_resolution"], resolution)
+
+    def test_live_script_defaults_to_auto(self):
+        from scripts import run_daily_brief
+
+        with patch.object(sys, "argv", ["run_daily_brief.py"]):
+            args = run_daily_brief.parse_args()
+
+        self.assertEqual(args.provider, "auto")
 
     def test_live_script_accepts_codex_oauth_provider(self):
         from scripts import run_daily_brief
@@ -117,11 +226,19 @@ class RunnerScriptProviderWiringTests(unittest.TestCase):
 
         planner = object()
         composer = object()
+        resolution = {
+            "requested_provider": "auto",
+            "resolved_provider": "openai",
+            "provider_mode": "model-assisted",
+            "provider_fallback_used": True,
+            "issue_planner": planner,
+            "claim_composer": composer,
+        }
 
         with (
             patch(
-                "apps.agent.daily_brief.provider_registry.build_daily_brief_providers",
-                return_value=(planner, composer),
+                "apps.agent.daily_brief.provider_registry.resolve_daily_brief_provider",
+                return_value=resolution,
             ) as registry_mock,
             patch(
                 "apps.agent.daily_brief.runner.run_daily_brief",
@@ -132,8 +249,6 @@ class RunnerScriptProviderWiringTests(unittest.TestCase):
                 "argv",
                 [
                     "run_daily_brief.py",
-                    "--provider",
-                    "openai",
                     "--openai-model",
                     "gpt-live",
                 ],
@@ -141,9 +256,10 @@ class RunnerScriptProviderWiringTests(unittest.TestCase):
         ):
             run_daily_brief.main()
 
-        registry_mock.assert_called_once_with(provider="openai", openai_model="gpt-live")
+        registry_mock.assert_called_once_with(provider="auto", openai_model="gpt-live")
         self.assertIs(runner_mock.call_args.kwargs["issue_planner"], planner)
         self.assertIs(runner_mock.call_args.kwargs["claim_composer"], composer)
+        self.assertEqual(runner_mock.call_args.kwargs["provider_resolution"], resolution)
 
 
 if __name__ == "__main__":

--- a/tests/agent/daily_brief/test_runner.py
+++ b/tests/agent/daily_brief/test_runner.py
@@ -205,6 +205,14 @@ class DailyBriefRunnerTests(unittest.TestCase):
                 {"text": "Bond traders push back on the soft-landing consensus as growth cools.", "doc_id": "doc_counter_invalid", "chunk_id": "doc_counter_invalid_chunk_000", "publisher": "Reuters", "source_id": "reuters_business", "published_at": None, "credibility_tier": 2},
                 {"text": "Investors question the soft-landing narrative as growth data weakens.", "doc_id": "doc_counter_retry", "chunk_id": "doc_counter_retry_chunk_000", "publisher": "Wall Street Journal", "source_id": "wsj_markets", "published_at": "2026-03-10T14:20:00Z", "credibility_tier": 2},
             ],
+            corpus_items=[
+                {"chunk_id": "doc_watch_chunk_000", "doc_id": "doc_watch", "source_id": "bls_preview", "publisher": "BLS Preview Desk", "text": "Watch Friday CPI for shelter inflation surprises.", "published_at": "2026-03-10T16:00:00Z", "credibility_tier": 1, "source_role": "official", "retrieval_score": 0.95},
+                {"chunk_id": "doc_minority_chunk_000", "doc_id": "doc_minority", "source_id": "market_commentary", "publisher": "Market Commentary", "text": "A minority of investors still expects a hard landing.", "published_at": "2026-03-10T15:30:00Z", "credibility_tier": 3, "source_role": "market_media", "retrieval_score": 0.9},
+                {"chunk_id": "doc_prevailing_chunk_000", "doc_id": "doc_prevailing", "source_id": "fed_press_releases", "publisher": "Federal Reserve", "text": "Fed officials kept policy steady while inflation progress remained uneven.", "published_at": "2026-03-10T14:00:00Z", "credibility_tier": 1, "source_role": "official", "retrieval_score": 0.88},
+                {"chunk_id": "doc_counter_invalid_chunk_000", "doc_id": "doc_counter_invalid", "source_id": "reuters_business", "publisher": "Reuters", "text": "Bond traders push back on the soft-landing consensus as growth cools.", "published_at": None, "credibility_tier": 2, "source_role": "market_media", "retrieval_score": 0.86},
+                {"chunk_id": "doc_counter_retry_chunk_000", "doc_id": "doc_counter_retry", "source_id": "wsj_markets", "publisher": "Wall Street Journal", "text": "Investors question the soft-landing narrative as growth data weakens.", "published_at": "2026-03-10T14:20:00Z", "credibility_tier": 2, "source_role": "market_media", "retrieval_score": 0.84},
+            ],
+            diversity_stats={"unique_publishers": 5},
         )
         registry = {
             "bls_preview": {"id": "bls_preview", "name": "BLS Preview Desk", "url": "https://example.test/watch", "type": "rss", "credibility_tier": 1, "paywall_policy": "full", "fetch_interval": "daily", "tags": ["macro_data"]},
@@ -650,6 +658,19 @@ class DailyBriefRunnerTests(unittest.TestCase):
                 syntheses = connection.execute(
                     "SELECT synthesis_id, kind, status FROM syntheses"
                 ).fetchall()
+                issue_maps = connection.execute(
+                    "SELECT issue_id, issue_question FROM issue_maps WHERE run_id = ? ORDER BY issue_id",
+                    ("run_fixture_sqlite",),
+                ).fetchall()
+                structured_claims = connection.execute(
+                    """
+                    SELECT claim_id, novelty_vs_prior_brief, why_it_matters
+                    FROM structured_claims
+                    WHERE run_id = ?
+                    ORDER BY claim_id
+                    """,
+                    ("run_fixture_sqlite",),
+                ).fetchall()
                 runs = connection.execute(
                     "SELECT run_id, run_type, status FROM runs"
                 ).fetchall()
@@ -664,6 +685,10 @@ class DailyBriefRunnerTests(unittest.TestCase):
         self.assertEqual(len(syntheses), 1)
         self.assertTrue(syntheses[0][0].startswith("syn_"))
         self.assertEqual(syntheses[0][1:], ("daily_brief", "ok"))
+        self.assertGreater(len(issue_maps), 0)
+        self.assertTrue(all(issue_id.startswith("issue_") for issue_id, _question in issue_maps))
+        self.assertGreater(len(structured_claims), 0)
+        self.assertTrue(all(claim_id for claim_id, _novelty, _why in structured_claims))
         self.assertEqual(runs, [("run_fixture_sqlite", "daily_brief", "ok")])
 
     def test_run_fixture_daily_brief_reuses_stable_document_ids_across_runs(self):
@@ -785,6 +810,30 @@ class DailyBriefRunnerTests(unittest.TestCase):
             self.assertEqual(run_summary["docs_fetched"], 5)
             self.assertEqual(result["pipeline_status"], "ok")
 
+    def test_run_daily_brief_persists_provider_resolution_metadata_in_run_summary(self):
+        fixture_payloads = load_active_fixture_payloads()
+
+        with patch("apps.agent.daily_brief.runner.fetch_live_payloads_for_source") as live_fetch_mock, tempfile.TemporaryDirectory() as tmpdir:
+            live_fetch_mock.side_effect = lambda *, source, fetched_at_utc: fixture_payloads.get(str(source["id"]), [])
+            result = run_daily_brief(
+                base_dir=Path(tmpdir),
+                run_id="run_live_provider_auto",
+                generated_at_utc="2026-03-10T16:00:00Z",
+                provider_resolution={
+                    "requested_provider": "auto",
+                    "resolved_provider": "openai",
+                    "provider_mode": "model-assisted",
+                    "provider_fallback_used": True,
+                },
+            )
+
+            run_summary = json.loads((Path(result["artifact_dir"]) / "run_summary.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(run_summary["requested_provider"], "auto")
+        self.assertEqual(run_summary["resolved_provider"], "openai")
+        self.assertEqual(run_summary["provider_mode"], "model-assisted")
+        self.assertTrue(run_summary["provider_fallback_used"])
+
     def test_run_fixture_daily_brief_includes_changed_section_when_previous_synthesis_exists(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             base_dir = Path(tmpdir)
@@ -821,7 +870,7 @@ class DailyBriefRunnerTests(unittest.TestCase):
 
         self.assertIn("changed", synthesis_payload)
         self.assertGreater(len(synthesis_payload["changed"]), 0)
-        self.assertIn("Changed Since Yesterday", html)
+        self.assertIn("What Changed", html)
 
     def test_run_fixture_daily_brief_persists_budget_preflight_truthfully(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1138,6 +1187,8 @@ class DailyBriefRunnerTests(unittest.TestCase):
             def plan_issues(self, *, brief_input):
                 call_order.append("planner")
                 test_case.assertEqual(brief_input["generated_at_utc"], "2026-03-10T16:00:00Z")
+                test_case.assertIn("brief_plan", brief_input)
+                test_case.assertIn("issue_evidence_scopes", brief_input)
                 return [
                     IssueMap(
                         issue_id="issue_001",
@@ -1306,6 +1357,13 @@ class DailyBriefRunnerTests(unittest.TestCase):
                 {"text": "Fed officials kept policy steady while inflation progress remained uneven.", "doc_id": "doc_prevailing", "chunk_id": "doc_prevailing_chunk_000", "publisher": "Federal Reserve", "source_id": "fed_press_releases", "published_at": "2026-03-10T14:00:00Z", "credibility_tier": 1},
                 {"text": "Investors question the soft-landing narrative as growth data weakens.", "doc_id": "doc_counter_retry", "chunk_id": "doc_counter_retry_chunk_000", "publisher": "Wall Street Journal", "source_id": "wsj_markets", "published_at": "2026-03-10T14:20:00Z", "credibility_tier": 2},
             ],
+            corpus_items=[
+                {"chunk_id": "doc_watch_chunk_000", "doc_id": "doc_watch", "source_id": "bls_preview", "publisher": "BLS Preview Desk", "text": "Watch Friday CPI for shelter inflation surprises.", "published_at": "2026-03-10T16:00:00Z", "credibility_tier": 1, "source_role": "official", "retrieval_score": 0.95},
+                {"chunk_id": "doc_minority_chunk_000", "doc_id": "doc_minority", "source_id": "market_commentary", "publisher": "Market Commentary", "text": "A minority of investors still expects a hard landing.", "published_at": "2026-03-10T15:30:00Z", "credibility_tier": 3, "source_role": "market_media", "retrieval_score": 0.9},
+                {"chunk_id": "doc_prevailing_chunk_000", "doc_id": "doc_prevailing", "source_id": "fed_press_releases", "publisher": "Federal Reserve", "text": "Fed officials kept policy steady while inflation progress remained uneven.", "published_at": "2026-03-10T14:00:00Z", "credibility_tier": 1, "source_role": "official", "retrieval_score": 0.88},
+                {"chunk_id": "doc_counter_retry_chunk_000", "doc_id": "doc_counter_retry", "source_id": "wsj_markets", "publisher": "Wall Street Journal", "text": "Investors question the soft-landing narrative as growth data weakens.", "published_at": "2026-03-10T14:20:00Z", "credibility_tier": 2, "source_role": "market_media", "retrieval_score": 0.84},
+            ],
+            diversity_stats={"unique_publishers": 4},
         )
         registry = {
             "bls_preview": {"id": "bls_preview", "name": "BLS Preview Desk", "url": "https://example.test/watch", "type": "rss", "credibility_tier": 1, "paywall_policy": "full", "fetch_interval": "daily", "tags": ["macro_data"]},
@@ -1348,6 +1406,8 @@ class DailyBriefRunnerTests(unittest.TestCase):
             documents=[],
             chunks=[],
             fts_rows=[],
+            corpus_items=[],
+            diversity_stats={},
         )
 
         class _Planner(IssuePlannerProvider):

--- a/tests/agent/delivery/test_email_sender.py
+++ b/tests/agent/delivery/test_email_sender.py
@@ -39,18 +39,44 @@ class DailyBriefEmailSenderTests(unittest.TestCase):
             report_date="2026-03-10",
             run_id="run_delivery",
             html_body="<html><body><h1>Daily Brief</h1></body></html>",
-            status_title="Validated",
+            status_title="Ready",
+            synthesis={
+                "brief": {
+                    "bottom_line": "Growth is cooling while policy language stays cautious.",
+                    "top_takeaways": ["Growth is cooling.", "Policy remains cautious."],
+                },
+                "issues": [
+                    {
+                        "title": "Will softer growth change near-term Fed expectations?",
+                        "prevailing": [
+                            {
+                                "text": "Softer growth is raising later-cut expectations.",
+                                "novelty_vs_prior_brief": "strengthened",
+                                "why_it_matters": "Rate-sensitive assets can reprice quickly.",
+                            }
+                        ],
+                    }
+                ],
+            },
+            citation_status="partial",
+            analytical_status="warn",
+            publish_decision="publish",
             smtp_class=_FakeSMTP,
         )
 
         message = _FakeSMTP.last_instance.sent_messages[0]
 
         self.assertEqual(result["recipient_count"], 2)
-        self.assertEqual(result["subject"], "Daily Brief: 2026-03-10")
+        self.assertEqual(result["subject"], "Daily Brief [PARTIAL/WARN]: 2026-03-10")
         self.assertTrue(_FakeSMTP.last_instance.started_tls)
         self.assertEqual(message["To"], "pm@example.test, risk@example.test")
-        self.assertEqual(message["Subject"], "Daily Brief: 2026-03-10")
-        self.assertIn("Daily Brief", message.as_string())
+        self.assertEqual(message["Subject"], "Daily Brief [PARTIAL/WARN]: 2026-03-10")
+        rendered = message.as_string()
+        self.assertIn("Citation status: partial", rendered)
+        self.assertIn("Analytical quality: warn", rendered)
+        self.assertIn("Bottom line: Growth is cooling while policy language stays cautious.", rendered)
+        self.assertIn("prevailing [strengthened]: Softer growth is raising later-cut expectations.", rendered)
+        self.assertIn("Why it matters: Rate-sensitive assets can reprice quickly.", rendered)
 
 
 if __name__ == "__main__":

--- a/tests/agent/delivery/test_html_report.py
+++ b/tests/agent/delivery/test_html_report.py
@@ -15,6 +15,16 @@ class HtmlReportTests(unittest.TestCase):
                 report_date="2026-03-10",
                 run_id="run_daily_fixture",
                 synthesis={
+                    "brief": {
+                        "bottom_line": "Supply pressure and demand softness are the two main debates.",
+                        "top_takeaways": [
+                            "Supply pressure remains live.",
+                            "Demand softness may cap the move.",
+                        ],
+                        "watchlist": ["Watch OPEC guidance next week."],
+                        "render_mode": "full",
+                        "source_scarcity_mode": "normal",
+                    },
                     "issues": [
                         {
                             "issue_id": "issue_001",
@@ -27,6 +37,10 @@ class HtmlReportTests(unittest.TestCase):
                                 {
                                     "text": "The prevailing argument emphasizes near-term supply pressure.",
                                     "citation_ids": ["cite_001"],
+                                    "novelty_vs_prior_brief": "strengthened",
+                                    "why_it_matters": (
+                                        "Energy inflation risk stays elevated if supply pressure persists."
+                                    ),
                                     "evidence": [
                                         {
                                             "citation_id": "cite_001",
@@ -79,8 +93,15 @@ class HtmlReportTests(unittest.TestCase):
             html = output_path.read_text(encoding="utf-8")
 
         self.assertEqual(result, output_path)
+        self.assertIn("Citation status", html)
+        self.assertIn("Analytical quality", html)
+        self.assertIn("Bottom Line", html)
+        self.assertIn("Key Takeaways", html)
         self.assertIn("Will oil prices keep rising over the next few weeks?", html)
         self.assertIn("What to Watch", html)
+        self.assertIn("Strengthened", html)
+        self.assertIn("Why it matters", html)
+        self.assertIn("Energy inflation risk stays elevated", html)
         self.assertIn("Supply disruptions stayed in focus for oil traders.", html)
         self.assertIn("https://example.test/reuters", html)
 
@@ -202,7 +223,7 @@ class HtmlReportTests(unittest.TestCase):
 
             html = output_path.read_text(encoding="utf-8")
 
-        self.assertIn("Changed Since Yesterday", html)
+        self.assertIn("What Changed", html)
         self.assertIn("Prevailing changed versus yesterday", html)
 
 

--- a/tests/agent/ingest/test_live_fetch.py
+++ b/tests/agent/ingest/test_live_fetch.py
@@ -23,6 +23,56 @@ RSS_FEED = """<?xml version="1.0" encoding="UTF-8"?>
 </rss>
 """
 
+HTML_PAGE = """<!doctype html>
+<html lang="en">
+  <head>
+    <title>Bank of England policy update</title>
+    <link rel="canonical" href="https://example.test/boe/policy-update" />
+    <meta name="description" content="A short HTML summary." />
+    <meta name="author" content="BOE Staff" />
+    <meta property="article:published_time" content="2026-03-10T14:00:00Z" />
+  </head>
+  <body>
+    <main>
+      <h1>Policy update</h1>
+      <p>The committee left policy unchanged.</p>
+      <p>Officials emphasized data dependence.</p>
+    </main>
+  </body>
+</html>
+"""
+
+
+def _build_pdf_bytes(text: str) -> bytes:
+    escaped_text = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+    content_stream = f"BT\n/F1 18 Tf\n72 72 Td\n({escaped_text}) Tj\nET"
+    objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R "
+        "/Resources << /Font << /F1 5 0 R >> >> >>",
+        f"<< /Length {len(content_stream.encode('latin-1'))} >>\nstream\n{content_stream}\nendstream",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+
+    parts: list[bytes] = [b"%PDF-1.4\n"]
+    offsets: list[int] = [0]
+    current_offset = len(parts[0])
+    for index, body in enumerate(objects, start=1):
+        object_bytes = f"{index} 0 obj\n{body}\nendobj\n".encode("latin-1")
+        offsets.append(current_offset)
+        parts.append(object_bytes)
+        current_offset += len(object_bytes)
+
+    xref_offset = current_offset
+    xref_rows = ["0000000000 65535 f \n"]
+    xref_rows.extend(f"{offset:010d} 00000 n \n" for offset in offsets[1:])
+    xref = f"xref\n0 {len(objects) + 1}\n{''.join(xref_rows)}"
+    trailer = (
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF"
+    )
+    return b"".join(parts) + xref.encode("latin-1") + trailer.encode("latin-1")
+
 
 class _FakeResponse:
     def __init__(self, payload: bytes) -> None:
@@ -71,10 +121,57 @@ class LiveFetchTests(unittest.TestCase):
         self.assertEqual(len(payloads), 2)
         self.assertEqual(payloads[0]["fetched_at"], "2026-03-10T16:00:00Z")
 
-    def test_fetch_live_payloads_rejects_non_rss_source_type_for_current_slice(self):
+    def test_fetch_live_payloads_for_source_reads_html_page(self):
+        source = {
+            "id": "boe_news",
+            "url": "https://example.test/boe/policy-update",
+            "type": "html",
+        }
+
+        with patch(
+            "apps.agent.ingest.live_fetch.urlopen",
+            return_value=_FakeResponse(HTML_PAGE.encode("utf-8")),
+        ):
+            payloads = fetch_live_payloads_for_source(
+                source=source,
+                fetched_at_utc="2026-03-10T16:00:00Z",
+            )
+
+        self.assertEqual(len(payloads), 1)
+        self.assertEqual(payloads[0]["canonical_url"], "https://example.test/boe/policy-update")
+        self.assertEqual(payloads[0]["headline"], "Bank of England policy update")
+        self.assertEqual(payloads[0]["byline"], "BOE Staff")
+        self.assertEqual(payloads[0]["published_at"], "2026-03-10T14:00:00Z")
+        self.assertEqual(payloads[0]["snippet"], "A short HTML summary.")
+        self.assertIn("The committee left policy unchanged.", payloads[0]["text"])
+
+    def test_fetch_live_payloads_for_source_reads_pdf_bytes(self):
+        source = {
+            "id": "fed_minutes_pdf",
+            "url": "https://example.test/fed/minutes.pdf",
+            "type": "pdf",
+        }
+
+        with patch(
+            "apps.agent.ingest.live_fetch.urlopen",
+            return_value=_FakeResponse(_build_pdf_bytes("FOMC minutes note inflation progress.")),
+        ):
+            payloads = fetch_live_payloads_for_source(
+                source=source,
+                fetched_at_utc="2026-03-10T16:00:00Z",
+            )
+
+        self.assertEqual(len(payloads), 1)
+        self.assertEqual(payloads[0]["canonical_url"], "https://example.test/fed/minutes.pdf")
+        self.assertEqual(payloads[0]["url"], "https://example.test/fed/minutes.pdf")
+        self.assertEqual(payloads[0]["fetched_at"], "2026-03-10T16:00:00Z")
+        self.assertEqual(payloads[0]["doc_type"], "pdf")
+        self.assertIsInstance(payloads[0]["pdf_bytes"], bytes)
+
+    def test_fetch_live_payloads_rejects_unknown_source_type(self):
         with self.assertRaises(ValueError):
             fetch_live_payloads_for_source(
-                source={"id": "boe_news", "url": "https://example.test/news", "type": "html"},
+                source={"id": "boe_news", "url": "https://example.test/news", "type": "api"},
                 fetched_at_utc="2026-03-10T16:00:00Z",
             )
 

--- a/tests/agent/pipeline/test_daily_brief_types.py
+++ b/tests/agent/pipeline/test_daily_brief_types.py
@@ -56,9 +56,13 @@ class DailyBriefTypeContractsTests(unittest.TestCase):
                 "counter",
                 "minority",
                 "watch",
+                "coverage_summary",
             },
         )
-        self.assertEqual(set(DailyBriefSynthesisV2.__annotations__), {"issues", "meta", "changed"})
+        self.assertEqual(
+            set(DailyBriefSynthesisV2.__annotations__),
+            {"brief", "issues", "claim_deltas", "meta", "changed"},
+        )
 
     def test_literal_vocabularies_match_redesign(self) -> None:
         self.assertEqual(

--- a/tests/agent/pipeline/test_stage10_decision_record.py
+++ b/tests/agent/pipeline/test_stage10_decision_record.py
@@ -26,8 +26,22 @@ class Stage10DecisionRecordTests(unittest.TestCase):
                             "issue_question": "Will oil prices keep rising?",
                             "title": "Will oil prices keep rising?",
                             "summary": "Supply and demand evidence point in different directions.",
-                            "prevailing": [{"text": "Supply risks support near-term upside.", "citation_ids": ["c1"]}],
-                            "counter": [{"text": "Demand softness could steady prices soon.", "citation_ids": ["c2"]}],
+                            "prevailing": [
+                                {
+                                    "text": "Supply risks support near-term upside.",
+                                    "citation_ids": ["c1"],
+                                    "why_it_matters": "Energy inflation can stay sticky.",
+                                    "novelty_vs_prior_brief": "strengthened",
+                                }
+                            ],
+                            "counter": [
+                                {
+                                    "text": "Demand softness could steady prices soon.",
+                                    "citation_ids": ["c2"],
+                                    "why_it_matters": "The rally can stall quickly.",
+                                    "novelty_vs_prior_brief": "continued",
+                                }
+                            ],
                             "minority": [],
                             "watch": [],
                         }
@@ -50,6 +64,10 @@ class Stage10DecisionRecordTests(unittest.TestCase):
                     "budget_check": "pass",
                     "notes": [],
                 },
+                citation_status="ok",
+                analytical_status="warn",
+                publish_decision="publish",
+                reason_codes=["source_by_source_paraphrase"],
                 output_path=output_path,
                 generated_at_utc="2026-02-19T08:00:00Z",
             )
@@ -59,6 +77,12 @@ class Stage10DecisionRecordTests(unittest.TestCase):
             self.assertEqual(claims[0]["issue_id"], "issue_001")
             self.assertEqual(claims[0]["issue_title"], "Will oil prices keep rising?")
             self.assertEqual(claims[0]["citation_ids"], ["c1"])
+            self.assertEqual(claims[0]["why_it_matters"], "Energy inflation can stay sticky.")
+            self.assertEqual(claims[0]["novelty_vs_prior_brief"], "strengthened")
+            self.assertEqual(result["decision_record"]["citation_status"], "ok")
+            self.assertEqual(result["decision_record"]["analytical_status"], "warn")
+            self.assertEqual(result["decision_record"]["publish_decision"], "publish")
+            self.assertEqual(result["decision_record"]["reason_codes"], ["source_by_source_paraphrase"])
             self.assertEqual(validate_decision_record(result["decision_record"]), [])
     def test_persists_decision_record_to_date_partitioned_path(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/agent/retrieval/test_evidence_pack.py
+++ b/tests/agent/retrieval/test_evidence_pack.py
@@ -229,7 +229,7 @@ class EvidencePackTests(unittest.TestCase):
                     "publisher": "Federal Reserve",
                     "credibility_tier": 1,
                     "retrieval_score": pack[0]["retrieval_score"],
-                    "semantic_score": None,
+                    "semantic_score": pack[0]["semantic_score"],
                     "recency_score": 1.0,
                     "credibility_score": 1.0,
                     "rank_in_pack": 1,
@@ -237,6 +237,7 @@ class EvidencePackTests(unittest.TestCase):
             ],
         )
         self.assertGreater(pack[0]["retrieval_score"], 0.0)
+        self.assertGreater(pack[0]["semantic_score"], 0.0)
 
     def test_missing_required_row_field_raises_value_error(self):
         fts_rows = [

--- a/tests/agent/retrieval/test_fts_index.py
+++ b/tests/agent/retrieval/test_fts_index.py
@@ -1,6 +1,9 @@
+import tempfile
 import unittest
+from pathlib import Path
 
-from apps.agent.retrieval.fts_index import build_fts_rows, search_fts_rows
+from apps.agent.retrieval.fts_index import build_fts_rows, search_fts_rows, search_runtime_fts_rows
+from apps.agent.storage.sqlite_runtime import persist_runtime_corpus
 
 
 class FtsIndexTests(unittest.TestCase):
@@ -87,6 +90,83 @@ class FtsIndexTests(unittest.TestCase):
                 },
             ],
         )
+
+    def test_runtime_fts_search_uses_persisted_sqlite_index(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            persist_runtime_corpus(
+                base_dir=base_dir,
+                source_rows=[
+                    {
+                        "source_id": "src_a",
+                        "name": "Federal Reserve",
+                        "base_url": "https://example.test/fed",
+                        "source_type": "rss",
+                        "credibility_tier": 1,
+                        "paywall_policy": "full",
+                        "fetch_interval": "daily",
+                        "tags_json": "[]",
+                        "enabled": 1,
+                        "created_at": "2026-03-10T10:00:00Z",
+                        "updated_at": "2026-03-10T10:00:00Z",
+                    }
+                ],
+                documents=[
+                    {
+                        "doc_id": "doc_001",
+                        "source_id": "src_a",
+                        "publisher": "Federal Reserve",
+                        "canonical_url": "https://example.test/fed/doc",
+                        "title": "Fed note",
+                        "author": None,
+                        "language": "en",
+                        "doc_type": "statement",
+                        "published_at": "2026-03-10T10:00:00Z",
+                        "fetched_at": "2026-03-10T10:05:00Z",
+                        "paywall_policy": "full",
+                        "metadata_only": 0,
+                        "rss_snippet": "Inflation remains restrictive.",
+                        "body_text": "Inflation remains restrictive.",
+                        "content_hash": "hash_001",
+                        "ingestion_run_id": "run_001",
+                        "status": "active",
+                        "created_at": "2026-03-10T10:05:00Z",
+                        "updated_at": "2026-03-10T10:05:00Z",
+                    }
+                ],
+                chunks=[
+                    {
+                        "chunk_id": "chunk_001",
+                        "doc_id": "doc_001",
+                        "chunk_index": 0,
+                        "text": "Inflation remains restrictive.",
+                        "token_count": 3,
+                        "char_start": 0,
+                        "char_end": 29,
+                        "created_at": "2026-03-10T10:05:00Z",
+                    }
+                ],
+                fts_rows=[
+                    {
+                        "chunk_id": "chunk_001",
+                        "doc_id": "doc_001",
+                        "publisher": "Federal Reserve",
+                        "source_id": "src_a",
+                        "published_at": "2026-03-10T10:00:00Z",
+                        "text": "Inflation remains restrictive.",
+                    }
+                ],
+            )
+
+            results = search_runtime_fts_rows(
+                base_dir=base_dir,
+                query_text="inflation",
+                limit=5,
+            )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["chunk_id"], "chunk_001")
+        self.assertEqual(results[0]["doc_id"], "doc_001")
 
     def test_invalid_chunk_row_raises_value_error(self):
         document = {


### PR DESCRIPTION
## Scope
This PR extracts the daily-brief redesign out of the oversized #141 into a reviewable base branch.

Implements:
- #127 model-assisted live path defaults and provider resolution metadata
- #128 brief-level editorial planner
- #129 corpus-first, issue-aware retrieval
- #130 issue deduplication and information-gain gating
- #131 end-to-end `why_it_matters` and `novelty_vs_prior_brief`
- #132 critic publish gate and split status labels
- #133 brief UX around bottom line / takeaways / issues / what changed
- #134 claim-level delta computation
- #135 PRD source-scarcity and issue-budget rules
- #137 live HTML/PDF fetching
- #138 runtime persistence for issue maps and structured claims

## Validation
- `python -m ruff check apps tests scripts`
- `python -m mypy apps`
- `python scripts/validate_artifacts.py`
- `python scripts/validate_decision_record_schema.py`
- `python -m compileall -q apps tests scripts`
- `python -m unittest discover -s tests -t . -p test_*.py -q`
- `python evals/run_eval_suite.py`