### PR TITLE
fix(delivery): close abstain render-state

### DIFF
--- a/apps/agent/delivery/html_report.py
+++ b/apps/agent/delivery/html_report.py
@@ -25,15 +25,29 @@ def render_daily_brief_html(
 ) -> Path:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     abstained = _is_abstained(synthesis)
+    synthesis_meta = _synthesis_meta(synthesis)
     brief = synthesis.get("brief", {}) if isinstance(synthesis.get("brief"), Mapping) else {}
-    citation_status = str((guardrail_checks or {}).get("citation_status") or ("abstained" if abstained else "ok"))
-    analytical_status = str((guardrail_checks or {}).get("analytical_status") or "pass")
-    publish_decision = str((guardrail_checks or {}).get("publish_decision") or ("hold" if abstained else "publish"))
+    citation_status = str(
+        (guardrail_checks or {}).get("citation_status")
+        or synthesis_meta.get("citation_status")
+        or ("abstained" if abstained else "ok")
+    )
+    analytical_status = str(
+        (guardrail_checks or {}).get("analytical_status")
+        or synthesis_meta.get("analytical_status")
+        or "pass"
+    )
+    publish_decision = str(
+        (guardrail_checks or {}).get("publish_decision")
+        or synthesis_meta.get("publish_decision")
+        or ("hold" if abstained else "publish")
+    )
     issues = _normalized_issues(synthesis)
-    overview_html = _render_overview(brief)
-
-    issues_html = "".join(_render_issue(issue) for issue in issues if isinstance(issue, Mapping))
-    changed_html = _render_changed_section(synthesis.get("changed"))
+    content_html = _render_abstain_section(meta=synthesis_meta) if abstained else _render_standard_content(
+        brief=brief,
+        issues=issues,
+        changed_bullets=synthesis.get("changed"),
+    )
     guardrails_html = _render_guardrails(guardrail_checks)
     citations_html = "".join(
         _render_citation(citation_id=citation_id, citation=citation_store[citation_id])
@@ -103,7 +117,7 @@ def render_daily_brief_html(
       color: var(--muted);
       font-size: 0.95rem;
     }}
