### PR TITLE
feat: add resolved source service and runtime eligibility

### DIFF
--- a/apps/agent/pipeline/types.py
+++ b/apps/agent/pipeline/types.py
@@ -65,6 +65,10 @@ class SourceRegistryEntry(TypedDict):
     url: Required[str]
     base_url: NotRequired[str]
     type: Required[str]
+    fetch_via: NotRequired[str]
+    source_role: NotRequired[str]
+    timestamp_authority: NotRequired[str]
+    content_mode: NotRequired[str]
     credibility_tier: Required[int]
     paywall_policy: Required[str]
     fetch_interval: Required[str]
@@ -136,6 +140,16 @@ class SourceOnboardingRunRow(TypedDict):
     proposed_strategy_id: str | None
     error_message: str | None
     result_summary_json: str | None
+
+
+class ResolvedSource(TypedDict):
+    source_id: str
+    contract: SourceRegistryEntry
+    operator_state: SourceOperatorStateRow
+    current_strategy: SourceStrategyVersionRow | None
+    latest_strategy: SourceStrategyVersionRow | None
+    latest_onboarding_run: SourceOnboardingRunRow | None
+    runtime_eligible: bool
 
 
 class RuntimeDocumentRecord(TypedDict):

--- a/apps/agent/runtime/resolved_sources.py
+++ b/apps/agent/runtime/resolved_sources.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from apps.agent.pipeline.types import (
+    ResolvedSource,
+    SourceOnboardingRunRow,
+    SourceOperatorStateRow,
+    SourceRegistryEntry,
+    SourceStrategyVersionRow,
+)
+from apps.agent.runtime.source_scope import load_source_registry
+from apps.agent.storage.source_control_plane import SourceControlPlaneStore
+
+
+def load_resolved_sources(
+    *,
+    base_dir: Path,
+    registry_path: Path | None = None,
+) -> list[ResolvedSource]:
+    registry = load_source_registry(registry_path=registry_path)
+    store = SourceControlPlaneStore(base_dir=base_dir)
+
+    resolved: list[ResolvedSource] = []
+    for source_id, contract in registry.items():
+        operator_state = store.get_operator_state(source_id) or _default_operator_state(source_id)
+        strategies = store.list_strategy_versions(source_id)
+        onboarding_runs = store.list_onboarding_runs(source_id)
+        current_strategy = _pick_current_strategy(operator_state=operator_state, strategies=strategies)
+        latest_strategy = strategies[0] if strategies else None
+        latest_onboarding_run = onboarding_runs[0] if onboarding_runs else None
+        resolved.append(
+            ResolvedSource(
+                source_id=source_id,
+                contract=_with_contract_fallbacks(contract),
+                operator_state=operator_state,
+                current_strategy=current_strategy,
+                latest_strategy=latest_strategy,
+                latest_onboarding_run=latest_onboarding_run,
+                runtime_eligible=_is_runtime_eligible(
+                    operator_state=operator_state,
+                    current_strategy=current_strategy,
+                ),
+            )
+        )
+    return resolved
+
+
+def get_resolved_source(
+    source_id: str,
+    *,
+    base_dir: Path,
+    registry_path: Path | None = None,
+) -> ResolvedSource:
+    for source in load_resolved_sources(base_dir=base_dir, registry_path=registry_path):
+        if source["source_id"] == source_id:
+            return source
+    raise ValueError(f"Unknown source id: {source_id}")
+
+
+def _default_operator_state(source_id: str) -> SourceOperatorStateRow:
+    return SourceOperatorStateRow(
+        source_id=source_id,
+        is_active=0,
+        strategy_state="missing",
+        current_strategy_id=None,
+        latest_strategy_id=None,
+        last_onboarding_run_id=None,
+        last_collection_status="idle",
+        last_collection_started_at=None,
+        last_collection_finished_at=None,
+        last_collection_error=None,
+        activated_at=None,
+        deactivated_at=None,
+        updated_at="",
+    )
+
+
+def _pick_current_strategy(
+    *,
+    operator_state: SourceOperatorStateRow,
+    strategies: list[SourceStrategyVersionRow],
+) -> SourceStrategyVersionRow | None:
+    current_strategy_id = operator_state["current_strategy_id"]
+    if current_strategy_id is None:
+        return None
+    for strategy in strategies:
+        if strategy["strategy_id"] == current_strategy_id:
+            return strategy
+    return None
+
+
+def _is_runtime_eligible(
+    *,
+    operator_state: SourceOperatorStateRow,
+    current_strategy: SourceStrategyVersionRow | None,
+) -> bool:
+    return (
+        bool(operator_state["is_active"])
+        and operator_state["strategy_state"] == "ready"
+        and operator_state["current_strategy_id"] is not None
+        and current_strategy is not None
+        and current_strategy["strategy_status"] == "approved"
+    )
+
+
+def _with_contract_fallbacks(source: SourceRegistryEntry) -> SourceRegistryEntry:
+    normalized = dict(source)
+    normalized.setdefault("fetch_via", _default_fetch_via(str(source["type"])))
+    normalized.setdefault("source_role", "authoritative")
+    normalized.setdefault("timestamp_authority", "source_page")
+    normalized.setdefault("content_mode", _default_content_mode(str(source["type"])))
+    return cast(SourceRegistryEntry, normalized)
+
+
+def _default_fetch_via(source_type: str) -> str:
+    if source_type == "rss":
+        return "direct_rss"
+    if source_type == "html":
+        return "direct_html"
+    if source_type == "pdf":
+        return "direct_pdf"
+    return "hybrid"
+
+
+def _default_content_mode(source_type: str) -> str:
+    if source_type == "pdf":
+        return "article_full_text"
+    if source_type == "rss":
+        return "feed_index"
+    return "article_full_text"

