### PR TITLE
feat: add source control plane foundation for issue 214

### DIFF
--- a/apps/agent/pipeline/types.py
+++ b/apps/agent/pipeline/types.py
@@ -65,6 +65,10 @@ class SourceRegistryEntry(TypedDict):
     url: Required[str]
     base_url: NotRequired[str]
     type: Required[str]
+    fetch_via: NotRequired[str]
+    source_role: NotRequired[str]
+    timestamp_authority: NotRequired[str]
+    content_mode: NotRequired[str]
     credibility_tier: Required[int]
     paywall_policy: Required[str]
     fetch_interval: Required[str]
@@ -136,6 +140,16 @@ class SourceOnboardingRunRow(TypedDict):
     proposed_strategy_id: str | None
     error_message: str | None
     result_summary_json: str | None
+
+
+class ResolvedSource(TypedDict):
+    source_id: str
+    contract: SourceRegistryEntry
+    operator_state: SourceOperatorStateRow
+    current_strategy: SourceStrategyVersionRow | None
+    latest_strategy: SourceStrategyVersionRow | None
+    latest_onboarding_run: SourceOnboardingRunRow | None
+    runtime_eligible: bool
 
 
 class RuntimeDocumentRecord(TypedDict):

--- a/apps/agent/pipeline/types.py
+++ b/apps/agent/pipeline/types.py
@@ -91,6 +91,53 @@ class SourceRow(TypedDict):
     updated_at: str
 
 
+class SourceOperatorStateRow(TypedDict):
+    source_id: str
+    is_active: int
+    strategy_state: str
+    current_strategy_id: str | None
+    latest_strategy_id: str | None
+    last_onboarding_run_id: str | None
+    last_collection_status: str
+    last_collection_started_at: str | None
+    last_collection_finished_at: str | None
+    last_collection_error: str | None
+    activated_at: str | None
+    deactivated_at: str | None
+    updated_at: str
+
+
+class SourceStrategyVersionRow(TypedDict):
+    strategy_id: str
+    source_id: str
+    version: int
+    strategy_status: str
+    entrypoint_url: str
+    fetch_via: str
+    content_mode: str
+    parser_profile: str | None
+    max_items_per_run: int
+    strategy_summary_json: str
+    strategy_details_json: str
+    created_from_run_id: str | None
+    created_at: str
+    approved_at: str | None
+
+
+class SourceOnboardingRunRow(TypedDict):
+    onboarding_run_id: str
+    source_id: str
+    status: str
+    worker_kind: str
+    worker_ref: str | None
+    submitted_at: str
+    started_at: str | None
+    finished_at: str | None
+    proposed_strategy_id: str | None
+    error_message: str | None
+    result_summary_json: str | None
+
+
 class RuntimeDocumentRecord(TypedDict):
     source_id: str
     publisher: str

--- a/apps/agent/runtime/resolved_sources.py
+++ b/apps/agent/runtime/resolved_sources.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from apps.agent.pipeline.types import (
+    ResolvedSource,
+    SourceOnboardingRunRow,
+    SourceOperatorStateRow,
+    SourceRegistryEntry,
+    SourceStrategyVersionRow,
+)
+from apps.agent.runtime.source_scope import load_source_registry
+from apps.agent.storage.source_control_plane import SourceControlPlaneStore
+
+
+def load_resolved_sources(
+    *,
+    base_dir: Path,
+    registry_path: Path | None = None,
+) -> list[ResolvedSource]:
+    registry = load_source_registry(registry_path=registry_path)
+    store = SourceControlPlaneStore(base_dir=base_dir)
+
+    resolved: list[ResolvedSource] = []
+    for source_id, contract in registry.items():
+        operator_state = store.get_operator_state(source_id) or _default_operator_state(source_id)
+        strategies = store.list_strategy_versions(source_id)
+        onboarding_runs = store.list_onboarding_runs(source_id)
+        current_strategy = _pick_current_strategy(operator_state=operator_state, strategies=strategies)
+        latest_strategy = strategies[0] if strategies else None
+        latest_onboarding_run = onboarding_runs[0] if onboarding_runs else None
+        resolved.append(
+            ResolvedSource(
+                source_id=source_id,
+                contract=_with_contract_fallbacks(contract),
+                operator_state=operator_state,
+                current_strategy=current_strategy,
+                latest_strategy=latest_strategy,
+                latest_onboarding_run=latest_onboarding_run,
+                runtime_eligible=_is_runtime_eligible(
+                    operator_state=operator_state,
+                    current_strategy=current_strategy,
+                ),
+            )
+        )
+    return resolved
+
+
+def get_resolved_source(
+    source_id: str,
+    *,
+    base_dir: Path,
+    registry_path: Path | None = None,
+) -> ResolvedSource:
+    for source in load_resolved_sources(base_dir=base_dir, registry_path=registry_path):
+        if source["source_id"] == source_id:
+            return source
+    raise ValueError(f"Unknown source id: {source_id}")
+
+
+def _default_operator_state(source_id: str) -> SourceOperatorStateRow:
+    return SourceOperatorStateRow(
+        source_id=source_id,
+        is_active=0,
+        strategy_state="missing",
+        current_strategy_id=None,
+        latest_strategy_id=None,
+        last_onboarding_run_id=None,
+        last_collection_status="idle",
+        last_collection_started_at=None,
+        last_collection_finished_at=None,
+        last_collection_error=None,
+        activated_at=None,
+        deactivated_at=None,
+        updated_at="",
+    )
+
+
+def _pick_current_strategy(
+    *,
+    operator_state: SourceOperatorStateRow,
+    strategies: list[SourceStrategyVersionRow],
+) -> SourceStrategyVersionRow | None:
+    current_strategy_id = operator_state["current_strategy_id"]
+    if current_strategy_id is None:
+        return None
+    for strategy in strategies:
+        if strategy["strategy_id"] == current_strategy_id:
+            return strategy
+    return None
+
+
+def _is_runtime_eligible(
+    *,
+    operator_state: SourceOperatorStateRow,
+    current_strategy: SourceStrategyVersionRow | None,
+) -> bool:
+    return (
+        bool(operator_state["is_active"])
+        and operator_state["strategy_state"] == "ready"
+        and operator_state["current_strategy_id"] is not None
+        and current_strategy is not None
+        and current_strategy["strategy_status"] == "approved"
+    )
+
+
+def _with_contract_fallbacks(source: SourceRegistryEntry) -> SourceRegistryEntry:
+    normalized = dict(source)
+    normalized.setdefault("fetch_via", _default_fetch_via(str(source["type"])))
+    normalized.setdefault("source_role", "authoritative")
+    normalized.setdefault("timestamp_authority", "source_page")
+    normalized.setdefault("content_mode", _default_content_mode(str(source["type"])))
+    return cast(SourceRegistryEntry, normalized)
+
+
+def _default_fetch_via(source_type: str) -> str:
+    if source_type == "rss":
+        return "direct_rss"
+    if source_type == "html":
+        return "direct_html"
+    if source_type == "pdf":
+        return "direct_pdf"
+    return "hybrid"
+
+
+def _default_content_mode(source_type: str) -> str:
+    if source_type == "pdf":
+        return "article_full_text"
+    if source_type == "rss":
+        return "feed_index"
+    return "article_full_text"

--- a/apps/agent/runtime/source_scope.py
+++ b/apps/agent/runtime/source_scope.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 import yaml  # type: ignore[import-untyped]
 
-from apps.agent.pipeline.types import SourceRegistryEntry
+from apps.agent.pipeline.types import ResolvedSource, SourceRegistryEntry
 
 ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_REGISTRY_PATH = ROOT / "artifacts" / "modelling" / "source_registry.yaml"