-    .issues, .changed, .guardrails, .references {{
+    .abstain, .issues, .changed, .guardrails, .references {{
       padding: 20px 32px 8px;
     }}
     .issue {{
@@ -167,12 +181,7 @@ def render_daily_brief_html(
         <span>Publish decision: {escape(_label(publish_decision))}</span>
       </div>
     </header>
-    {overview_html}
-    <section class="issues">
-      <h2>Issues</h2>
-      {issues_html}
-    </section>
-    {changed_html}
+    {content_html}
     {guardrails_html}
     <section class="references">
       <h2>Citations</h2>
@@ -208,6 +217,46 @@ def _render_overview(brief: Mapping[str, Any]) -> str:
         f"<p>{escape(bottom_line)}</p>"
         f"{takeaways_html}"
         f"{watchlist_html}"
+        "</section>"
+    )
+
+
+def _render_standard_content(
+    *,
+    brief: Mapping[str, Any],
+    issues: list[Mapping[str, Any]],
+    changed_bullets: Any,
+) -> str:
+    overview_html = _render_overview(brief)
+    issues_html = "".join(_render_issue(issue) for issue in issues if isinstance(issue, Mapping))
+    changed_html = _render_changed_section(changed_bullets)
+    return (
+        f"{overview_html}"
+        '<section class="issues">'
+        "<h2>Issues</h2>"
+        f"{issues_html}"
+        "</section>"
+        f"{changed_html}"
+    )
+
+
+def _render_abstain_section(*, meta: Mapping[str, Any]) -> str:
+    reason = str(meta.get("reason") or "").strip()
+    reason_codes = ", ".join(
+        str(code)
+        for code in meta.get("reason_codes", [])
+        if isinstance(code, str) and str(code).strip()
+    )
+    reason_html = f"<p><strong>Reason:</strong> {escape(reason)}</p>" if reason else ""
+    reason_codes_html = (
+        f"<p><strong>Reason codes:</strong> {escape(reason_codes)}</p>" if reason_codes else ""
+    )
+    return (
+        '<section class="abstain">'
+        "<h2>Abstained</h2>"
+        "<p>Insufficient evidence to publish a validated daily brief.</p>"
+        f"{reason_html}"
+        f"{reason_codes_html}"
         "</section>"
     )
 
@@ -334,7 +383,18 @@ def _render_callout(title: str, value: str) -> str:
     return f'<p><strong>{escape(title)}:</strong> {escape(value)}</p>'
 
 
+def _synthesis_meta(synthesis: Mapping[str, Any]) -> Mapping[str, Any]:
+    meta = synthesis.get("meta")
+    if isinstance(meta, Mapping):
+        return meta
+    return {}
+
+
 def _is_abstained(synthesis: Mapping[str, Any]) -> bool:
+    status = str(_synthesis_meta(synthesis).get("status") or "").strip().lower()
+    if status:
+        return status == "abstained"
+
     issues = _normalized_issues(synthesis)
     if not issues:
         return True

--- a/tests/agent/delivery/test_html_report.py
+++ b/tests/agent/delivery/test_html_report.py
@@ -202,6 +202,98 @@ class HtmlReportTests(unittest.TestCase):
         self.assertIn("Abstained", html)
         self.assertIn("Insufficient evidence", html)
 
+    def test_render_daily_brief_html_renders_only_abstain_ui_when_meta_status_is_abstained(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "artifacts" / "daily" / "2026-03-10" / "brief.html"
+
+            render_daily_brief_html(
+                output_path=output_path,
+                report_date="2026-03-10",
+                run_id="run_meta_abstain",
+                synthesis={
+                    "issues": [
+                        {
+                            "issue_id": "issue_001",
+                            "issue_question": "Will the Fed cut soon?",
+                            "title": "Will the Fed cut soon?",
+                            "summary": "Normal issue content should not render in an abstain state.",
+                            "prevailing": [
+                                {
+                                    "text": "Markets still expect policy easing later this year.",
+                                    "citation_ids": ["cite_001"],
+                                }
+                            ],
+                            "counter": [],
+                            "minority": [],
+                            "watch": [],
+                        }
+                    ],
+                    "meta": {
+                        "status": "abstained",
+                        "reason": "validation_retry_exhausted",
+                        "citation_status": "abstained",
+                        "analytical_status": "pass",
+                        "publish_decision": "hold",
+                        "reason_codes": ["citation_validation_abstained"],
+                    },
+                },
+                citation_store={
+                    "cite_001": {"title": "Fed release", "url": "https://example.test/fed"},
+                },
+            )
+
+            html = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("Abstained", html)
+        self.assertIn("validation_retry_exhausted", html)
+        self.assertNotIn("Will the Fed cut soon?", html)
+        self.assertNotIn(">Issues<", html)
+
+    def test_render_daily_brief_html_uses_meta_statuses_for_non_abstain_hold_state(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "artifacts" / "daily" / "2026-03-10" / "brief.html"
+
+            render_daily_brief_html(
+                output_path=output_path,
+                report_date="2026-03-10",
+                run_id="run_hold_without_abstain",
+                synthesis={
+                    "issues": [
+                        {
+                            "issue_id": "issue_001",
+                            "issue_question": "Issue preserved despite hold",
+                            "title": "Issue preserved despite hold",
+                            "summary": "A critic hold should not turn this into abstain UI.",
+                            "prevailing": [
+                                {
+                                    "text": "[Insufficient evidence to produce a validated output]",
+                                    "citation_ids": [],
+                                }
+                            ],
+                            "counter": [],
+                            "minority": [],
+                            "watch": [],
+                        }
+                    ],
+                    "meta": {
+                        "status": "validated",
+                        "citation_status": "partial",
+                        "analytical_status": "fail",
+                        "publish_decision": "hold",
+                        "reason_codes": ["empty_why_it_matters"],
+                    },
+                },
+                citation_store={},
+            )
+
+            html = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("Issue preserved despite hold", html)
+        self.assertIn("Partial", html)
+        self.assertIn("Fail", html)
+        self.assertIn("Hold", html)
+        self.assertNotIn("validation_retry_exhausted", html)
+
     def test_render_daily_brief_html_renders_changed_section_only_when_present(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "artifacts" / "daily" / "2026-03-10" / "brief.html"


### PR DESCRIPTION
Issue: https://github.com/WanxiaJaneYang/mvp-agent/issues/161

Closes #161

## Summary
- treat synthesis meta status as authoritative for abstain detection in the HTML renderer
- render a dedicated abstain section instead of normal issue cards when the brief is abstained
- preserve normal issue rendering for non-abstain hold states while keeping header statuses aligned to typed meta fields

## Validation
- python -m unittest tests.agent.synthesis.test_postprocess tests.agent.delivery.test_html_report tests.agent.daily_brief.test_runner -v

## Reviewer Checklist
- [ ] meta.status=abstained takes precedence over bullet heuristics
- [ ] abstained briefs render no normal issue cards
- [ ] hold-state headers remain aligned with rendered body semantics