### PR TITLE
feat(runtime): default live daily brief provider to auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Run the active-subset daily brief against live feeds:
 python scripts/run_daily_brief.py
 ```
 
+The live runner now defaults to `--provider auto`, which resolves providers in this order:
+- `codex-oauth`
+- `openai`
+
+If neither provider is available, the live command fails closed instead of silently falling back to the deterministic path.
+
 Run the deterministic fixture-backed daily brief slice:
 
 ```bash

--- a/apps/agent/daily_brief/provider_registry.py
+++ b/apps/agent/daily_brief/provider_registry.py
@@ -1,30 +1,114 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, TypeAlias, TypedDict
 
 from apps.agent.daily_brief.model_interfaces import ClaimComposerProvider, IssuePlannerProvider
 
 DailyBriefProviderName: TypeAlias = Literal["deterministic", "openai", "codex-oauth"]
+RequestedDailyBriefProviderName: TypeAlias = Literal["auto", "deterministic", "openai", "codex-oauth"]
+DailyBriefProviderMode: TypeAlias = Literal["deterministic", "model-assisted"]
+
+
+class DailyBriefProviderResolution(TypedDict):
+    requested_provider: RequestedDailyBriefProviderName | str
+    resolved_provider: DailyBriefProviderName
+    provider_mode: DailyBriefProviderMode
+    provider_fallback_used: bool
+    issue_planner: IssuePlannerProvider | None
+    claim_composer: ClaimComposerProvider | None
 
 
 def build_daily_brief_providers(
     *,
-    provider: DailyBriefProviderName | str,
+    provider: RequestedDailyBriefProviderName | str,
     openai_model: str | None = None,
     codex_runner: Callable[..., Any] | None = None,
     login_checker: Callable[[], bool] | None = None,
 ) -> tuple[IssuePlannerProvider | None, ClaimComposerProvider | None]:
-    if provider == "deterministic":
-        return (None, None)
-    if provider == "openai":
-        return _build_openai_providers(openai_model=openai_model)
-    if provider == "codex-oauth":
-        return _build_codex_oauth_providers(
+    resolution = resolve_daily_brief_provider(
+        provider=provider,
+        openai_model=openai_model,
+        codex_runner=codex_runner,
+        login_checker=login_checker,
+    )
+    return (resolution["issue_planner"], resolution["claim_composer"])
+
+
+def resolve_daily_brief_provider(
+    *,
+    provider: RequestedDailyBriefProviderName | str,
+    openai_model: str | None = None,
+    codex_runner: Callable[..., Any] | None = None,
+    login_checker: Callable[[], bool] | None = None,
+) -> DailyBriefProviderResolution:
+    if provider == "auto":
+        return _resolve_auto_provider(
+            openai_model=openai_model,
             codex_runner=codex_runner,
             login_checker=login_checker,
         )
+    if provider == "deterministic":
+        return {
+            "requested_provider": str(provider),
+            "resolved_provider": "deterministic",
+            "provider_mode": "deterministic",
+            "provider_fallback_used": False,
+            "issue_planner": None,
+            "claim_composer": None,
+        }
+    if provider == "openai":
+        issue_planner, claim_composer = _build_openai_providers(openai_model=openai_model)
+        return {
+            "requested_provider": str(provider),
+            "resolved_provider": "openai",
+            "provider_mode": "model-assisted",
+            "provider_fallback_used": False,
+            "issue_planner": issue_planner,
+            "claim_composer": claim_composer,
+        }
+    if provider == "codex-oauth":
+        issue_planner, claim_composer = _build_codex_oauth_providers(
+            codex_runner=codex_runner,
+            login_checker=login_checker,
+        )
+        return {
+            "requested_provider": str(provider),
+            "resolved_provider": "codex-oauth",
+            "provider_mode": "model-assisted",
+            "provider_fallback_used": False,
+            "issue_planner": issue_planner,
+            "claim_composer": claim_composer,
+        }
     raise ValueError(f"Unsupported provider: {provider}")
+
+
+def _resolve_auto_provider(
+    *,
+    openai_model: str | None,
+    codex_runner: Callable[..., Any] | None,
+    login_checker: Callable[[], bool] | None,
+) -> DailyBriefProviderResolution:
+    provider_errors: list[str] = []
+    for index, candidate in enumerate(("codex-oauth", "openai")):
+        try:
+            resolution = resolve_daily_brief_provider(
+                provider=candidate,
+                openai_model=openai_model,
+                codex_runner=codex_runner,
+                login_checker=login_checker,
+            )
+        except ValueError as exc:
+            provider_errors.append(f"{candidate}: {exc}")
+            continue
+        return {
+            **resolution,
+            "requested_provider": "auto",
+            "provider_fallback_used": index > 0,
+        }
+
+    joined_errors = "; ".join(provider_errors) if provider_errors else "no provider checks ran"
+    raise ValueError(f"Auto provider resolution failed. Tried {joined_errors}.")
 
 
 def _build_openai_providers(

--- a/apps/agent/daily_brief/runner.py
+++ b/apps/agent/daily_brief/runner.py
@@ -158,6 +158,7 @@ def run_fixture_daily_brief(
     issue_planner: IssuePlannerProvider | None = None,
     claim_composer: ClaimComposerProvider | None = None,
     critic: CriticProvider | None = None,
+    provider_resolution: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     lifecycle: list[dict[str, Any]] = []
     execution: dict[str, Any] = {}
@@ -177,6 +178,7 @@ def run_fixture_daily_brief(
                 issue_planner=issue_planner,
                 claim_composer=claim_composer,
                 critic=critic,
+                provider_resolution=provider_resolution,
             )
         except Exception as exc:
             execution["status"] = "failed"
@@ -205,6 +207,7 @@ def run_fixture_daily_brief(
                 run_id=run_id,
                 generated_at_utc=timestamp,
                 pipeline_result=pipeline_result,
+                provider_resolution=provider_resolution,
             )
         )
     execution.setdefault("status", pipeline_result["status"])
@@ -234,6 +237,7 @@ def run_daily_brief(
     issue_planner: IssuePlannerProvider | None = None,
     claim_composer: ClaimComposerProvider | None = None,
     critic: CriticProvider | None = None,
+    provider_resolution: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     lifecycle: list[dict[str, Any]] = []
     execution: dict[str, Any] = {}
@@ -254,6 +258,7 @@ def run_daily_brief(
                 issue_planner=issue_planner,
                 claim_composer=claim_composer,
                 critic=critic,
+                provider_resolution=provider_resolution,
             )
         except Exception as exc:
             execution["status"] = "failed"
@@ -282,6 +287,7 @@ def run_daily_brief(
                 run_id=run_id,
                 generated_at_utc=timestamp,
                 pipeline_result=pipeline_result,
+                provider_resolution=provider_resolution,
             )
         )
     execution.setdefault("status", pipeline_result["status"])
@@ -313,6 +319,7 @@ def _execute_daily_brief_slice(
     issue_planner: IssuePlannerProvider | None = None,
     claim_composer: ClaimComposerProvider | None = None,
     critic: CriticProvider | None = None,
+    provider_resolution: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     report_date = generated_at_utc[:10]
     schedule = delivery_schedule or DailyBriefSchedule()
@@ -465,6 +472,7 @@ def _execute_daily_brief_slice(
             "publish_decision": publish_summary["publish_decision"],
             "reason_codes": publish_summary["reason_codes"],
             "delivery_mode": publish_summary["delivery_mode"],
+            **_provider_summary(provider_resolution=provider_resolution),
         },
     )
 
@@ -483,6 +491,7 @@ def _execute_daily_brief_slice(
         "publish_decision": publish_summary["publish_decision"],
         "reason_codes": publish_summary["reason_codes"],
         "delivery_mode": publish_summary["delivery_mode"],
+        **_provider_summary(provider_resolution=provider_resolution),
     }
 
 
@@ -1435,6 +1444,7 @@ def _persist_budget_stop_outputs(
     run_id: str,
     generated_at_utc: str,
     pipeline_result: Mapping[str, Any],
+    provider_resolution: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     report_date = generated_at_utc[:10]
     artifact_dir = _artifact_dir(base_dir=base_dir, report_date=report_date, run_id=run_id)
@@ -1472,6 +1482,7 @@ def _persist_budget_stop_outputs(
             "budget_ledger_rows": list(pipeline_result.get("budget_ledger_rows", [])),
             "guardrail_checks": guardrail_checks,
             "diversity_stats": {},
+            **_provider_summary(provider_resolution=provider_resolution),
         },
     )
     return {
@@ -1481,6 +1492,7 @@ def _persist_budget_stop_outputs(
         "artifact_dir": str(artifact_dir),
         "query_text": None,
         "abstain_reason": pipeline_result.get("error_summary"),
+        **_provider_summary(provider_resolution=provider_resolution),
     }
 
 
@@ -1575,6 +1587,22 @@ def _persist_run_state(
         run_row=run_row,
         budget_ledger_rows=pipeline_result.get("budget_ledger_rows", []),
     )
+
+
+def _provider_summary(*, provider_resolution: Mapping[str, Any] | None) -> dict[str, Any]:
+    if isinstance(provider_resolution, Mapping):
+        return {
+            "requested_provider": provider_resolution.get("requested_provider"),
+            "resolved_provider": provider_resolution.get("resolved_provider"),
+            "provider_mode": provider_resolution.get("provider_mode"),
+            "provider_fallback_used": bool(provider_resolution.get("provider_fallback_used", False)),
+        }
+    return {
+        "requested_provider": None,
+        "resolved_provider": None,
+        "provider_mode": None,
+        "provider_fallback_used": False,
+    }
 
 
 def _utc_now_iso() -> str:

--- a/scripts/run_daily_brief.py
+++ b/scripts/run_daily_brief.py
@@ -30,8 +30,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--provider",
-        choices=("deterministic", "openai", "codex-oauth"),
-        default="deterministic",
+        choices=("auto", "deterministic", "openai", "codex-oauth"),
+        default="auto",
         help="Daily-brief synthesis provider mode.",
     )
     parser.add_argument(
@@ -43,14 +43,15 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
-    from apps.agent.daily_brief.provider_registry import build_daily_brief_providers
+    from apps.agent.daily_brief.critic import LocalDailyBriefCritic
+    from apps.agent.daily_brief.provider_registry import resolve_daily_brief_provider
     from apps.agent.daily_brief.runner import run_daily_brief
     from apps.agent.delivery.email_sender import EmailDeliveryConfig
     from apps.agent.delivery.scheduler import DailyBriefSchedule
 
     args = parse_args()
     try:
-        issue_planner, claim_composer = build_daily_brief_providers(
+        provider_resolution = resolve_daily_brief_provider(
             provider=args.provider,
             openai_model=args.openai_model,
         )
@@ -76,8 +77,10 @@ def main() -> None:
             delivery_minute=args.delivery_minute,
         ),
         email_config=email_config,
-        issue_planner=issue_planner,
-        claim_composer=claim_composer,
+        issue_planner=provider_resolution["issue_planner"],
+        claim_composer=provider_resolution["claim_composer"],
+        critic=LocalDailyBriefCritic(),
+        provider_resolution=provider_resolution,
     )
     print(json.dumps(result, indent=2))
     if result["status"] == "failed":

--- a/scripts/run_daily_brief_fixture.py
+++ b/scripts/run_daily_brief_fixture.py
@@ -44,14 +44,14 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
-    from apps.agent.daily_brief.provider_registry import build_daily_brief_providers
+    from apps.agent.daily_brief.provider_registry import resolve_daily_brief_provider
     from apps.agent.daily_brief.runner import run_fixture_daily_brief
     from apps.agent.delivery.email_sender import EmailDeliveryConfig
     from apps.agent.delivery.scheduler import DailyBriefSchedule
 
     args = parse_args()
     try:
-        issue_planner, claim_composer = build_daily_brief_providers(
+        provider_resolution = resolve_daily_brief_provider(
             provider=args.provider,
             openai_model=args.openai_model,
         )
@@ -78,8 +78,9 @@ def main() -> None:
             delivery_minute=args.delivery_minute,
         ),
         email_config=email_config,
-        issue_planner=issue_planner,
-        claim_composer=claim_composer,
+        issue_planner=provider_resolution["issue_planner"],
+        claim_composer=provider_resolution["claim_composer"],
+        provider_resolution=provider_resolution,
     )
     print(json.dumps(result, indent=2))
     if result["status"] == "failed":

--- a/tests/agent/daily_brief/test_provider_registry.py
+++ b/tests/agent/daily_brief/test_provider_registry.py
@@ -6,6 +6,18 @@ from unittest.mock import patch
 
 
 class ProviderRegistryTests(unittest.TestCase):
+    def test_resolve_daily_brief_provider_returns_deterministic_mode(self):
+        from apps.agent.daily_brief.provider_registry import resolve_daily_brief_provider
+
+        resolution = resolve_daily_brief_provider(provider="deterministic")
+
+        self.assertEqual(resolution["requested_provider"], "deterministic")
+        self.assertEqual(resolution["resolved_provider"], "deterministic")
+        self.assertEqual(resolution["provider_mode"], "deterministic")
+        self.assertFalse(resolution["provider_fallback_used"])
+        self.assertIsNone(resolution["issue_planner"])
+        self.assertIsNone(resolution["claim_composer"])
+
     def test_build_daily_brief_providers_returns_none_for_deterministic(self):
         from apps.agent.daily_brief.provider_registry import build_daily_brief_providers
 
@@ -55,6 +67,84 @@ class ProviderRegistryTests(unittest.TestCase):
         self.assertIs(issue_planner, planner)
         self.assertIs(claim_composer, composer)
 
+    def test_resolve_daily_brief_provider_prefers_codex_oauth_for_auto(self):
+        from apps.agent.daily_brief import provider_registry
+
+        planner = object()
+        composer = object()
+
+        with (
+            patch.object(
+                provider_registry,
+                "_build_codex_oauth_providers",
+                return_value=(planner, composer),
+            ) as codex_mock,
+            patch.object(provider_registry, "_build_openai_providers") as openai_mock,
+        ):
+            resolution = provider_registry.resolve_daily_brief_provider(provider="auto")
+
+        codex_mock.assert_called_once_with(codex_runner=None, login_checker=None)
+        openai_mock.assert_not_called()
+        self.assertEqual(resolution["requested_provider"], "auto")
+        self.assertEqual(resolution["resolved_provider"], "codex-oauth")
+        self.assertEqual(resolution["provider_mode"], "model-assisted")
+        self.assertFalse(resolution["provider_fallback_used"])
+        self.assertIs(resolution["issue_planner"], planner)
+        self.assertIs(resolution["claim_composer"], composer)
+
+    def test_resolve_daily_brief_provider_falls_back_to_openai_for_auto(self):
+        from apps.agent.daily_brief import provider_registry
+
+        planner = object()
+        composer = object()
+
+        with (
+            patch.object(
+                provider_registry,
+                "_build_codex_oauth_providers",
+                side_effect=ValueError("codex unavailable"),
+            ) as codex_mock,
+            patch.object(
+                provider_registry,
+                "_build_openai_providers",
+                return_value=(planner, composer),
+            ) as openai_mock,
+        ):
+            resolution = provider_registry.resolve_daily_brief_provider(
+                provider="auto",
+                openai_model="gpt-fallback",
+            )
+
+        codex_mock.assert_called_once_with(codex_runner=None, login_checker=None)
+        openai_mock.assert_called_once_with(openai_model="gpt-fallback")
+        self.assertEqual(resolution["requested_provider"], "auto")
+        self.assertEqual(resolution["resolved_provider"], "openai")
+        self.assertEqual(resolution["provider_mode"], "model-assisted")
+        self.assertTrue(resolution["provider_fallback_used"])
+        self.assertIs(resolution["issue_planner"], planner)
+        self.assertIs(resolution["claim_composer"], composer)
+
+    def test_resolve_daily_brief_provider_fails_closed_for_auto(self):
+        from apps.agent.daily_brief import provider_registry
+
+        with (
+            patch.object(
+                provider_registry,
+                "_build_codex_oauth_providers",
+                side_effect=ValueError("codex unavailable"),
+            ) as codex_mock,
+            patch.object(
+                provider_registry,
+                "_build_openai_providers",
+                side_effect=ValueError("openai unavailable"),
+            ) as openai_mock,
+        ):
+            with self.assertRaisesRegex(ValueError, "Auto provider resolution failed"):
+                provider_registry.resolve_daily_brief_provider(provider="auto")
+
+        codex_mock.assert_called_once_with(codex_runner=None, login_checker=None)
+        openai_mock.assert_called_once_with(openai_model=None)
+
     def test_build_daily_brief_providers_rejects_unknown_provider(self):
         from apps.agent.daily_brief.provider_registry import build_daily_brief_providers
 
@@ -76,11 +166,19 @@ class RunnerScriptProviderWiringTests(unittest.TestCase):
 
         planner = object()
         composer = object()
+        provider_resolution = {
+            "requested_provider": "openai",
+            "resolved_provider": "openai",
+            "provider_mode": "model-assisted",
+            "provider_fallback_used": False,
+            "issue_planner": planner,
+            "claim_composer": composer,
+        }
 
         with (
             patch(
-                "apps.agent.daily_brief.provider_registry.build_daily_brief_providers",
-                return_value=(planner, composer),
+                "apps.agent.daily_brief.provider_registry.resolve_daily_brief_provider",
+                return_value=provider_resolution,
             ) as registry_mock,
             patch(
                 "apps.agent.daily_brief.runner.run_fixture_daily_brief",
@@ -103,6 +201,7 @@ class RunnerScriptProviderWiringTests(unittest.TestCase):
         registry_mock.assert_called_once_with(provider="openai", openai_model="gpt-test")
         self.assertIs(runner_mock.call_args.kwargs["issue_planner"], planner)
         self.assertIs(runner_mock.call_args.kwargs["claim_composer"], composer)
+        self.assertEqual(runner_mock.call_args.kwargs["provider_resolution"], provider_resolution)
 
     def test_live_script_accepts_codex_oauth_provider(self):
         from scripts import run_daily_brief
@@ -112,16 +211,32 @@ class RunnerScriptProviderWiringTests(unittest.TestCase):
 
         self.assertEqual(args.provider, "codex-oauth")
 
+    def test_live_script_defaults_provider_to_auto(self):
+        from scripts import run_daily_brief
+
+        with patch.object(sys, "argv", ["run_daily_brief.py"]):
+            args = run_daily_brief.parse_args()
+
+        self.assertEqual(args.provider, "auto")
+
     def test_live_script_resolves_providers_through_registry(self):
         from scripts import run_daily_brief
 
         planner = object()
         composer = object()
+        provider_resolution = {
+            "requested_provider": "auto",
+            "resolved_provider": "openai",
+            "provider_mode": "model-assisted",
+            "provider_fallback_used": True,
+            "issue_planner": planner,
+            "claim_composer": composer,
+        }
 
         with (
             patch(
-                "apps.agent.daily_brief.provider_registry.build_daily_brief_providers",
-                return_value=(planner, composer),
+                "apps.agent.daily_brief.provider_registry.resolve_daily_brief_provider",
+                return_value=provider_resolution,
             ) as registry_mock,
             patch(
                 "apps.agent.daily_brief.runner.run_daily_brief",
@@ -144,6 +259,7 @@ class RunnerScriptProviderWiringTests(unittest.TestCase):
         registry_mock.assert_called_once_with(provider="openai", openai_model="gpt-live")
         self.assertIs(runner_mock.call_args.kwargs["issue_planner"], planner)
         self.assertIs(runner_mock.call_args.kwargs["claim_composer"], composer)
+        self.assertEqual(runner_mock.call_args.kwargs["provider_resolution"], provider_resolution)
 
 
 if __name__ == "__main__":

--- a/tests/agent/daily_brief/test_runner.py
+++ b/tests/agent/daily_brief/test_runner.py
@@ -599,11 +599,18 @@ class DailyBriefRunnerTests(unittest.TestCase):
         self.assertNotIn("slower", query)
 
     def test_run_fixture_daily_brief_writes_expected_artifacts(self):
+        provider_resolution = {
+            "requested_provider": "deterministic",
+            "resolved_provider": "deterministic",
+            "provider_mode": "deterministic",
+            "provider_fallback_used": False,
+        }
         with tempfile.TemporaryDirectory() as tmpdir:
             result = run_fixture_daily_brief(
                 base_dir=Path(tmpdir),
                 run_id="run_fixture_ok",
                 generated_at_utc="2026-03-10T16:00:00Z",
+                provider_resolution=provider_resolution,
             )
 
             html_path = Path(result["html_path"])
@@ -643,6 +650,14 @@ class DailyBriefRunnerTests(unittest.TestCase):
             self.assertEqual(run_summary["guardrail_checks"]["budget_check"], "pass")
             self.assertIn(run_summary["guardrail_checks"]["diversity_check"], {"pass", "fail"})
             self.assertIn(run_summary["render_mode"], {"full", "compressed"})
+            self.assertEqual(run_summary["requested_provider"], "deterministic")
+            self.assertEqual(run_summary["resolved_provider"], "deterministic")
+            self.assertEqual(run_summary["provider_mode"], "deterministic")
+            self.assertFalse(run_summary["provider_fallback_used"])
+            self.assertEqual(result["requested_provider"], "deterministic")
+            self.assertEqual(result["resolved_provider"], "deterministic")
+            self.assertEqual(result["provider_mode"], "deterministic")
+            self.assertFalse(result["provider_fallback_used"])
 
     def test_run_fixture_daily_brief_persists_modeled_rows_to_sqlite(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1786,6 +1801,12 @@ class DailyBriefRunnerTests(unittest.TestCase):
         planner = _Planner()
         composer = _Composer()
         critic = _Critic()
+        provider_resolution = {
+            "requested_provider": "deterministic",
+            "resolved_provider": "deterministic",
+            "provider_mode": "deterministic",
+            "provider_fallback_used": False,
+        }
         with tempfile.TemporaryDirectory() as temp_dir:
             with patch("apps.agent.daily_brief.runner._execute_daily_brief_slice") as execute_mock:
                 execute_mock.return_value = {
@@ -1806,11 +1827,13 @@ class DailyBriefRunnerTests(unittest.TestCase):
                     issue_planner=planner,
                     claim_composer=composer,
                     critic=critic,
+                    provider_resolution=provider_resolution,
                 )
 
         self.assertIs(execute_mock.call_args.kwargs["issue_planner"], planner)
         self.assertIs(execute_mock.call_args.kwargs["claim_composer"], composer)
         self.assertIs(execute_mock.call_args.kwargs["critic"], critic)
+        self.assertEqual(execute_mock.call_args.kwargs["provider_resolution"], provider_resolution)
 
     def test_run_daily_brief_forwards_opaque_provider_objects_to_execute_slice(self):
         class _Planner(IssuePlannerProvider):
@@ -1828,6 +1851,12 @@ class DailyBriefRunnerTests(unittest.TestCase):
         planner = _Planner()
         composer = _Composer()
         critic = _Critic()
+        provider_resolution = {
+            "requested_provider": "auto",
+            "resolved_provider": "openai",
+            "provider_mode": "model-assisted",
+            "provider_fallback_used": True,
+        }
         with tempfile.TemporaryDirectory() as temp_dir:
             with patch("apps.agent.daily_brief.runner._execute_daily_brief_slice") as execute_mock:
                 execute_mock.return_value = {
@@ -1848,11 +1877,13 @@ class DailyBriefRunnerTests(unittest.TestCase):
                     issue_planner=planner,
                     claim_composer=composer,
                     critic=critic,
+                    provider_resolution=provider_resolution,
                 )
 
         self.assertIs(execute_mock.call_args.kwargs["issue_planner"], planner)
         self.assertIs(execute_mock.call_args.kwargs["claim_composer"], composer)
         self.assertIs(execute_mock.call_args.kwargs["critic"], critic)
+        self.assertEqual(execute_mock.call_args.kwargs["provider_resolution"], provider_resolution)
 
     def test_build_daily_brief_synthesis_calls_critic_after_validation(self):
         class _Critic(CriticProvider):


### PR DESCRIPTION
## Summary
- switch the live daily brief CLI to `--provider auto` and fail closed when no model-backed provider resolves
- add explicit provider resolution metadata to runner outputs and artifact summaries
- keep the fixture runner deterministic by default while covering auto resolution, fallback, and fail-closed behavior in tests

## Validation
- python -m ruff check apps tests scripts
- python -m mypy apps
- python scripts/validate_artifacts.py
- python scripts/validate_decision_record_schema.py
- python -m compileall -q apps tests scripts
- python -m unittest discover -s tests -t . -p "test_*.py" -q
- python evals/run_eval_suite.py

Closes #127
