### PR TITLE
feat(ingest): add live html and pdf fetching

### DIFF
--- a/apps/agent/ingest/live_fetch.py
+++ b/apps/agent/ingest/live_fetch.py
@@ -119,6 +119,8 @@ def _pdf_payload_from_bytes(
     pdf_bytes: bytes,
     fetched_at_utc: str,
 ) -> dict[str, Any]:
+    if not pdf_bytes.startswith(b"%PDF-"):
+        raise ValueError("Expected PDF content for pdf source")
     url = str(source["url"])
     return {
         "url": url,
@@ -178,6 +180,7 @@ class _HtmlPayloadParser(HTMLParser):
         self._current_tag: str | None = None
         self._title_buffer = StringIO()
         self._body_depth = 0
+        self._ignored_body_tag_depth = 0
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         attributes = {name.lower(): value for name, value in attrs}
@@ -187,6 +190,8 @@ class _HtmlPayloadParser(HTMLParser):
             self._current_tag = "title"
         elif tag == "body":
             self._body_depth += 1
+        elif tag in {"script", "style", "noscript", "template"} and self._body_depth > 0:
+            self._ignored_body_tag_depth += 1
         elif tag == "meta":
             self._capture_meta(attributes)
         elif tag == "link" and str(attributes.get("rel") or "").lower() == "canonical":
@@ -198,13 +203,15 @@ class _HtmlPayloadParser(HTMLParser):
             if title:
                 self.title = title
             self._current_tag = None
+        elif tag in {"script", "style", "noscript", "template"} and self._ignored_body_tag_depth > 0:
+            self._ignored_body_tag_depth -= 1
         elif tag == "body" and self._body_depth > 0:
             self._body_depth -= 1
 
     def handle_data(self, data: str) -> None:
         if self._current_tag == "title":
             self._title_buffer.write(data)
-        if self._body_depth > 0:
+        if self._body_depth > 0 and self._ignored_body_tag_depth == 0:
             normalized = " ".join(data.split())
             if normalized:
                 if self.body_text is None:

--- a/tests/agent/ingest/test_live_fetch.py
+++ b/tests/agent/ingest/test_live_fetch.py
@@ -42,6 +42,24 @@ HTML_PAGE = """<!doctype html>
 </html>
 """
 
+HTML_PAGE_WITH_NOISE = """<!doctype html>
+<html lang="en">
+  <head>
+    <title>ECB speech</title>
+    <style>.banner { display: none; }</style>
+    <script>window.__BOOTSTRAP__ = { noisy: true };</script>
+  </head>
+  <body>
+    <nav>Cookie banner links</nav>
+    <main>
+      <h1>ECB speech</h1>
+      <p>Officials emphasized patience.</p>
+    </main>
+    <script>console.log("tracking")</script>
+  </body>
+</html>
+"""
+
 
 def _build_pdf_bytes(text: str) -> bytes:
     escaped_text = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
@@ -167,6 +185,45 @@ class LiveFetchTests(unittest.TestCase):
         self.assertEqual(payloads[0]["fetched_at"], "2026-03-10T16:00:00Z")
         self.assertEqual(payloads[0]["doc_type"], "pdf")
         self.assertIsInstance(payloads[0]["pdf_bytes"], bytes)
+
+    def test_fetch_live_payloads_for_source_ignores_script_and_style_body_noise(self):
+        source = {
+            "id": "ecb_speech",
+            "url": "https://example.test/ecb/speech",
+            "type": "html",
+        }
+
+        with patch(
+            "apps.agent.ingest.live_fetch.urlopen",
+            return_value=_FakeResponse(HTML_PAGE_WITH_NOISE.encode("utf-8")),
+        ):
+            payloads = fetch_live_payloads_for_source(
+                source=source,
+                fetched_at_utc="2026-03-10T16:00:00Z",
+            )
+
+        self.assertEqual(len(payloads), 1)
+        self.assertIn("Officials emphasized patience.", payloads[0]["text"])
+        self.assertNotIn("window.__BOOTSTRAP__", payloads[0]["text"])
+        self.assertNotIn("display: none", payloads[0]["text"])
+        self.assertNotIn("console.log", payloads[0]["text"])
+
+    def test_fetch_live_payloads_for_source_rejects_non_pdf_bytes_for_pdf_source(self):
+        source = {
+            "id": "fed_minutes_pdf",
+            "url": "https://example.test/fed/minutes.pdf",
+            "type": "pdf",
+        }
+
+        with patch(
+            "apps.agent.ingest.live_fetch.urlopen",
+            return_value=_FakeResponse(b"<html>not actually a pdf</html>"),
+        ):
+            with self.assertRaisesRegex(ValueError, "Expected PDF content"):
+                fetch_live_payloads_for_source(
+                    source=source,
+                    fetched_at_utc="2026-03-10T16:00:00Z",
+                )
 
     def test_fetch_live_payloads_rejects_unknown_source_type(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Scope
Implements #137 as a single-issue PR.

Adds live runtime fetching for non-RSS sources:
- HTML page fetching and metadata/body extraction
- PDF byte fetching for downstream extraction
- regression coverage for HTML/PDF live fetch paths

## Validation
- `python -m ruff check apps tests scripts`
- `python -m unittest discover -s tests -t . -p test_*.py -q`