### PR TITLE
[Ops] Document Repo Ops Dashboard launch and verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
         run: python -m pip install -e ".[dev]"
 
       - name: Run Ruff
-        run: python -m ruff check apps tests scripts
+        run: python -m ruff check apps tests scripts tools
 
       - name: Run mypy
-        run: python -m mypy apps
+        run: python -m mypy apps tools
 
       - name: Validate modelling artifacts
         run: python scripts/validate_artifacts.py
@@ -34,7 +34,7 @@ jobs:
         run: python scripts/validate_decision_record_schema.py
 
       - name: Bytecode compile check
-        run: python -m compileall -q apps tests scripts
+        run: python -m compileall -q apps tests scripts tools
 
       - name: Run golden eval suite
         run: python evals/run_eval_suite.py

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ Lint and type-check commands are required and CI-gated:
 Run lint:
 
 ```bash
-python -m ruff check apps tests scripts
+python -m ruff check apps tests scripts tools
 ```
 
 Run type checks:
 
 ```bash
-python -m mypy apps
+python -m mypy apps tools
 ```
 
 Run tests:
@@ -174,8 +174,23 @@ Run repository validation:
 ```bash
 python scripts/validate_artifacts.py
 python scripts/validate_decision_record_schema.py
-python -m compileall -q apps tests scripts
+python -m compileall -q apps tests scripts tools
 ```
+
+Run the local Repo Ops Dashboard:
+
+```bash
+python -m tools.repo_dashboard.app
+```
+
+The dashboard runs locally at `http://127.0.0.1:8000/` and exposes:
+- architecture/doc anchors for the current pipeline and data model
+- latest health for fixture demo, eval suite, targeted tests, and live daily brief
+- buttons to launch those four commands locally
+- latest publish decision, reason, `reason_codes`, and artifact links
+- a polled log tail for the active or most recent dashboard-triggered run
+
+Dashboard-specific notes and storage paths live in `tools/repo_dashboard/README.md`.
 
 ## Working Conventions
 

--- a/tests/agent/test_project_tooling.py
+++ b/tests/agent/test_project_tooling.py
@@ -4,8 +4,10 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SUPPORTED_TEST_COMMAND = 'python -m unittest discover -s tests -t . -p "test_*.py" -v'
-SUPPORTED_RUFF_COMMAND = "python -m ruff check apps tests scripts"
-SUPPORTED_MYPY_COMMAND = "python -m mypy apps"
+SUPPORTED_RUFF_COMMAND = "python -m ruff check apps tests scripts tools"
+SUPPORTED_MYPY_COMMAND = "python -m mypy apps tools"
+SUPPORTED_COMPILE_COMMAND = "python -m compileall -q apps tests scripts tools"
+SUPPORTED_DASHBOARD_COMMAND = "python -m tools.repo_dashboard.app"
 
 
 class ProjectToolingTests(unittest.TestCase):
@@ -39,12 +41,24 @@ class ProjectToolingTests(unittest.TestCase):
         self.assertNotIn("not CI-gated yet", readme_text)
         self.assertNotIn("currently fail on pre-existing repo-wide issues", readme_text)
 