--- a/apps/agent/runtime/source_scope.py
+++ b/apps/agent/runtime/source_scope.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 import yaml  # type: ignore[import-untyped]
 
-from apps.agent.pipeline.types import SourceRegistryEntry
+from apps.agent.pipeline.types import ResolvedSource, SourceRegistryEntry
 
 ROOT = Path(__file__).resolve().parents[3]
 DEFAULT_REGISTRY_PATH = ROOT / "artifacts" / "modelling" / "source_registry.yaml"
@@ -58,3 +58,17 @@ def load_active_source_subset(
         raise ValueError(f"Unknown active source ids: {', '.join(missing_ids)}")
 
     return active_sources
+
+
+def load_runtime_eligible_sources(
+    *,
+    base_dir: Path,
+    registry_path: Path | None = None,
+) -> list[ResolvedSource]:
+    from apps.agent.runtime.resolved_sources import load_resolved_sources
+
+    return [
+        source
+        for source in load_resolved_sources(base_dir=base_dir, registry_path=registry_path)
+        if source["runtime_eligible"]
+    ]

--- a/tests/agent/runtime/test_resolved_sources.py
+++ b/tests/agent/runtime/test_resolved_sources.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from apps.agent.runtime.resolved_sources import load_resolved_sources
+from apps.agent.storage.source_control_plane import SourceControlPlaneStore
+
+
+class ResolvedSourcesTests(unittest.TestCase):
+    def test_marks_only_active_ready_sources_as_runtime_eligible(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            registry_path = base_dir / "registry.yaml"
+            registry_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "sources": [
+                            {
+                                "id": "reuters_business",
+                                "name": "Reuters - Business News",
+                                "url": "https://www.reuters.com/business/",
+                                "type": "rss",
+                                "credibility_tier": 2,
+                                "paywall_policy": "full",
+                                "fetch_interval": "daily",
+                                "tags": ["market_narrative", "us"],
+                            },
+                            {
+                                "id": "wsj_markets",
+                                "name": "Wall Street Journal - Markets",
+                                "url": "https://feeds.a.dj.com/rss/RSSMarketsMain.xml",
+                                "type": "rss",
+                                "credibility_tier": 2,
+                                "paywall_policy": "metadata_only",
+                                "fetch_interval": "daily",
+                                "tags": ["market_narrative", "us"],
+                            },
+                        ]
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            store = SourceControlPlaneStore(base_dir=base_dir)
+            store.upsert_operator_state(
+                {
+                    "source_id": "reuters_business",
+                    "is_active": 1,
+                    "strategy_state": "ready",
+                    "current_strategy_id": "strat_reuters_001",
+                    "latest_strategy_id": "strat_reuters_001",
+                    "last_onboarding_run_id": None,
+                    "last_collection_status": "idle",
+                    "last_collection_started_at": None,
+                    "last_collection_finished_at": None,
+                    "last_collection_error": None,
+                    "activated_at": "2026-04-04T00:00:00Z",
+                    "deactivated_at": None,
+                    "updated_at": "2026-04-04T00:00:00Z",
+                }
+            )
+            store.insert_strategy_version(
+                {
+                    "strategy_id": "strat_reuters_001",
+                    "source_id": "reuters_business",
+                    "version": 1,
+                    "strategy_status": "approved",
+                    "entrypoint_url": "https://www.reuters.com/business/",
+                    "fetch_via": "direct_rss",
+                    "content_mode": "article_full_text",
+                    "parser_profile": None,
+                    "max_items_per_run": 25,
+                    "strategy_summary_json": "{\"headline\":\"business feed\"}",
+                    "strategy_details_json": "{\"entrypoints\":[\"https://www.reuters.com/business/\"]}",
+                    "created_from_run_id": None,
+                    "created_at": "2026-04-04T00:05:00Z",
+                    "approved_at": "2026-04-04T00:06:00Z",
+                }
+            )
+            store.upsert_operator_state(
+                {
+                    "source_id": "wsj_markets",
+                    "is_active": 1,
+                    "strategy_state": "missing",
+                    "current_strategy_id": None,
+                    "latest_strategy_id": None,
+                    "last_onboarding_run_id": None,
+                    "last_collection_status": "idle",
+                    "last_collection_started_at": None,
+                    "last_collection_finished_at": None,
+                    "last_collection_error": None,
+                    "activated_at": "2026-04-04T00:00:00Z",
+                    "deactivated_at": None,
+                    "updated_at": "2026-04-04T00:00:00Z",
+                }
+            )
+
+            resolved = load_resolved_sources(base_dir=base_dir, registry_path=registry_path)
+            eligible = [item for item in resolved if item["runtime_eligible"]]
+
+            self.assertEqual([item["source_id"] for item in eligible], ["reuters_business"])
+            self.assertEqual(eligible[0]["current_strategy"]["strategy_id"], "strat_reuters_001")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements `#216` on top of the `#215` control-plane foundation.

Included in this PR:
- add a resolved-source service that joins:
  - file-based source contract
  - source operator state
  - approved strategy state
- add runtime eligibility logic for sources that are:
  - active
  - strategy-ready
  - pointing at an approved current strategy
- extend source contract typing with forward-compatible fields from `#210`
- add a helper path in `source_scope.py` for runtime-eligible resolved sources
- add focused runtime tests for resolved-source behavior

Stacking note:
- base branch is `issue-215-source-control-plane`
- review this PR commit-for-commit on top of `#215`

## Issues

- Parent: `#214`
- Depends on: `#215`
- This PR implements: `#216`

## Verification

- `python -m unittest tests.agent.runtime.test_resolved_sources tests.agent.runtime.test_source_scope -v`
- `python -m compileall -q apps tests tools scripts`
- `python scripts/validate_artifacts.py`
- `python scripts/validate_decision_record_schema.py`