@@ -58,3 +58,17 @@ def load_active_source_subset(
         raise ValueError(f"Unknown active source ids: {', '.join(missing_ids)}")
 
     return active_sources
+
+
+def load_runtime_eligible_sources(
+    *,
+    base_dir: Path,
+    registry_path: Path | None = None,
+) -> list[ResolvedSource]:
+    from apps.agent.runtime.resolved_sources import load_resolved_sources
+
+    return [
+        source
+        for source in load_resolved_sources(base_dir=base_dir, registry_path=registry_path)
+        if source["runtime_eligible"]
+    ]

--- a/apps/agent/storage/source_control_plane.py
+++ b/apps/agent/storage/source_control_plane.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-from apps.agent.pipeline.types import SourceOperatorStateRow
+from apps.agent.pipeline.types import (
+    SourceOnboardingRunRow,
+    SourceOperatorStateRow,
+    SourceStrategyVersionRow,
+)
 
 
 def control_plane_db_path(*, base_dir: Path) -> Path:
@@ -27,6 +31,12 @@ class SourceControlPlaneStore:
     def __init__(self, *, base_dir: Path) -> None:
         self.base_dir = base_dir
         self.db_path = ensure_control_plane_db(base_dir=base_dir)
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        return connection
 
     def get_operator_state(self, source_id: str) -> SourceOperatorStateRow | None:
         connection = self._connect()
@@ -57,37 +67,294 @@ class SourceControlPlaneStore:
 
         if row is None:
             return None
-        return SourceOperatorStateRow(
-            source_id=str(row["source_id"]),
-            is_active=int(row["is_active"]),
-            strategy_state=str(row["strategy_state"]),
-            current_strategy_id=None
-            if row["current_strategy_id"] is None
-            else str(row["current_strategy_id"]),
-            latest_strategy_id=None if row["latest_strategy_id"] is None else str(row["latest_strategy_id"]),
-            last_onboarding_run_id=None
-            if row["last_onboarding_run_id"] is None
-            else str(row["last_onboarding_run_id"]),
-            last_collection_status=str(row["last_collection_status"]),
-            last_collection_started_at=None
-            if row["last_collection_started_at"] is None
-            else str(row["last_collection_started_at"]),
-            last_collection_finished_at=None
-            if row["last_collection_finished_at"] is None
-            else str(row["last_collection_finished_at"]),
-            last_collection_error=None
-            if row["last_collection_error"] is None
-            else str(row["last_collection_error"]),
-            activated_at=None if row["activated_at"] is None else str(row["activated_at"]),
-            deactivated_at=None if row["deactivated_at"] is None else str(row["deactivated_at"]),
-            updated_at=str(row["updated_at"]),
-        )
+        return _row_to_operator_state(row)
 
-    def _connect(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(self.db_path)
-        connection.row_factory = sqlite3.Row
-        connection.execute("PRAGMA foreign_keys = ON")
-        return connection
+    def list_operator_states(self) -> list[SourceOperatorStateRow]:
+        connection = self._connect()
+        try:
+            rows = connection.execute(
+                """
+                SELECT
+                  source_id,
+                  is_active,
+                  strategy_state,
+                  current_strategy_id,
+                  latest_strategy_id,
+                  last_onboarding_run_id,
+                  last_collection_status,
+                  last_collection_started_at,
+                  last_collection_finished_at,
+                  last_collection_error,
+                  activated_at,
+                  deactivated_at,
+                  updated_at
+                FROM source_operator_state
+                ORDER BY source_id ASC
+                """
+            ).fetchall()
+        finally:
+            connection.close()
+        return [_row_to_operator_state(row) for row in rows]
+
+    def upsert_operator_state(self, row: SourceOperatorStateRow) -> None:
+        connection = self._connect()
+        try:
+            connection.execute(
+                """
+                INSERT INTO source_operator_state (
+                  source_id,
+                  is_active,
+                  strategy_state,
+                  current_strategy_id,
+                  latest_strategy_id,
+                  last_onboarding_run_id,
+                  last_collection_status,
+                  last_collection_started_at,
+                  last_collection_finished_at,
+                  last_collection_error,
+                  activated_at,
+                  deactivated_at,
+                  updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(source_id) DO UPDATE SET
+                  is_active = excluded.is_active,
+                  strategy_state = excluded.strategy_state,
+                  current_strategy_id = excluded.current_strategy_id,
+                  latest_strategy_id = excluded.latest_strategy_id,
+                  last_onboarding_run_id = excluded.last_onboarding_run_id,
+                  last_collection_status = excluded.last_collection_status,
+                  last_collection_started_at = excluded.last_collection_started_at,
+                  last_collection_finished_at = excluded.last_collection_finished_at,
+                  last_collection_error = excluded.last_collection_error,
+                  activated_at = excluded.activated_at,
+                  deactivated_at = excluded.deactivated_at,
+                  updated_at = excluded.updated_at
+                """,
+                (
+                    row["source_id"],
+                    row["is_active"],
+                    row["strategy_state"],
+                    row["current_strategy_id"],
+                    row["latest_strategy_id"],
+                    row["last_onboarding_run_id"],
+                    row["last_collection_status"],
+                    row["last_collection_started_at"],
+                    row["last_collection_finished_at"],
+                    row["last_collection_error"],
+                    row["activated_at"],
+                    row["deactivated_at"],
+                    row["updated_at"],
+                ),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+    def insert_strategy_version(self, row: SourceStrategyVersionRow) -> None:
+        connection = self._connect()
+        try:
+            connection.execute(
+                """
+                INSERT INTO source_strategy_versions (
+                  strategy_id,
+                  source_id,
+                  version,
+                  strategy_status,
+                  entrypoint_url,
+                  fetch_via,
+                  content_mode,
+                  parser_profile,
+                  max_items_per_run,
+                  strategy_summary_json,
+                  strategy_details_json,
+                  created_from_run_id,
+                  created_at,
+                  approved_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    row["strategy_id"],
+                    row["source_id"],
+                    row["version"],
+                    row["strategy_status"],
+                    row["entrypoint_url"],
+                    row["fetch_via"],
+                    row["content_mode"],
+                    row["parser_profile"],
+                    row["max_items_per_run"],
+                    row["strategy_summary_json"],
+                    row["strategy_details_json"],
+                    row["created_from_run_id"],
+                    row["created_at"],
+                    row["approved_at"],
+                ),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+    def list_strategy_versions(self, source_id: str) -> list[SourceStrategyVersionRow]:
+        connection = self._connect()
+        try:
+            rows = connection.execute(
+                """
+                SELECT
+                  strategy_id,
+                  source_id,
+                  version,
+                  strategy_status,
+                  entrypoint_url,
+                  fetch_via,
+                  content_mode,
+                  parser_profile,
+                  max_items_per_run,
+                  strategy_summary_json,
+                  strategy_details_json,
+                  created_from_run_id,
+                  created_at,
+                  approved_at
+                FROM source_strategy_versions
+                WHERE source_id = ?
+                ORDER BY version DESC, created_at DESC
+                """,
+                (source_id,),
+            ).fetchall()
+        finally:
+            connection.close()
+        return [_row_to_strategy_version(row) for row in rows]
+
+    def insert_onboarding_run(self, row: SourceOnboardingRunRow) -> None:
+        connection = self._connect()
+        try:
+            connection.execute(
+                """
+                INSERT INTO source_onboarding_runs (
+                  onboarding_run_id,
+                  source_id,
+                  status,
+                  worker_kind,
+                  worker_ref,
+                  submitted_at,
+                  started_at,
+                  finished_at,
+                  proposed_strategy_id,
+                  error_message,
+                  result_summary_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    row["onboarding_run_id"],
+                    row["source_id"],
+                    row["status"],
+                    row["worker_kind"],
+                    row["worker_ref"],
+                    row["submitted_at"],
+                    row["started_at"],
+                    row["finished_at"],
+                    row["proposed_strategy_id"],
+                    row["error_message"],
+                    row["result_summary_json"],
+                ),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+    def list_onboarding_runs(self, source_id: str) -> list[SourceOnboardingRunRow]:
+        connection = self._connect()
+        try:
+            rows = connection.execute(
+                """
+                SELECT
+                  onboarding_run_id,
+                  source_id,
+                  status,
+                  worker_kind,
+                  worker_ref,
+                  submitted_at,
+                  started_at,
+                  finished_at,
+                  proposed_strategy_id,
+                  error_message,
+                  result_summary_json
+                FROM source_onboarding_runs
+                WHERE source_id = ?
+                ORDER BY submitted_at DESC, onboarding_run_id DESC
+                """,
+                (source_id,),
+            ).fetchall()
+        finally:
+            connection.close()
+        return [_row_to_onboarding_run(row) for row in rows]
+
+
+def _row_to_operator_state(row: sqlite3.Row) -> SourceOperatorStateRow:
+    return SourceOperatorStateRow(
+        source_id=str(row["source_id"]),
+        is_active=int(row["is_active"]),
+        strategy_state=str(row["strategy_state"]),
+        current_strategy_id=None
+        if row["current_strategy_id"] is None
+        else str(row["current_strategy_id"]),
+        latest_strategy_id=None if row["latest_strategy_id"] is None else str(row["latest_strategy_id"]),
+        last_onboarding_run_id=None
+        if row["last_onboarding_run_id"] is None
+        else str(row["last_onboarding_run_id"]),
+        last_collection_status=str(row["last_collection_status"]),
+        last_collection_started_at=None
+        if row["last_collection_started_at"] is None
+        else str(row["last_collection_started_at"]),
+        last_collection_finished_at=None
+        if row["last_collection_finished_at"] is None
+        else str(row["last_collection_finished_at"]),
+        last_collection_error=None
+        if row["last_collection_error"] is None
+        else str(row["last_collection_error"]),
+        activated_at=None if row["activated_at"] is None else str(row["activated_at"]),
+        deactivated_at=None if row["deactivated_at"] is None else str(row["deactivated_at"]),
+        updated_at=str(row["updated_at"]),
+    )
+
+
+def _row_to_strategy_version(row: sqlite3.Row) -> SourceStrategyVersionRow:
+    return SourceStrategyVersionRow(
+        strategy_id=str(row["strategy_id"]),
+        source_id=str(row["source_id"]),
+        version=int(row["version"]),
+        strategy_status=str(row["strategy_status"]),
+        entrypoint_url=str(row["entrypoint_url"]),
+        fetch_via=str(row["fetch_via"]),
+        content_mode=str(row["content_mode"]),
+        parser_profile=None if row["parser_profile"] is None else str(row["parser_profile"]),
+        max_items_per_run=int(row["max_items_per_run"]),
+        strategy_summary_json=str(row["strategy_summary_json"]),
+        strategy_details_json=str(row["strategy_details_json"]),
+        created_from_run_id=None
+        if row["created_from_run_id"] is None
+        else str(row["created_from_run_id"]),
+        created_at=str(row["created_at"]),
+        approved_at=None if row["approved_at"] is None else str(row["approved_at"]),
+    )
+
+
+def _row_to_onboarding_run(row: sqlite3.Row) -> SourceOnboardingRunRow:
+    return SourceOnboardingRunRow(
+        onboarding_run_id=str(row["onboarding_run_id"]),
+        source_id=str(row["source_id"]),
+        status=str(row["status"]),
+        worker_kind=str(row["worker_kind"]),
+        worker_ref=None if row["worker_ref"] is None else str(row["worker_ref"]),
+        submitted_at=str(row["submitted_at"]),
+        started_at=None if row["started_at"] is None else str(row["started_at"]),
+        finished_at=None if row["finished_at"] is None else str(row["finished_at"]),
+        proposed_strategy_id=None
+        if row["proposed_strategy_id"] is None
+        else str(row["proposed_strategy_id"]),
+        error_message=None if row["error_message"] is None else str(row["error_message"]),
+        result_summary_json=None
+        if row["result_summary_json"] is None
+        else str(row["result_summary_json"]),
+    )
 
 
 def _initialize_schema(connection: sqlite3.Connection) -> None:

--- a/apps/agent/storage/source_control_plane.py
+++ b/apps/agent/storage/source_control_plane.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from apps.agent.pipeline.types import SourceOperatorStateRow
+
+
+def control_plane_db_path(*, base_dir: Path) -> Path:
+    runtime_dir = base_dir / "artifacts" / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    return runtime_dir / "source_control_plane.sqlite3"
+
+
+def ensure_control_plane_db(*, base_dir: Path) -> Path:
+    db_path = control_plane_db_path(base_dir=base_dir)
+    connection = sqlite3.connect(db_path)
+    try:
+        _initialize_schema(connection)
+        connection.commit()
+    finally:
+        connection.close()
+    return db_path
+
+
+class SourceControlPlaneStore:
+    def __init__(self, *, base_dir: Path) -> None:
+        self.base_dir = base_dir
+        self.db_path = ensure_control_plane_db(base_dir=base_dir)
+
+    def get_operator_state(self, source_id: str) -> SourceOperatorStateRow | None:
+        connection = self._connect()
+        try:
+            row = connection.execute(
+                """
+                SELECT
+                  source_id,
+                  is_active,
+                  strategy_state,
+                  current_strategy_id,
+                  latest_strategy_id,
+                  last_onboarding_run_id,
+                  last_collection_status,
+                  last_collection_started_at,
+                  last_collection_finished_at,
+                  last_collection_error,
+                  activated_at,
+                  deactivated_at,
+                  updated_at
+                FROM source_operator_state
+                WHERE source_id = ?
+                """,
+                (source_id,),
+            ).fetchone()
+        finally:
+            connection.close()
+
+        if row is None:
+            return None
+        return SourceOperatorStateRow(
+            source_id=str(row["source_id"]),
+            is_active=int(row["is_active"]),
+            strategy_state=str(row["strategy_state"]),
+            current_strategy_id=None
+            if row["current_strategy_id"] is None
+            else str(row["current_strategy_id"]),
+            latest_strategy_id=None if row["latest_strategy_id"] is None else str(row["latest_strategy_id"]),
+            last_onboarding_run_id=None
+            if row["last_onboarding_run_id"] is None
+            else str(row["last_onboarding_run_id"]),
+            last_collection_status=str(row["last_collection_status"]),
+            last_collection_started_at=None
+            if row["last_collection_started_at"] is None
+            else str(row["last_collection_started_at"]),
+            last_collection_finished_at=None
+            if row["last_collection_finished_at"] is None
+            else str(row["last_collection_finished_at"]),
+            last_collection_error=None
+            if row["last_collection_error"] is None
+            else str(row["last_collection_error"]),
+            activated_at=None if row["activated_at"] is None else str(row["activated_at"]),
+            deactivated_at=None if row["deactivated_at"] is None else str(row["deactivated_at"]),
+            updated_at=str(row["updated_at"]),
+        )
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        return connection
+
+
+def _initialize_schema(connection: sqlite3.Connection) -> None:
+    connection.execute("PRAGMA foreign_keys = ON")
+    statements = (
+        """
+        CREATE TABLE IF NOT EXISTS source_operator_state (
+          source_id TEXT PRIMARY KEY,
+          is_active INTEGER NOT NULL DEFAULT 0,
+          strategy_state TEXT NOT NULL DEFAULT 'missing',
+          current_strategy_id TEXT,
+          latest_strategy_id TEXT,
+          last_onboarding_run_id TEXT,
+          last_collection_status TEXT NOT NULL DEFAULT 'idle',
+          last_collection_started_at TEXT,
+          last_collection_finished_at TEXT,
+          last_collection_error TEXT,
+          activated_at TEXT,
+          deactivated_at TEXT,
+          updated_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS source_strategy_versions (
+          strategy_id TEXT PRIMARY KEY,
+          source_id TEXT NOT NULL,
+          version INTEGER NOT NULL,
+          strategy_status TEXT NOT NULL,
+          entrypoint_url TEXT NOT NULL,
+          fetch_via TEXT NOT NULL,
+          content_mode TEXT NOT NULL,
+          parser_profile TEXT,
+          max_items_per_run INTEGER NOT NULL,
+          strategy_summary_json TEXT NOT NULL,
+          strategy_details_json TEXT NOT NULL,
+          created_from_run_id TEXT,
+          created_at TEXT NOT NULL,
+          approved_at TEXT
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS source_onboarding_runs (
+          onboarding_run_id TEXT PRIMARY KEY,
+          source_id TEXT NOT NULL,
+          status TEXT NOT NULL,
+          worker_kind TEXT NOT NULL,
+          worker_ref TEXT,
+          submitted_at TEXT NOT NULL,
+          started_at TEXT,
+          finished_at TEXT,
+          proposed_strategy_id TEXT,
+          error_message TEXT,
+          result_summary_json TEXT
+        )
+        """,
+    )
+    for statement in statements:
+        connection.execute(statement)

--- a/artifacts/modelling/data_model.md
+++ b/artifacts/modelling/data_model.md
@@ -322,6 +322,61 @@ CREATE TABLE IF NOT EXISTS budget_ledger (
 );
 ```
 
+### 4.11 Source Control Plane
+
+```sql
+CREATE TABLE IF NOT EXISTS source_operator_state (
+  source_id TEXT PRIMARY KEY, -- matches source_registry.yaml id
+  is_active INTEGER NOT NULL DEFAULT 0 CHECK (is_active IN (0,1)),
+  strategy_state TEXT NOT NULL CHECK (strategy_state IN ('missing', 'proposed', 'ready', 'paused')),
+  current_strategy_id TEXT,
+  latest_strategy_id TEXT,
+  last_onboarding_run_id TEXT,
+  last_collection_status TEXT NOT NULL CHECK (last_collection_status IN ('idle', 'queued', 'running', 'succeeded', 'failed')),
+  last_collection_started_at TEXT,
+  last_collection_finished_at TEXT,
+  last_collection_error TEXT,
+  activated_at TEXT,
+  deactivated_at TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS source_strategy_versions (
+  strategy_id TEXT PRIMARY KEY,
+  source_id TEXT NOT NULL, -- joins to file-based source contract
+  version INTEGER NOT NULL,
+  strategy_status TEXT NOT NULL CHECK (strategy_status IN ('proposed', 'approved', 'superseded', 'rejected')),
+  entrypoint_url TEXT NOT NULL,
+  fetch_via TEXT NOT NULL,
+  content_mode TEXT NOT NULL,
+  parser_profile TEXT,
+  max_items_per_run INTEGER NOT NULL,
+  strategy_summary_json TEXT NOT NULL,
+  strategy_details_json TEXT NOT NULL,
+  created_from_run_id TEXT,
+  created_at TEXT NOT NULL,
+  approved_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS source_onboarding_runs (
+  onboarding_run_id TEXT PRIMARY KEY,
+  source_id TEXT NOT NULL, -- joins to file-based source contract
+  status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'succeeded', 'failed')),
+  worker_kind TEXT NOT NULL,
+  worker_ref TEXT,
+  submitted_at TEXT NOT NULL,
+  started_at TEXT,
+  finished_at TEXT,
+  proposed_strategy_id TEXT,
+  error_message TEXT,
+  result_summary_json TEXT
+);
+```
+
+- Source contract remains file-based and reviewed in `source_registry.yaml`.
+- Control-plane tables store mutable operator state, strategy lifecycle, and onboarding lifecycle.
+- Runtime eligibility is computed from the join of source contract and control-plane records; it is not stored as a separate source-of-truth table.
+
 ## 5. Index Plan
 
 ```sql

--- a/docs/plans/2026-04-04-issue-214-source-ops-dashboard-design.md
+++ b/docs/plans/2026-04-04-issue-214-source-ops-dashboard-design.md
@@ -1,0 +1,393 @@
+# Issue 214 Source Ops Dashboard Design
+
+**Goal**
+
+Define the shared source control plane needed for `#214` so source activation, onboarding, strategy approval, and fetched-document visibility become first-class runtime concepts rather than dashboard-local state.
+
+**Scope**
+
+This design covers:
+
+- repo-level source control-plane tables and lifecycle semantics
+- resolved-source service boundaries shared by runtime, agent workers, and dashboard
+- the operator surface to view sources, activate/deactivate them, run onboarding, approve strategies, and inspect fetched documents
+- alignment with `#210`, `#209`, and `#213`
+
+This design does not turn the dashboard into the source of truth for source contracts, and it does not redesign the content store in this issue.
+
+## Why This Exists
+
+The current repo has:
+
+- a reviewed source list in [artifacts/modelling/source_registry.yaml](/D:/aiProjects/workspaces/mvp-agent/.worktrees/issue-214-source-ops-dashboard/artifacts/modelling/source_registry.yaml)
+- an active-subset artifact in `artifacts/runtime/v1_active_sources.yaml`
+- direct type-based runtime source resolution in [apps/agent/runtime/source_scope.py](/D:/aiProjects/workspaces/mvp-agent/.worktrees/issue-214-source-ops-dashboard/apps/agent/runtime/source_scope.py)
+- dashboard-local JSON state in [tools/repo_dashboard/services/status_store.py](/D:/aiProjects/workspaces/mvp-agent/.worktrees/issue-214-source-ops-dashboard/tools/repo_dashboard/services/status_store.py)
+
+That is not enough for the new operating model.
+
+The intended direction is:
+
+`source contract -> operator state -> approved strategy -> resolved source view -> collection worker`
+
+The dashboard is only the operator surface for that model. It must not invent a second private state model.
+
+## Design Constraints
+
+- `#210` remains the reviewed source-contract layer. Contract stays file-based.
+- `#209` should later consume the same resolved source view to drive fetch/storage coverage work.
+- `#213` should own storage abstractions. `#214` must depend on those interfaces instead of hard-coding content storage details.
+- Daily ingest remains source-driven, not freeform web research.
+- A source does not enter steady-state collection until it has an approved strategy.
+- Dashboard state must not be stored in mutable YAML files.
+
+## Architecture
+
+The design separates three planes.
+
+### 1. Contract Plane
+
+Reviewed source definitions remain file-based:
+
+- source identity
+- source metadata
+- source contract fields from `#210`
+
+This is still owned by `source_registry.yaml` and review-driven changes.
+
+### 2. Control Plane
+
+A new shared control-plane SQLite database stores runtime and operator state:
+
+- activation state
+- strategy lifecycle
+- onboarding job lifecycle
+- current approved strategy pointer
+
+This database is repo-level shared infrastructure, not dashboard-local storage.
+
+### 3. Content Plane
+
+Documents, probe samples, and chunks remain content-plane concerns:
+
+- `documents` are official ingest outputs
+- `probe samples` are onboarding/exploration outputs
+- `chunks` remain downstream retrieval material
+
+`#214` only depends on content-plane query abstractions. It must not lock the repo into SQLite for content storage. The long-term direction may move content-plane storage toward a document-oriented backend, but that migration is out of scope here.
+
+## Shared Control-Plane Schema
+
+The new tables exist to be consumed by runtime, workers, and future issues first. The dashboard only reads and mutates them through services.
+
+### `source_operator_state`
+
+One row per `source_id`. Stores current operational state.
+
+Required fields:
+
+- `source_id` primary key
+- `is_active`
+- `strategy_state = missing | proposed | ready | paused`
+- `current_strategy_id` nullable
+- `latest_strategy_id` nullable
+- `last_onboarding_run_id` nullable
+- `last_collection_status = idle | queued | running | succeeded | failed`
+- `last_collection_started_at` nullable
+- `last_collection_finished_at` nullable
+- `last_collection_error` nullable
+- `activated_at` nullable
+- `deactivated_at` nullable
+- `updated_at`
+
+Semantics:
+
+- runtime eligibility depends on `is_active = true` and `strategy_state = ready`
+- `current_strategy_id` is the strategy runtime should execute
+- `latest_strategy_id` may point at a newer `proposed` strategy than the current approved one
+
+### `source_strategy_versions`
+
+One row per strategy version. Stores source-specific executable collection strategy.
+
+Required fields:
+
+- `strategy_id` primary key
+- `source_id`
+- `version`
+- `strategy_status = proposed | approved | superseded | rejected`
+- `entrypoint_url`
+- `fetch_via`
+- `content_mode`
+- `parser_profile` nullable
+- `max_items_per_run`
+- `strategy_summary_json`
+- `strategy_details_json`
+- `created_from_run_id`
+- `created_at`
+- `approved_at` nullable
+
+Semantics:
+
+- strategy is stored in a hybrid model
+- stable, frequently-consumed fields are first-class columns
+- richer strategy details remain in JSON
+- runtime executes only the current approved strategy
+- historical strategies remain queryable for inspection and rollback decisions
+
+### `source_onboarding_runs`
+
+One row per asynchronous onboarding job.
+
+Required fields:
+
+- `onboarding_run_id` primary key
+- `source_id`
+- `status = queued | running | succeeded | failed`
+- `worker_kind`
+- `worker_ref` nullable
+- `submitted_at`
+- `started_at` nullable
+- `finished_at` nullable
+- `proposed_strategy_id` nullable
+- `error_message` nullable
+- `result_summary_json` nullable
+
+Semantics:
+
+- job lifecycle is tracked independently from strategy lifecycle
+- a successful onboarding run may emit a `proposed_strategy_id`
+- failed onboarding does not mutate the current approved strategy
+
+## Resolved Source View
+
+The repo should not materialize a second source-of-truth table. Instead, runtime and dashboard should consume a service-level resolved view built from:
+
+- file-based source contract
+- `source_operator_state`
+- current approved strategy from `source_strategy_versions`
+
+This resolved view should expose:
+
+- contract fields from `#210`
+- current operational state
+- latest onboarding status
+- approved executable strategy when present
+- runtime eligibility flag
+
+It should be computed dynamically through a shared service layer, not persisted as a separate table.
+
+## Source Lifecycle
+
+The first implementation only needs these states:
+
+- `inactive`
+- `active + missing`
+- `active + proposed`
+- `active + ready`
+
+Interpretation:
+
+- `inactive`: not eligible for daily collection
+- `active + missing`: operator activated source, but there is no approved strategy
+- `active + proposed`: onboarding produced a proposal, but operator has not approved it
+- `active + ready`: active source with approved executable strategy; eligible for steady-state collection
+
+`paused` can exist as a future extension, but should not complicate the first-cut workflow.
+
+## Operator Workflows
+
+### Activate / Deactivate
+
+- operator toggles activation from dashboard
+- this updates `source_operator_state`
+- activation does not auto-run onboarding
+- if no approved strategy exists, activation yields `active + missing`
+
+### Run Onboarding
+
+- operator manually triggers onboarding
+- dashboard enqueues an asynchronous job
+- worker performs bounded per-source exploration against the source surface
+- worker may propose a new strategy version
+- successful onboarding transitions the source to `active + proposed`
+
+Onboarding is not broad-web discovery. It is source-bounded strategy discovery so future runs can become deterministic.
+
+### Approve Strategy
+
+- operator reviews the proposed strategy in read-only form
+- approval marks that version `approved`
+- any previous approved version becomes `superseded`
+- `current_strategy_id` is updated
+- `strategy_state` becomes `ready`
+
+Only after this step does the source enter steady-state collection.
+
+## Dashboard Surface
+
+The existing `repo_dashboard` should grow an operator-facing `Sources` area.
+
+### Sources List
+
+Each source row should display:
+
+- contract summary: `source_id`, `name`, `fetch_via`, `source_role`, `content_mode`
+- current operational state: `is_active`, `strategy_state`, `last_collection_status`
+- current strategy version when available
+- latest onboarding status
+- fetched document count
+
+Actions:
+
+- `Activate`
+- `Deactivate`
+- `Run onboarding`
+- `Approve strategy`
+- `View details`
+
+### Source Detail
+
+The detail page remains read-only for contract and strategy content. It should have five sections:
+
+- `Contract`
+- `Operator State`
+- `Current Strategy`
+- `Strategy History / Onboarding Runs`
+- `Fetched Documents` and `Probe Samples`
+
+`Fetched Documents` and `Probe Samples` should be separate tabs, not one combined timeline.
+
+## Content-Plane Query Boundary
+
+`#214` should not redefine how content is stored. It only requires stable query interfaces.
+
+Required query capabilities:
+
+- list official fetched documents by `source_id`
+- list onboarding probe samples by `source_id`
+- provide counts and recent records for dashboard summaries
+
+Rules:
+
+- probe samples must not appear in the official documents view
+- official documents must remain the collection outputs used for downstream evidence and citation work
+- chunks are not first-class dashboard list items in v1
+
+## Service Interfaces
+
+### Control-Plane Service
+
+Required operations:
+
+- `list_resolved_sources(...)`
+- `get_resolved_source(source_id)`
+- `set_source_active(source_id, is_active)`
+- `enqueue_onboarding(source_id)`
+- `list_onboarding_runs(source_id)`
+- `list_strategy_versions(source_id)`
+- `approve_strategy(source_id, strategy_id)`
+
+### Content-Plane Query Service
+
+Required operations:
+
+- `list_source_documents(source_id, ...)`
+- `list_source_probe_samples(source_id, ...)`
+- `count_source_documents(source_id)`
+
+The dashboard should call services, not join files, DB tables, and content storage directly.
+
+## Async Execution Model
+
+Onboarding jobs should run outside the dashboard process.
+
+First-cut shape:
+
+- dashboard submits onboarding job request
+- job is recorded in `source_onboarding_runs`
+- a separate worker/CLI executes the job
+- dashboard polls or refreshes for status changes
+
+The dashboard is not the job runner.
+
+## Compatibility With Neighbor Issues
+
+### `#210`
+
+`#214` consumes the source-contract fields but does not edit them in the UI. The reviewed contract remains file-based and PR-driven.
+
+### `#209`
+
+`#209` should later consume the same resolved source view and approved strategies to drive coverage expansion. It should not invent a different active-source state model.
+
+### `#213`
+
+`#213` should own the storage abstractions behind:
+
+- control-plane DB access
+- document/sample queries
+- future content-plane storage changes
+
+`#214` depends on those interfaces and should not hard-code SQLite layout for content-plane access.
+
+## Testing Scope
+
+Minimum tests for the first implementation:
+
+### Control-Plane Schema and Services
+
+- create/read/update the new control-plane tables
+- resolve source state from contract + operator state + current strategy
+- verify runtime eligibility logic
+
+### Lifecycle Transitions
+
+- activate without strategy -> `active + missing`
+- onboarding success -> `active + proposed`
+- approve strategy -> `active + ready`
+- deactivate -> source removed from eligible set
+
+### Dashboard API
+
+- list endpoint returns contract summary + operator state + strategy summary
+- detail endpoint returns strategy history, onboarding runs, document list, and probe sample list
+- approval and onboarding endpoints enforce valid transitions
+
+### Guardrails
+
+- unapproved strategies are not runtime-eligible
+- probe samples never appear in official document queries
+- dashboard does not mutate reviewed source contract files
+
+## Sub-Issue Shape
+
+This design suggests the following execution slices under `#214`:
+
+1. shared control-plane schema and service foundation
+2. resolved-source service and runtime eligibility integration
+3. dashboard sources list and source detail views
+4. onboarding queue and worker handoff integration
+5. strategy approval flow and lifecycle guards
+6. fetched-documents and probe-samples content queries
+
+These should be split so the shared data model lands before UI-heavy work.
+
+## Recommended Implementation Order
+
+1. add shared control-plane schema and storage/service access
+2. add resolved-source service
+3. add runtime eligibility integration on top of resolved sources
+4. add dashboard sources list
+5. add source detail view
+6. add onboarding enqueue flow
+7. add strategy approval flow
+8. connect official document and probe-sample queries
+
+## Rollout Notes
+
+- keep source contract file-based
+- make control-plane changes additive
+- keep existing dashboard run-status behavior intact while the source operator surface is added
+- do not require a full content-plane migration before landing control-plane work
+- allow the dashboard to become an operator surface without making it the owner of core runtime logic

--- a/docs/plans/2026-04-04-issue-214-source-ops-dashboard-implementation-plan.md
+++ b/docs/plans/2026-04-04-issue-214-source-ops-dashboard-implementation-plan.md
@@ -1,0 +1,449 @@
+# Issue 214 Source Ops Dashboard Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build the shared source control plane and operator dashboard flow for `#214` without making the dashboard the source of truth for runtime source behavior.
+
+**Architecture:** Keep source contract file-based, add a separate control-plane SQLite store for operator state and strategies, and expose a dynamic resolved-source service that runtime, workers, and dashboard can all consume. Land the data model and lifecycle services first, then add dashboard views and content visibility on top of those shared interfaces.
+
+**Tech Stack:** Python, FastAPI, SQLite, YAML source registry loading, existing `repo_dashboard` static frontend, `unittest`.
+
+---
+
+### Task 1: Add Shared Control-Plane Storage Foundations (`#215`)
+
+**Files:**
+- Create: `apps/agent/storage/source_control_plane.py`
+- Modify: `apps/agent/pipeline/types.py`
+- Test: `tests/agent/storage/test_source_control_plane.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/agent/storage/test_source_control_plane.py` with focused storage expectations:
+
+```python
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from apps.agent.storage.source_control_plane import (
+    control_plane_db_path,
+    ensure_control_plane_db,
+    SourceControlPlaneStore,
+)
+
+
+class SourceControlPlaneStoreTests(unittest.TestCase):
+    def test_bootstraps_control_plane_tables(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            db_path = ensure_control_plane_db(base_dir=base_dir)
+            self.assertEqual(db_path, control_plane_db_path(base_dir=base_dir))
+
+            store = SourceControlPlaneStore(base_dir=base_dir)
+            operator_state = store.get_operator_state("reuters_business")
+
+            self.assertIsNone(operator_state)
+            self.assertTrue(db_path.exists())
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.agent.storage.test_source_control_plane -v`
+
+Expected: FAIL with import error because `apps.agent.storage.source_control_plane` does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create `apps/agent/storage/source_control_plane.py` with:
+
+- `control_plane_db_path(base_dir: Path) -> Path`
+- `ensure_control_plane_db(base_dir: Path) -> Path`
+- `SourceControlPlaneStore`
+- schema initialization for:
+  - `source_operator_state`
+  - `source_strategy_versions`
+  - `source_onboarding_runs`
+
+Add typed rows to `apps/agent/pipeline/types.py`, for example:
+
+```python
+class SourceOperatorStateRow(TypedDict):
+    source_id: str
+    is_active: int
+    strategy_state: str
+    current_strategy_id: str | None
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m unittest tests.agent.storage.test_source_control_plane -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/agent/storage/source_control_plane.py apps/agent/pipeline/types.py tests/agent/storage/test_source_control_plane.py
+git commit -m "feat: add source control plane storage foundation"
+```
+
+### Task 2: Add Control-Plane CRUD And Lifecycle Persistence (`#215`)
+
+**Files:**
+- Modify: `apps/agent/storage/source_control_plane.py`
+- Modify: `tests/agent/storage/test_source_control_plane.py`
+
+**Step 1: Write the failing test**
+
+Extend `tests/agent/storage/test_source_control_plane.py` with lifecycle persistence checks:
+
+```python
+def test_persists_operator_state_strategy_versions_and_onboarding_runs(self) -> None:
+    with TemporaryDirectory() as tmpdir:
+        store = SourceControlPlaneStore(base_dir=Path(tmpdir))
+        store.upsert_operator_state(
+            {
+                "source_id": "reuters_business",
+                "is_active": 1,
+                "strategy_state": "missing",
+                "current_strategy_id": None,
+                "latest_strategy_id": None,
+                "last_onboarding_run_id": None,
+                "last_collection_status": "idle",
+                "last_collection_started_at": None,
+                "last_collection_finished_at": None,
+                "last_collection_error": None,
+                "activated_at": "2026-04-04T00:00:00Z",
+                "deactivated_at": None,
+                "updated_at": "2026-04-04T00:00:00Z",
+            }
+        )
+        state = store.get_operator_state("reuters_business")
+        self.assertEqual(state["strategy_state"], "missing")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.agent.storage.test_source_control_plane -v`
+
+Expected: FAIL because CRUD methods like `upsert_operator_state(...)` do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add storage methods:
+
+- `get_operator_state(source_id)`
+- `list_operator_states()`
+- `upsert_operator_state(row)`
+- `insert_strategy_version(row)`
+- `list_strategy_versions(source_id)`
+- `insert_onboarding_run(row)`
+- `update_onboarding_run(run_id, ...)`
+- `list_onboarding_runs(source_id)`
+
+Keep timestamps and status transitions explicit. Do not add dashboard-only columns.
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m unittest tests.agent.storage.test_source_control_plane -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/agent/storage/source_control_plane.py tests/agent/storage/test_source_control_plane.py
+git commit -m "feat: add source control plane lifecycle persistence"
+```
+
+### Task 3: Add Resolved Source Service And Runtime Eligibility (`#216`)
+
+**Files:**
+- Create: `apps/agent/runtime/resolved_sources.py`
+- Modify: `apps/agent/runtime/source_scope.py`
+- Modify: `apps/agent/pipeline/types.py`
+- Test: `tests/agent/runtime/test_resolved_sources.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/agent/runtime/test_resolved_sources.py` to cover merged source resolution:
+
+```python
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from apps.agent.runtime.resolved_sources import load_resolved_sources
+from apps.agent.storage.source_control_plane import SourceControlPlaneStore
+
+
+class ResolvedSourcesTests(unittest.TestCase):
+    def test_marks_only_active_ready_sources_as_runtime_eligible(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            store = SourceControlPlaneStore(base_dir=base_dir)
+            # seed operator state + approved strategy here
+            resolved = load_resolved_sources(base_dir=base_dir)
+            eligible = [item for item in resolved if item["runtime_eligible"]]
+            self.assertEqual([item["source_id"] for item in eligible], ["reuters_business"])
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.agent.runtime.test_resolved_sources -v`
+
+Expected: FAIL with import error because `apps.agent.runtime.resolved_sources` does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create `apps/agent/runtime/resolved_sources.py` with:
+
+- `load_resolved_sources(...)`
+- `get_resolved_source(source_id, ...)`
+- helper to compute `runtime_eligible`
+
+Update `apps/agent/pipeline/types.py` with a `ResolvedSource` typed shape.
+
+Keep the join dynamic:
+
+```python
+runtime_eligible = (
+    bool(operator_state["is_active"])
+    and operator_state["strategy_state"] == "ready"
+    and operator_state["current_strategy_id"] is not None
+)
+```
+
+Update `apps/agent/runtime/source_scope.py` so the legacy YAML active list can remain as compatibility input while the resolved-source path becomes available for later collection work.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+python -m unittest tests.agent.runtime.test_resolved_sources -v
+python -m unittest tests.agent.runtime.test_source_scope -v
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/agent/runtime/resolved_sources.py apps/agent/runtime/source_scope.py apps/agent/pipeline/types.py tests/agent/runtime/test_resolved_sources.py
+git commit -m "feat: add resolved source service and runtime eligibility"
+```
+
+### Task 4: Add Onboarding Queue And Strategy Approval Services (`#217`, `#218`)
+
+**Files:**
+- Create: `tools/repo_dashboard/services/source_ops_service.py`
+- Modify: `apps/agent/storage/source_control_plane.py`
+- Test: `tests/tools/test_repo_dashboard_services.py`
+
+**Step 1: Write the failing test**
+
+Extend `tests/tools/test_repo_dashboard_services.py` with service-level lifecycle checks:
+
+```python
+def test_enqueue_onboarding_and_approve_strategy_updates_source_lifecycle(self) -> None:
+    service = SourceOpsService(repo_root=repo_root, data_dir=data_dir)
+    service.set_source_active("reuters_business", True)
+    run = service.enqueue_onboarding("reuters_business")
+    service.record_proposed_strategy(run["onboarding_run_id"], proposed_strategy_row)
+    service.approve_strategy("reuters_business", proposed_strategy_row["strategy_id"])
+    resolved = service.get_resolved_source("reuters_business")
+    self.assertEqual(resolved["strategy_state"], "ready")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.tools.test_repo_dashboard_services -v`
+
+Expected: FAIL because `SourceOpsService` and onboarding/approval methods do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create `tools/repo_dashboard/services/source_ops_service.py` as a thin orchestration layer over the shared control plane.
+
+Add methods:
+
+- `list_resolved_sources()`
+- `get_resolved_source(source_id)`
+- `set_source_active(source_id, is_active)`
+- `enqueue_onboarding(source_id)`
+- `record_proposed_strategy(onboarding_run_id, row)`
+- `approve_strategy(source_id, strategy_id)`
+
+Keep onboarding asynchronous in model only: record the job and status, but do not execute the worker in-process.
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m unittest tests.tools.test_repo_dashboard_services -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tools/repo_dashboard/services/source_ops_service.py apps/agent/storage/source_control_plane.py tests/tools/test_repo_dashboard_services.py
+git commit -m "feat: add source onboarding and approval services"
+```
+
+### Task 5: Add Dashboard Sources API And Views (`#219`)
+
+**Files:**
+- Modify: `tools/repo_dashboard/app.py`
+- Modify: `tools/repo_dashboard/static/index.html`
+- Modify: `tools/repo_dashboard/static/app.js`
+- Modify: `tools/repo_dashboard/static/styles.css`
+- Test: `tests/tools/test_repo_dashboard_api.py`
+- Test: `tests/tools/test_repo_dashboard_frontend.py`
+
+**Step 1: Write the failing test**
+
+Add API and frontend expectations:
+
+```python
+def test_sources_endpoints_return_resolved_source_rows(self) -> None:
+    response = client.get("/api/sources")
+    self.assertEqual(response.status_code, 200)
+    self.assertEqual(response.json()["items"][0]["source_id"], "reuters_business")
+
+def test_root_serves_sources_panel_shell(self) -> None:
+    response = client.get("/")
+    self.assertIn('id="sources-panel"', response.text)
+    self.assertIn('id="source-detail-panel"', response.text)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+python -m unittest tests.tools.test_repo_dashboard_api -v
+python -m unittest tests.tools.test_repo_dashboard_frontend -v
+```
+
+Expected: FAIL because the new API routes and HTML anchors do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add new FastAPI routes in `tools/repo_dashboard/app.py`:
+
+- `GET /api/sources`
+- `GET /api/sources/{source_id}`
+- `POST /api/sources/{source_id}/activate`
+- `POST /api/sources/{source_id}/deactivate`
+- `POST /api/sources/{source_id}/onboarding`
+- `POST /api/sources/{source_id}/strategies/{strategy_id}/approve`
+
+Update frontend files to render:
+
+- a `Sources` overview panel
+- a source detail panel
+- read-only strategy summary
+
+Keep contract display read-only and keep current runtime run panels intact.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+python -m unittest tests.tools.test_repo_dashboard_api -v
+python -m unittest tests.tools.test_repo_dashboard_frontend -v
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tools/repo_dashboard/app.py tools/repo_dashboard/static/index.html tools/repo_dashboard/static/app.js tools/repo_dashboard/static/styles.css tests/tools/test_repo_dashboard_api.py tests/tools/test_repo_dashboard_frontend.py
+git commit -m "feat: add source ops dashboard views and actions"
+```
+
+### Task 6: Add Documents And Probe-Sample Visibility (`#220`)
+
+**Files:**
+- Create: `tools/repo_dashboard/services/source_content_service.py`
+- Modify: `tools/repo_dashboard/app.py`
+- Modify: `tools/repo_dashboard/static/app.js`
+- Modify: `tools/repo_dashboard/static/styles.css`
+- Test: `tests/tools/test_repo_dashboard_api.py`
+
+**Step 1: Write the failing test**
+
+Extend the dashboard API test with document and probe-sample detail expectations:
+
+```python
+def test_source_detail_returns_documents_and_probe_samples_separately(self) -> None:
+    response = client.get("/api/sources/reuters_business")
+    payload = response.json()
+    self.assertIn("documents", payload)
+    self.assertIn("probe_samples", payload)
+    self.assertNotEqual(payload["documents"], payload["probe_samples"])
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m unittest tests.tools.test_repo_dashboard_api -v`
+
+Expected: FAIL because source detail does not yet include content-plane query results.
+
+**Step 3: Write minimal implementation**
+
+Create `tools/repo_dashboard/services/source_content_service.py` with query methods:
+
+- `list_source_documents(source_id, limit=...)`
+- `list_source_probe_samples(source_id, limit=...)`
+- `count_source_documents(source_id)`
+
+Initial implementation may read official documents from the current runtime store and return an empty probe-sample list until onboarding sample persistence lands, but the API shape must already keep the two planes separate.
+
+Update source detail endpoint and frontend tabs so `Fetched Documents` and `Probe Samples` are distinct UI surfaces.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+python -m unittest tests.tools.test_repo_dashboard_api -v
+python -m unittest tests.tools.test_repo_dashboard_frontend -v
+python -m unittest tests.tools.test_repo_dashboard_services -v
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tools/repo_dashboard/services/source_content_service.py tools/repo_dashboard/app.py tools/repo_dashboard/static/app.js tools/repo_dashboard/static/styles.css tests/tools/test_repo_dashboard_api.py
+git commit -m "feat: add source document and probe sample visibility"
+```
+
+### Final Verification
+
+Run the focused verification set after Task 6:
+
+```bash
+python -m unittest tests.agent.storage.test_source_control_plane tests.agent.runtime.test_resolved_sources tests.agent.runtime.test_source_scope tests.tools.test_repo_dashboard_services tests.tools.test_repo_dashboard_api tests.tools.test_repo_dashboard_frontend -v
+python -m compileall -q apps tests tools scripts
+python scripts/validate_artifacts.py
+python scripts/validate_decision_record_schema.py
+```
+
+Expected:
+
+- all targeted tests pass
+- compile step is clean
+- artifact validators remain green
+
+### Notes For Execution
+
+- keep `source_registry.yaml` file-based and read-only from dashboard code
+- do not make onboarding worker execution in-process
+- do not treat `artifacts/runtime/v1_active_sources.yaml` as the mutable source-of-truth once control-plane eligibility exists
+- keep probe samples out of official document queries even if probe-sample persistence is initially thin

--- a/docs/plans/2026-04-04-issue-214-source-ops-dashboard-implementation-plan.md
+++ b/docs/plans/2026-04-04-issue-214-source-ops-dashboard-implementation-plan.md
@@ -15,6 +15,7 @@
 **Files:**
 - Create: `apps/agent/storage/source_control_plane.py`
 - Modify: `apps/agent/pipeline/types.py`
+- Modify: `artifacts/modelling/data_model.md`
 - Test: `tests/agent/storage/test_source_control_plane.py`
 
 **Step 1: Write the failing test**
@@ -75,6 +76,8 @@ class SourceOperatorStateRow(TypedDict):
     current_strategy_id: str | None
 ```
 
+Update `artifacts/modelling/data_model.md` with the additive control-plane schema so runtime code is not the only source of truth for the new persistence contract.
+
 **Step 4: Run test to verify it passes**
 
 Run: `python -m unittest tests.agent.storage.test_source_control_plane -v`
@@ -84,7 +87,7 @@ Expected: PASS
 **Step 5: Commit**
 
 ```bash
-git add apps/agent/storage/source_control_plane.py apps/agent/pipeline/types.py tests/agent/storage/test_source_control_plane.py
+git add apps/agent/storage/source_control_plane.py apps/agent/pipeline/types.py artifacts/modelling/data_model.md tests/agent/storage/test_source_control_plane.py
 git commit -m "feat: add source control plane storage foundation"
 ```
 

--- a/tests/agent/runtime/test_resolved_sources.py
+++ b/tests/agent/runtime/test_resolved_sources.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from apps.agent.runtime.resolved_sources import load_resolved_sources
+from apps.agent.storage.source_control_plane import SourceControlPlaneStore
+
+
+class ResolvedSourcesTests(unittest.TestCase):
+    def test_marks_only_active_ready_sources_as_runtime_eligible(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            registry_path = base_dir / "registry.yaml"
+            registry_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "sources": [
+                            {
+                                "id": "reuters_business",
+                                "name": "Reuters - Business News",
+                                "url": "https://www.reuters.com/business/",
+                                "type": "rss",
+                                "credibility_tier": 2,
+                                "paywall_policy": "full",
+                                "fetch_interval": "daily",
+                                "tags": ["market_narrative", "us"],
+                            },
+                            {
+                                "id": "wsj_markets",
+                                "name": "Wall Street Journal - Markets",
+                                "url": "https://feeds.a.dj.com/rss/RSSMarketsMain.xml",
+                                "type": "rss",
+                                "credibility_tier": 2,
+                                "paywall_policy": "metadata_only",
+                                "fetch_interval": "daily",
+                                "tags": ["market_narrative", "us"],
+                            },
+                        ]
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            store = SourceControlPlaneStore(base_dir=base_dir)
+            store.upsert_operator_state(
+                {
+                    "source_id": "reuters_business",
+                    "is_active": 1,
+                    "strategy_state": "ready",
+                    "current_strategy_id": "strat_reuters_001",
+                    "latest_strategy_id": "strat_reuters_001",
+                    "last_onboarding_run_id": None,
+                    "last_collection_status": "idle",
+                    "last_collection_started_at": None,
+                    "last_collection_finished_at": None,
+                    "last_collection_error": None,
+                    "activated_at": "2026-04-04T00:00:00Z",
+                    "deactivated_at": None,
+                    "updated_at": "2026-04-04T00:00:00Z",
+                }
+            )
+            store.insert_strategy_version(
+                {
+                    "strategy_id": "strat_reuters_001",
+                    "source_id": "reuters_business",
+                    "version": 1,
+                    "strategy_status": "approved",
+                    "entrypoint_url": "https://www.reuters.com/business/",
+                    "fetch_via": "direct_rss",
+                    "content_mode": "article_full_text",
+                    "parser_profile": None,
+                    "max_items_per_run": 25,
+                    "strategy_summary_json": "{\"headline\":\"business feed\"}",
+                    "strategy_details_json": "{\"entrypoints\":[\"https://www.reuters.com/business/\"]}",
+                    "created_from_run_id": None,
+                    "created_at": "2026-04-04T00:05:00Z",
+                    "approved_at": "2026-04-04T00:06:00Z",
+                }
+            )
+            store.upsert_operator_state(
+                {
+                    "source_id": "wsj_markets",
+                    "is_active": 1,
+                    "strategy_state": "missing",
+                    "current_strategy_id": None,
+                    "latest_strategy_id": None,
+                    "last_onboarding_run_id": None,
+                    "last_collection_status": "idle",
+                    "last_collection_started_at": None,
+                    "last_collection_finished_at": None,
+                    "last_collection_error": None,
+                    "activated_at": "2026-04-04T00:00:00Z",
+                    "deactivated_at": None,
+                    "updated_at": "2026-04-04T00:00:00Z",
+                }
+            )
+
+            resolved = load_resolved_sources(base_dir=base_dir, registry_path=registry_path)
+            eligible = [item for item in resolved if item["runtime_eligible"]]
+
+            self.assertEqual([item["source_id"] for item in eligible], ["reuters_business"])
+            self.assertEqual(eligible[0]["current_strategy"]["strategy_id"], "strat_reuters_001")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/storage/test_source_control_plane.py
+++ b/tests/agent/storage/test_source_control_plane.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from apps.agent.storage.source_control_plane import (
+    SourceControlPlaneStore,
+    control_plane_db_path,
+    ensure_control_plane_db,
+)
+
+
+class SourceControlPlaneStoreTests(unittest.TestCase):
+    def test_bootstraps_control_plane_tables(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+
+            db_path = ensure_control_plane_db(base_dir=base_dir)
+
+            self.assertEqual(db_path, control_plane_db_path(base_dir=base_dir))
+            self.assertTrue(db_path.exists())
+
+            store = SourceControlPlaneStore(base_dir=base_dir)
+            operator_state = store.get_operator_state("reuters_business")
+
+            self.assertIsNone(operator_state)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/storage/test_source_control_plane.py
+++ b/tests/agent/storage/test_source_control_plane.py
@@ -26,6 +26,70 @@ class SourceControlPlaneStoreTests(unittest.TestCase):
 
             self.assertIsNone(operator_state)
 
+    def test_persists_operator_state_strategy_versions_and_onboarding_runs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            store = SourceControlPlaneStore(base_dir=Path(tmpdir))
+
+            store.upsert_operator_state(
+                {
+                    "source_id": "reuters_business",
+                    "is_active": 1,
+                    "strategy_state": "missing",
+                    "current_strategy_id": None,
+                    "latest_strategy_id": None,
+                    "last_onboarding_run_id": None,
+                    "last_collection_status": "idle",
+                    "last_collection_started_at": None,
+                    "last_collection_finished_at": None,
+                    "last_collection_error": None,
+                    "activated_at": "2026-04-04T00:00:00Z",
+                    "deactivated_at": None,
+                    "updated_at": "2026-04-04T00:00:00Z",
+                }
+            )
+            store.insert_strategy_version(
+                {
+                    "strategy_id": "strat_001",
+                    "source_id": "reuters_business",
+                    "version": 1,
+                    "strategy_status": "proposed",
+                    "entrypoint_url": "https://www.reuters.com/business/",
+                    "fetch_via": "direct_rss",
+                    "content_mode": "article_full_text",
+                    "parser_profile": None,
+                    "max_items_per_run": 25,
+                    "strategy_summary_json": "{\"headline\":\"business feed\"}",
+                    "strategy_details_json": "{\"entrypoints\":[\"https://www.reuters.com/business/\"]}",
+                    "created_from_run_id": None,
+                    "created_at": "2026-04-04T00:05:00Z",
+                    "approved_at": None,
+                }
+            )
+            store.insert_onboarding_run(
+                {
+                    "onboarding_run_id": "onboard_001",
+                    "source_id": "reuters_business",
+                    "status": "queued",
+                    "worker_kind": "claude_code_headless",
+                    "worker_ref": None,
+                    "submitted_at": "2026-04-04T00:01:00Z",
+                    "started_at": None,
+                    "finished_at": None,
+                    "proposed_strategy_id": None,
+                    "error_message": None,
+                    "result_summary_json": None,
+                }
+            )
+
+            state = store.get_operator_state("reuters_business")
+            strategies = store.list_strategy_versions("reuters_business")
+            runs = store.list_onboarding_runs("reuters_business")
+
+            self.assertIsNotNone(state)
+            self.assertEqual(state["strategy_state"], "missing")
+            self.assertEqual(strategies[0]["strategy_id"], "strat_001")
+            self.assertEqual(runs[0]["onboarding_run_id"], "onboard_001")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This draft PR starts `#214` by landing the shared source control-plane foundation and the first resolved-source integration.

Included in this PR:
- add the issue `#214` design and implementation plan docs
- add shared source control-plane storage for:
  - `source_operator_state`
  - `source_strategy_versions`
  - `source_onboarding_runs`
- add typed control-plane rows in pipeline/runtime contracts
- update the modelling data model with the new control-plane schema
- add a resolved-source service that joins source contract + operator state + approved strategy
- add runtime eligibility helper logic without breaking the current `source_scope` path
- add focused storage/runtime tests for the new foundation

Not included yet:
- async onboarding queue and worker handoff (`#217`)
- strategy approval flow and lifecycle guards (`#218`)
- dashboard source list/detail UI (`#219`)
- fetched-document / probe-sample visibility (`#220`)

## Issues

- Parent: `#214`
- Implemented foundation:
  - `#215`
  - `#216`
- Follow-up work remains in:
  - `#217`
  - `#218`
  - `#219`
  - `#220`

## Verification

- `python -m unittest tests.agent.storage.test_source_control_plane tests.agent.runtime.test_resolved_sources tests.agent.runtime.test_source_scope -v`
- `python -m compileall -q apps tests tools scripts`
- `python scripts/validate_artifacts.py`
- `python scripts/validate_decision_record_schema.py`
