### PR TITLE
docs(status): close out open-issue execution state

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,10 @@ Current runtime validation narrows the full catalogue to an active source subset
   - `reuters_business`
   - `wsj_markets`
 
-Open-issue execution order for the remaining backlog/program sequencing:
-- daily-brief stabilization leads: `#135 -> #128 -> #129 -> #130 -> #131 -> #138 -> #134 -> #132 -> #133 -> #136`
-- retrieval expansion follows with `#69`
-- non-RSS live fetch then alert delivery follow with `#137 -> #74`
-- the umbrella tracking docs live in `issue_139.md` and `docs/plans/2026-03-13-daily-brief-integrity-issue-mapping.md`
+Historical open-issue execution order for the now-landed daily-brief program:
+- the sequence `#135 -> #128 -> #129 -> #130 -> #131 -> #138 -> #134 -> #132 -> #133 -> #136 -> #69 -> #137 -> #74` landed on `master` through PRs `#143`-`#157`
+- treat `issue_139.md` and `docs/plans/2026-03-13-daily-brief-integrity-issue-mapping.md` as historical reference material for that completed execution stream
+- re-triage new work from current repo status, `docs/status-matrix.md`, `artifacts/modelling/backlog.json`, and fresh GitHub issue state instead of resuming the old list
 
 ## Core Non-Negotiables
 

--- a/artifacts/modelling/TODO.md
+++ b/artifacts/modelling/TODO.md
@@ -10,8 +10,8 @@ Last updated: 2026-03-13
 - [ ] P0: Define provider selection and registry contract for daily brief runner scripts
   - Acceptance: one spec covers `deterministic`, `openai`, and `codex-oauth` selection plus provider-specific config validation.
 
-- [ ] P0: Record the daily-brief integrity execution order across open issues
-  - Acceptance: the repo docs point to `#135 -> #128 -> #129 -> #130 -> #131 -> #138 -> #134 -> #132 -> #133 -> #136 -> #69 -> #137 -> #74` and treat daily-brief stabilization as the lead stream.
+- [x] P0: Record the daily-brief integrity execution order across the then-open issues
+  - Acceptance: the repo docs point to `#135 -> #128 -> #129 -> #130 -> #131 -> #138 -> #134 -> #132 -> #133 -> #136 -> #69 -> #137 -> #74` and now preserve it as historical reference material rather than active backlog sequencing.
 
 - [x] P0: Define `decision_record` artifact schema and storage location
   - Acceptance: markdown spec + JSON example + field-level validation rules.

--- a/docs/plans/2026-03-13-daily-brief-integrity-implementation-plan.md
+++ b/docs/plans/2026-03-13-daily-brief-integrity-implementation-plan.md
@@ -2,6 +2,8 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
+> Historical note (2026-03-14): this plan was executed and landed on `master` through PRs `#143`-`#157`. Keep it as historical execution mapping only. The next batch starts from repo/GitHub status reconciliation rather than continuing this list as active work.
+
 **Goal:** Cover every currently open GitHub issue in one explicit execution order, while keeping the daily-brief correctness stream ahead of lower-priority retrieval expansion and alert delivery work.
 
 **Architecture:** Treat `#128-#138` as the primary serial daily-brief program because they share planner, retrieval, validator, renderer, and artifact contracts. Keep `#69`, `#137`, and `#74` in the same global order but behind the daily-brief stabilization stream, because they either expand substrate capability or depend on the brief path being trustworthy first.

--- a/issue_139.md
+++ b/issue_139.md
@@ -1,5 +1,8 @@
 # [P0][daily-brief-integrity] Close validation/render state gaps, enforce per-issue evidence binding, and harden brief thesis generation
 
+## Status Note (2026-03-14)
+The execution program tracked here has now landed on `master` through PRs `#143`-`#157`. Treat this document as historical mapping for the completed stream. Remaining work starts with post-open-issue hygiene and fresh repo/GitHub triage, not by continuing the original execution order below.
+
 ## Summary
 The current daily-brief pipeline still allows internally inconsistent output. A brief can reach a held or `abstained` state while looking like a normal full brief, placeholder validator text can leak into delivery, `What Changed` can reference claims that did not survive validation, and issue/citation binding is not yet enforced end to end.
 


### PR DESCRIPTION
## Summary
- realign repo-facing status docs after the landed PR #143-#157 stream
- convert the old open-issue execution order into historical reference material
- mark the sequencing TODO as completed historical work

## Validation
- python scripts/validate_artifacts.py
- python scripts/validate_decision_record_schema.py
- python -m compileall -q apps tests scripts
- python -m unittest discover -s tests -t . -p test_*.py -v