+    def test_readme_documents_dashboard_launch_command(self):
+        readme_text = (ROOT / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn(SUPPORTED_DASHBOARD_COMMAND, readme_text)
+
+    def test_dashboard_readme_documents_one_command_launch(self):
+        dashboard_readme = (ROOT / "tools" / "repo_dashboard" / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn(SUPPORTED_DASHBOARD_COMMAND, dashboard_readme)
+        self.assertIn("http://127.0.0.1:8000/", dashboard_readme)
+
     def test_ci_uses_supported_commands(self):
         ci_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
 
         self.assertIn(SUPPORTED_TEST_COMMAND, ci_text)
         self.assertIn(SUPPORTED_RUFF_COMMAND, ci_text)
         self.assertIn(SUPPORTED_MYPY_COMMAND, ci_text)
+        self.assertIn(SUPPORTED_COMPILE_COMMAND, ci_text)
 
 
 if __name__ == "__main__":

--- a/tools/repo_dashboard/README.md
+++ b/tools/repo_dashboard/README.md
@@ -1,0 +1,52 @@
+# Repo Ops Dashboard
+
+Local dashboard for repo architecture visibility, command control, and daily-brief runtime inspection.
+
+## Launch
+
+Install the project and dev dependencies from the repo root:
+
+```bash
+python -m pip install -e ".[dev]"
+```
+
+Start the dashboard with one command:
+
+```bash
+python -m tools.repo_dashboard.app
+```
+
+Open `http://127.0.0.1:8000/`.
+
+## What The Dashboard Shows
+
+- architecture, data model, and run-flow document links from `artifacts/modelling/`
+- latest health status for fixture demo, eval suite, targeted tests, and live daily brief
+- latest publish decision, reason, and `reason_codes`
+- recent dashboard-triggered runs and the latest log tail
+- artifact links for the generated HTML brief, decision record, and run summary when present
+
+## Commands Triggered By The UI
+
+- `python scripts/run_daily_brief_fixture.py --base-dir .tmp_repo_dashboard/demo`
+- `python evals/run_eval_suite.py`
+- `python -m unittest tests.agent.daily_brief.test_runner tests.agent.delivery.test_html_report tests.agent.validators.test_citation_validator -v`
+- `python scripts/run_daily_brief.py --base-dir .tmp_repo_dashboard/live`
+
+## Local Storage
+
+- state seed and latest dashboard state: `tools/repo_dashboard/data/dashboard_state.json`
+- per-run metadata and logs: `tools/repo_dashboard/data/runs/`
+- generated fixture artifacts: `.tmp_repo_dashboard/demo/`
+- generated live artifacts: `.tmp_repo_dashboard/live/`
+
+## Verification
+
+```bash
+python -m ruff check apps tests scripts tools
+python -m mypy apps tools
+python scripts/validate_artifacts.py
+python scripts/validate_decision_record_schema.py
+python -m compileall -q apps tests scripts tools
+python -m unittest discover -s tests -t . -p "test_*.py" -v
+```

--- a/tools/repo_dashboard/services/artifact_reader.py
+++ b/tools/repo_dashboard/services/artifact_reader.py
@@ -19,7 +19,11 @@ def discover_dashboard_artifacts(*, repo_root: Path) -> dict[str, Any]:
         if relative_base is None:
             by_kind[run_kind] = _empty_entry(run_kind)
             continue
-        by_kind[run_kind] = _discover_run_kind(repo_root=repo_root, run_kind=run_kind, base_dir=repo_root / relative_base)
+        by_kind[run_kind] = _discover_run_kind(
+            repo_root=repo_root,
+            run_kind=run_kind,
+            base_dir=repo_root / relative_base,
+        )
     latest = _select_latest(by_kind)
     return {"refreshed_at_utc": _utc_now_iso(), "by_kind": by_kind, "latest": latest}
 

--- a/tools/repo_dashboard/services/repo_scan.py
+++ b/tools/repo_dashboard/services/repo_scan.py
@@ -75,7 +75,13 @@ def build_repo_overview(*, repo_root: Path) -> dict[str, Any]:
     }
 
 
-def _card(*, card_id: str, title: str, primary_path: Path, assets: list[dict[str, str]] | None = None) -> dict[str, Any]:
+def _card(
+    *,
+    card_id: str,
+    title: str,
+    primary_path: Path,
+    assets: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
     return {
         "id": card_id,
         "title": title,

--- a/tools/repo_dashboard/services/status_store.py
+++ b/tools/repo_dashboard/services/status_store.py
@@ -140,7 +140,10 @@ class DashboardStatusStore:
         state["recent_runs"] = recent_runs[:20]
         if is_active:
             state["active_run_id"] = normalized["run_id"]
-        elif state["active_run_id"] == normalized["run_id"] and normalized["status"] != DashboardRunStatus.RUNNING.value:
+        elif (
+            state["active_run_id"] == normalized["run_id"]
+            and normalized["status"] != DashboardRunStatus.RUNNING.value
+        ):
             state["active_run_id"] = None
         self.save_state(state)
         return normalized


### PR DESCRIPTION
## Summary
- add the dashboard-specific README and main README launch instructions
- expand CI and documented lint/type/compile commands to cover `tools/`
- add tooling tests for the dashboard launch command and tighten backend line wrapping so the expanded `ruff` command passes

## Testing
- python -m ruff check apps tests scripts tools
- python -m mypy apps tools
- python scripts/validate_artifacts.py
- python scripts/validate_decision_record_schema.py
- python -m compileall -q apps tests scripts tools
- python evals/run_eval_suite.py
- python -m unittest discover -s tests -t . -p "test_*.py" -v

Closes #183
Part of #179
