### PR TITLE
feat: add resolved source service and runtime eligibility

### DIFF
--- a/apps/agent/pipeline/types.py
+++ b/apps/agent/pipeline/types.py
@@ -214,6 +214,16 @@ class SourceOnboardingRunRow(TypedDict):
     result_summary_json: str | None
 
 
+class ResolvedSource(TypedDict):
+    source_id: str
+    contract: SourceRegistryEntry
+    operator_state: SourceOperatorStateRow
+    current_strategy: SourceStrategyVersionRow | None
+    latest_strategy: SourceStrategyVersionRow | None
+    latest_onboarding_run: SourceOnboardingRunRow | None
+    runtime_eligible: bool
+
+
 class RuntimeDocumentRecord(TypedDict):
     source_id: str
     publisher: str

--- a/apps/agent/runtime/resolved_sources.py
+++ b/apps/agent/runtime/resolved_sources.py
@@ -166,6 +166,9 @@ def _default_content_mode(source: SourceRegistryEntry) -> str:
     tags = {str(tag) for tag in source.get("tags", [])}
     if "event_calendar" in tags:
         return "calendar_event"
+    # Metadata-only sources stay snippet-oriented even when transported via RSS.
+    # This keeps downstream handling aligned with paywall constraints instead of
+    # implying full feed-index semantics from the transport alone.
     if str(source.get("paywall_policy", "")) == "metadata_only":
         return "snippet_only"
     if source_type == "pdf":

--- a/apps/agent/runtime/resolved_sources.py
+++ b/apps/agent/runtime/resolved_sources.py
@@ -5,9 +5,16 @@ from typing import cast
 
 from apps.agent.pipeline.types import (
     ResolvedSource,
+    SourceCollectionStatus,
+    SourceContentMode,
+    SourceFetchVia,
     SourceOperatorStateRow,
     SourceRegistryEntry,
+    SourceRole,
+    SourceStrategyState,
+    SourceStrategyStatus,
     SourceStrategyVersionRow,
+    SourceTimestampAuthority,
 )
 from apps.agent.runtime.source_scope import load_source_registry
 from apps.agent.storage.source_control_plane import SourceControlPlaneStore
@@ -86,11 +93,11 @@ def _default_operator_state(source_id: str) -> SourceOperatorStateRow:
     return SourceOperatorStateRow(
         source_id=source_id,
         is_active=0,
-        strategy_state="missing",
+        strategy_state=SourceStrategyState.MISSING,
         current_strategy_id=None,
         latest_strategy_id=None,
         last_onboarding_run_id=None,
-        last_collection_status="idle",
+        last_collection_status=SourceCollectionStatus.IDLE,
         last_collection_started_at=None,
         last_collection_finished_at=None,
         last_collection_error=None,
@@ -121,10 +128,10 @@ def _is_runtime_eligible(
 ) -> bool:
     return (
         bool(operator_state["is_active"])
-        and operator_state["strategy_state"] == "ready"
+        and operator_state["strategy_state"] == SourceStrategyState.READY
         and operator_state["current_strategy_id"] is not None
         and current_strategy is not None
-        and current_strategy["strategy_status"] == "approved"
+        and current_strategy["strategy_status"] == SourceStrategyStatus.APPROVED
     )
 
 
@@ -137,44 +144,44 @@ def _with_contract_fallbacks(source: SourceRegistryEntry) -> SourceRegistryEntry
     return cast(SourceRegistryEntry, normalized)
 
 
-def _default_fetch_via(source_type: str) -> str:
+def _default_fetch_via(source_type: str) -> SourceFetchVia:
     if source_type == "rss":
-        return "direct_rss"
+        return SourceFetchVia.DIRECT_RSS
     if source_type == "html":
-        return "direct_html"
+        return SourceFetchVia.DIRECT_HTML
     if source_type == "pdf":
-        return "direct_pdf"
-    return "hybrid"
+        return SourceFetchVia.DIRECT_PDF
+    return SourceFetchVia.HYBRID
 
 
-def _default_source_role(source: SourceRegistryEntry) -> str:
+def _default_source_role(source: SourceRegistryEntry) -> SourceRole:
     credibility_tier = int(source.get("credibility_tier", 4))
     if credibility_tier >= 4:
-        return "monitor_only"
-    return "supplementary"
+        return SourceRole.MONITOR_ONLY
+    return SourceRole.SUPPLEMENTARY
 
 
-def _default_timestamp_authority(source: SourceRegistryEntry) -> str:
+def _default_timestamp_authority(source: SourceRegistryEntry) -> SourceTimestampAuthority:
     source_type = str(source["type"])
     if source_type == "rss":
-        return "feed_timestamp"
-    return "retrieval_time_only"
+        return SourceTimestampAuthority.FEED_TIMESTAMP
+    return SourceTimestampAuthority.RETRIEVAL_TIME_ONLY
 
 
-def _default_content_mode(source: SourceRegistryEntry) -> str:
+def _default_content_mode(source: SourceRegistryEntry) -> SourceContentMode:
     source_type = str(source["type"])
     tags = {str(tag) for tag in source.get("tags", [])}
     if "event_calendar" in tags:
-        return "calendar_event"
+        return SourceContentMode.CALENDAR_EVENT
     # Metadata-only sources stay snippet-oriented even when transported via RSS.
     # This keeps downstream handling aligned with paywall constraints instead of
     # implying full feed-index semantics from the transport alone.
     if str(source.get("paywall_policy", "")) == "metadata_only":
-        return "snippet_only"
+        return SourceContentMode.SNIPPET_ONLY
     if source_type == "pdf":
-        return "article_full_text"
+        return SourceContentMode.ARTICLE_FULL_TEXT
     if source_type == "rss":
-        return "feed_index"
+        return SourceContentMode.FEED_INDEX
     if source_type == "api":
-        return "structured_data"
-    return "listing_page"
+        return SourceContentMode.STRUCTURED_DATA
+    return SourceContentMode.LISTING_PAGE

--- a/apps/agent/runtime/resolved_sources.py
+++ b/apps/agent/runtime/resolved_sources.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from apps.agent.pipeline.types import (
+    ResolvedSource,
+    SourceOnboardingRunRow,
+    SourceOperatorStateRow,
+    SourceRegistryEntry,
+    SourceStrategyVersionRow,
+)
+from apps.agent.runtime.source_scope import load_source_registry
+from apps.agent.storage.source_control_plane import SourceControlPlaneStore
+
+
+def load_resolved_sources(
+    *,
+    base_dir: Path,
+    registry_path: Path | None = None,
+) -> list[ResolvedSource]:
+    registry = load_source_registry(registry_path=registry_path)
+    store = SourceControlPlaneStore(base_dir=base_dir)
+
+    resolved: list[ResolvedSource] = []
+    for source_id, contract in registry.items():
+        operator_state = store.get_operator_state(source_id) or _default_operator_state(source_id)
+        strategies = store.list_strategy_versions(source_id)
+        onboarding_runs = store.list_onboarding_runs(source_id)
+        current_strategy = _pick_current_strategy(operator_state=operator_state, strategies=strategies)
+        latest_strategy = strategies[0] if strategies else None
+        latest_onboarding_run = onboarding_runs[0] if onboarding_runs else None
+        resolved.append(
+            ResolvedSource(
+                source_id=source_id,
+                contract=_with_contract_fallbacks(contract),
+                operator_state=operator_state,
+                current_strategy=current_strategy,
+                latest_strategy=latest_strategy,
+                latest_onboarding_run=latest_onboarding_run,
+                runtime_eligible=_is_runtime_eligible(
+                    operator_state=operator_state,
+                    current_strategy=current_strategy,
+                ),
+            )
+        )
+    return resolved
+
+
+def get_resolved_source(
+    source_id: str,
+    *,
+    base_dir: Path,
+    registry_path: Path | None = None,
+) -> ResolvedSource:
+    for source in load_resolved_sources(base_dir=base_dir, registry_path=registry_path):
+        if source["source_id"] == source_id:
+            return source
+    raise ValueError(f"Unknown source id: {source_id}")
+
+
+def _default_operator_state(source_id: str) -> SourceOperatorStateRow:
+    return SourceOperatorStateRow(
+        source_id=source_id,
+        is_active=0,
+        strategy_state="missing",
+        current_strategy_id=None,
+        latest_strategy_id=None,
+        last_onboarding_run_id=None,
+        last_collection_status="idle",
+        last_collection_started_at=None,
+        last_collection_finished_at=None,
+        last_collection_error=None,
+        activated_at=None,
+        deactivated_at=None,
+        updated_at="",
+    )
+
+
+def _pick_current_strategy(
+    *,
+    operator_state: SourceOperatorStateRow,
+    strategies: list[SourceStrategyVersionRow],
+) -> SourceStrategyVersionRow | None:
+    current_strategy_id = operator_state["current_strategy_id"]
+    if current_strategy_id is None:
+        return None
+    for strategy in strategies:
+        if strategy["strategy_id"] == current_strategy_id:
+            return strategy
+    return None
+
+
+def _is_runtime_eligible(
+    *,
+    operator_state: SourceOperatorStateRow,
+    current_strategy: SourceStrategyVersionRow | None,
+) -> bool:
+    return (
+        bool(operator_state["is_active"])
+        and operator_state["strategy_state"] == "ready"
+        and operator_state["current_strategy_id"] is not None
+        and current_strategy is not None
+        and current_strategy["strategy_status"] == "approved"
+    )
+
+
+def _with_contract_fallbacks(source: SourceRegistryEntry) -> SourceRegistryEntry:
+    normalized = dict(source)
+    normalized.setdefault("fetch_via", _default_fetch_via(str(source["type"])))
+    normalized.setdefault("source_role", "authoritative")
+    normalized.setdefault("timestamp_authority", "source_page")
+    normalized.setdefault("content_mode", _default_content_mode(str(source["type"])))
+    return cast(SourceRegistryEntry, normalized)
+
+
+def _default_fetch_via(source_type: str) -> str:
+    if source_type == "rss":
+        return "direct_rss"
+    if source_type == "html":
+        return "direct_html"
+    if source_type == "pdf":
+        return "direct_pdf"
+    return "hybrid"
+
+
+def _default_content_mode(source_type: str) -> str:
+    if source_type == "pdf":
+        return "article_full_text"
+    if source_type == "rss":
+        return "feed_index"
+    return "article_full_text"

--- a/apps/agent/runtime/resolved_sources.py
+++ b/apps/agent/runtime/resolved_sources.py
@@ -21,12 +21,16 @@ def load_resolved_sources(
 ) -> list[ResolvedSource]:
     registry = load_source_registry(registry_path=registry_path)
     store = SourceControlPlaneStore(base_dir=base_dir)
+    source_ids = list(registry.keys())
+    operator_states = {row["source_id"]: row for row in store.list_operator_states()}
+    strategies_by_source = store.list_strategy_versions_by_source_ids(source_ids)
+    onboarding_runs_by_source = store.list_onboarding_runs_by_source_ids(source_ids)
 
     resolved: list[ResolvedSource] = []
     for source_id, contract in registry.items():
-        operator_state = store.get_operator_state(source_id) or _default_operator_state(source_id)
-        strategies = store.list_strategy_versions(source_id)
-        onboarding_runs = store.list_onboarding_runs(source_id)
+        operator_state = operator_states.get(source_id) or _default_operator_state(source_id)
+        strategies = strategies_by_source.get(source_id, [])
+        onboarding_runs = onboarding_runs_by_source.get(source_id, [])
         current_strategy = _pick_current_strategy(operator_state=operator_state, strategies=strategies)
         latest_strategy = strategies[0] if strategies else None
         latest_onboarding_run = onboarding_runs[0] if onboarding_runs else None
@@ -108,9 +112,9 @@ def _is_runtime_eligible(
 def _with_contract_fallbacks(source: SourceRegistryEntry) -> SourceRegistryEntry:
     normalized = dict(source)
     normalized.setdefault("fetch_via", _default_fetch_via(str(source["type"])))
-    normalized.setdefault("source_role", "authoritative")
-    normalized.setdefault("timestamp_authority", "source_page")
-    normalized.setdefault("content_mode", _default_content_mode(str(source["type"])))
+    normalized.setdefault("source_role", _default_source_role(source))
+    normalized.setdefault("timestamp_authority", _default_timestamp_authority(source))
+    normalized.setdefault("content_mode", _default_content_mode(source))
     return cast(SourceRegistryEntry, normalized)
 
 
@@ -124,9 +128,31 @@ def _default_fetch_via(source_type: str) -> str:
     return "hybrid"
 
 
-def _default_content_mode(source_type: str) -> str:
+def _default_source_role(source: SourceRegistryEntry) -> str:
+    credibility_tier = int(source.get("credibility_tier", 4))
+    if credibility_tier >= 4:
+        return "monitor_only"
+    return "supplementary"
+
+
+def _default_timestamp_authority(source: SourceRegistryEntry) -> str:
+    source_type = str(source["type"])
+    if source_type == "rss":
+        return "feed_timestamp"
+    return "retrieval_time_only"
+
+
+def _default_content_mode(source: SourceRegistryEntry) -> str:
+    source_type = str(source["type"])
+    tags = {str(tag) for tag in source.get("tags", [])}
+    if "event_calendar" in tags:
+        return "calendar_event"
+    if str(source.get("paywall_policy", "")) == "metadata_only":
+        return "snippet_only"
     if source_type == "pdf":
         return "article_full_text"
     if source_type == "rss":
         return "feed_index"
-    return "article_full_text"
+    if source_type == "api":
+        return "structured_data"
+    return "listing_page"

--- a/apps/agent/runtime/resolved_sources.py
+++ b/apps/agent/runtime/resolved_sources.py
@@ -5,7 +5,6 @@ from typing import cast
 
 from apps.agent.pipeline.types import (
     ResolvedSource,
-    SourceOnboardingRunRow,
     SourceOperatorStateRow,
     SourceRegistryEntry,
     SourceStrategyVersionRow,

--- a/apps/agent/runtime/resolved_sources.py
+++ b/apps/agent/runtime/resolved_sources.py
@@ -57,10 +57,30 @@ def get_resolved_source(
     base_dir: Path,
     registry_path: Path | None = None,
 ) -> ResolvedSource:
-    for source in load_resolved_sources(base_dir=base_dir, registry_path=registry_path):
-        if source["source_id"] == source_id:
-            return source
-    raise ValueError(f"Unknown source id: {source_id}")
+    registry = load_source_registry(registry_path=registry_path)
+    contract = registry.get(source_id)
+    if contract is None:
+        raise ValueError(f"Unknown source id: {source_id}")
+
+    store = SourceControlPlaneStore(base_dir=base_dir)
+    operator_state = store.get_operator_state(source_id) or _default_operator_state(source_id)
+    strategies = store.list_strategy_versions(source_id)
+    onboarding_runs = store.list_onboarding_runs(source_id)
+    current_strategy = _pick_current_strategy(operator_state=operator_state, strategies=strategies)
+    latest_strategy = strategies[0] if strategies else None
+    latest_onboarding_run = onboarding_runs[0] if onboarding_runs else None
+    return ResolvedSource(
+        source_id=source_id,
+        contract=_with_contract_fallbacks(contract),
+        operator_state=operator_state,
+        current_strategy=current_strategy,
+        latest_strategy=latest_strategy,
+        latest_onboarding_run=latest_onboarding_run,
+        runtime_eligible=_is_runtime_eligible(
+            operator_state=operator_state,
+            current_strategy=current_strategy,
+        ),
+    )
 
 
 def _default_operator_state(source_id: str) -> SourceOperatorStateRow:
@@ -77,7 +97,7 @@ def _default_operator_state(source_id: str) -> SourceOperatorStateRow:
         last_collection_error=None,
         activated_at=None,
         deactivated_at=None,
-        updated_at="",
+        updated_at=None,
     )
 
 

--- a/apps/agent/runtime/source_scope.py
+++ b/apps/agent/runtime/source_scope.py
@@ -8,6 +8,7 @@ from typing import Any, TypeVar, cast
 import yaml  # type: ignore[import-untyped,unused-ignore]
 
 from apps.agent.pipeline.types import (
+    ResolvedSource,
     SourceContentMode,
     SourceFetchVia,
     SourceRegistryEntry,
@@ -93,3 +94,17 @@ def _normalize_optional_enum_field(
         raise ValueError(
             f"Invalid {field_name!r} value {value!r} for source {source_id!r}"
         ) from None
+
+
+def load_runtime_eligible_sources(
+    *,
+    base_dir: Path,
+    registry_path: Path | None = None,
+) -> list[ResolvedSource]:
+    from apps.agent.runtime.resolved_sources import load_resolved_sources
+
+    return [
+        source
+        for source in load_resolved_sources(base_dir=base_dir, registry_path=registry_path)
+        if source["runtime_eligible"]
+    ]

--- a/docs/plans/2026-04-04-issue-214-source-ops-dashboard-implementation-plan.md
+++ b/docs/plans/2026-04-04-issue-214-source-ops-dashboard-implementation-plan.md
@@ -215,6 +215,8 @@ runtime_eligible = (
     bool(operator_state["is_active"])
     and operator_state["strategy_state"] == "ready"
     and operator_state["current_strategy_id"] is not None
+    and current_strategy is not None
+    and current_strategy["strategy_status"] == "approved"
 )
 ```
 

--- a/tests/agent/runtime/test_resolved_sources.py
+++ b/tests/agent/runtime/test_resolved_sources.py
@@ -106,6 +106,68 @@ class ResolvedSourcesTests(unittest.TestCase):
             self.assertEqual([item["source_id"] for item in eligible], ["reuters_business"])
             self.assertEqual(eligible[0]["current_strategy"]["strategy_id"], "strat_reuters_001")
 
+    def test_fallback_contract_semantics_remain_conservative_for_unannotated_sources(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            registry_path = base_dir / "registry.yaml"
+            registry_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "sources": [
+                            {
+                                "id": "zerohedge",
+                                "name": "Zero Hedge - Markets",
+                                "url": "https://www.zerohedge.com/s/RSS",
+                                "type": "rss",
+                                "credibility_tier": 4,
+                                "paywall_policy": "full",
+                                "fetch_interval": "daily",
+                                "tags": ["market_narrative", "contrarian"],
+                            },
+                            {
+                                "id": "us_bls_schedule",
+                                "name": "U.S. Bureau of Labor Statistics - Economic Release Schedule",
+                                "url": "https://www.bls.gov/schedule/news_release/",
+                                "type": "html",
+                                "credibility_tier": 1,
+                                "paywall_policy": "full",
+                                "fetch_interval": "weekly",
+                                "tags": ["macro_data", "event_calendar", "us"],
+                            },
+                            {
+                                "id": "seekingalpha_news",
+                                "name": "Seeking Alpha - Market News",
+                                "url": "https://seekingalpha.com/market-news",
+                                "type": "html",
+                                "credibility_tier": 4,
+                                "paywall_policy": "metadata_only",
+                                "fetch_interval": "daily",
+                                "tags": ["market_narrative", "equity_risk"],
+                            },
+                        ]
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            resolved = {
+                item["source_id"]: item
+                for item in load_resolved_sources(base_dir=base_dir, registry_path=registry_path)
+            }
+
+            self.assertEqual(resolved["zerohedge"]["contract"]["source_role"], "monitor_only")
+            self.assertEqual(resolved["zerohedge"]["contract"]["timestamp_authority"], "feed_timestamp")
+            self.assertEqual(resolved["zerohedge"]["contract"]["content_mode"], "feed_index")
+
+            self.assertEqual(resolved["us_bls_schedule"]["contract"]["source_role"], "supplementary")
+            self.assertEqual(resolved["us_bls_schedule"]["contract"]["timestamp_authority"], "retrieval_time_only")
+            self.assertEqual(resolved["us_bls_schedule"]["contract"]["content_mode"], "calendar_event")
+
+            self.assertEqual(resolved["seekingalpha_news"]["contract"]["source_role"], "monitor_only")
+            self.assertEqual(resolved["seekingalpha_news"]["contract"]["timestamp_authority"], "retrieval_time_only")
+            self.assertEqual(resolved["seekingalpha_news"]["contract"]["content_mode"], "snippet_only")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/agent/runtime/test_resolved_sources.py
+++ b/tests/agent/runtime/test_resolved_sources.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from apps.agent.runtime.resolved_sources import load_resolved_sources
+from apps.agent.storage.source_control_plane import SourceControlPlaneStore
+
+
+class ResolvedSourcesTests(unittest.TestCase):
+    def test_marks_only_active_ready_sources_as_runtime_eligible(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            registry_path = base_dir / "registry.yaml"
+            registry_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "sources": [
+                            {
+                                "id": "reuters_business",
+                                "name": "Reuters - Business News",
+                                "url": "https://www.reuters.com/business/",
+                                "type": "rss",
+                                "credibility_tier": 2,
+                                "paywall_policy": "full",
+                                "fetch_interval": "daily",
+                                "tags": ["market_narrative", "us"],
+                            },
+                            {
+                                "id": "wsj_markets",
+                                "name": "Wall Street Journal - Markets",
+                                "url": "https://feeds.a.dj.com/rss/RSSMarketsMain.xml",
+                                "type": "rss",
+                                "credibility_tier": 2,
+                                "paywall_policy": "metadata_only",
+                                "fetch_interval": "daily",
+                                "tags": ["market_narrative", "us"],
+                            },
+                        ]
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            store = SourceControlPlaneStore(base_dir=base_dir)
+            store.upsert_operator_state(
+                {
+                    "source_id": "reuters_business",
+                    "is_active": 1,
+                    "strategy_state": "ready",
+                    "current_strategy_id": "strat_reuters_001",
+                    "latest_strategy_id": "strat_reuters_001",
+                    "last_onboarding_run_id": None,
+                    "last_collection_status": "idle",
+                    "last_collection_started_at": None,
+                    "last_collection_finished_at": None,
+                    "last_collection_error": None,
+                    "activated_at": "2026-04-04T00:00:00Z",
+                    "deactivated_at": None,
+                    "updated_at": "2026-04-04T00:00:00Z",
+                }
+            )
+            store.insert_strategy_version(
+                {
+                    "strategy_id": "strat_reuters_001",
+                    "source_id": "reuters_business",
+                    "version": 1,
+                    "strategy_status": "approved",
+                    "entrypoint_url": "https://www.reuters.com/business/",
+                    "fetch_via": "direct_rss",
+                    "content_mode": "article_full_text",
+                    "parser_profile": None,
+                    "max_items_per_run": 25,
+                    "strategy_summary_json": "{\"headline\":\"business feed\"}",
+                    "strategy_details_json": "{\"entrypoints\":[\"https://www.reuters.com/business/\"]}",
+                    "created_from_run_id": None,
+                    "created_at": "2026-04-04T00:05:00Z",
+                    "approved_at": "2026-04-04T00:06:00Z",
+                }
+            )
+            store.upsert_operator_state(
+                {
+                    "source_id": "wsj_markets",
+                    "is_active": 1,
+                    "strategy_state": "missing",
+                    "current_strategy_id": None,
+                    "latest_strategy_id": None,
+                    "last_onboarding_run_id": None,
+                    "last_collection_status": "idle",
+                    "last_collection_started_at": None,
+                    "last_collection_finished_at": None,
+                    "last_collection_error": None,
+                    "activated_at": "2026-04-04T00:00:00Z",
+                    "deactivated_at": None,
+                    "updated_at": "2026-04-04T00:00:00Z",
+                }
+            )
+
+            resolved = load_resolved_sources(base_dir=base_dir, registry_path=registry_path)
+            eligible = [item for item in resolved if item["runtime_eligible"]]
+
+            self.assertEqual([item["source_id"] for item in eligible], ["reuters_business"])
+            self.assertEqual(eligible[0]["current_strategy"]["strategy_id"], "strat_reuters_001")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/runtime/test_resolved_sources.py
+++ b/tests/agent/runtime/test_resolved_sources.py
@@ -6,6 +6,15 @@ from tempfile import TemporaryDirectory
 
 import yaml
 
+from apps.agent.pipeline.types import (
+    SourceCollectionStatus,
+    SourceContentMode,
+    SourceFetchVia,
+    SourceRole,
+    SourceStrategyState,
+    SourceStrategyStatus,
+    SourceTimestampAuthority,
+)
 from apps.agent.runtime.resolved_sources import get_resolved_source, load_resolved_sources
 from apps.agent.storage.source_control_plane import SourceControlPlaneStore
 
@@ -51,11 +60,11 @@ class ResolvedSourcesTests(unittest.TestCase):
                 {
                     "source_id": "reuters_business",
                     "is_active": 1,
-                    "strategy_state": "ready",
+                    "strategy_state": SourceStrategyState.READY,
                     "current_strategy_id": "strat_reuters_001",
                     "latest_strategy_id": "strat_reuters_001",
                     "last_onboarding_run_id": None,
-                    "last_collection_status": "idle",
+                    "last_collection_status": SourceCollectionStatus.IDLE,
                     "last_collection_started_at": None,
                     "last_collection_finished_at": None,
                     "last_collection_error": None,
@@ -69,10 +78,10 @@ class ResolvedSourcesTests(unittest.TestCase):
                     "strategy_id": "strat_reuters_001",
                     "source_id": "reuters_business",
                     "version": 1,
-                    "strategy_status": "approved",
+                    "strategy_status": SourceStrategyStatus.APPROVED,
                     "entrypoint_url": "https://www.reuters.com/business/",
-                    "fetch_via": "direct_rss",
-                    "content_mode": "article_full_text",
+                    "fetch_via": SourceFetchVia.DIRECT_RSS,
+                    "content_mode": SourceContentMode.ARTICLE_FULL_TEXT,
                     "parser_profile": None,
                     "max_items_per_run": 25,
                     "strategy_summary_json": "{\"headline\":\"business feed\"}",
@@ -86,11 +95,11 @@ class ResolvedSourcesTests(unittest.TestCase):
                 {
                     "source_id": "wsj_markets",
                     "is_active": 1,
-                    "strategy_state": "missing",
+                    "strategy_state": SourceStrategyState.MISSING,
                     "current_strategy_id": None,
                     "latest_strategy_id": None,
                     "last_onboarding_run_id": None,
-                    "last_collection_status": "idle",
+                    "last_collection_status": SourceCollectionStatus.IDLE,
                     "last_collection_started_at": None,
                     "last_collection_finished_at": None,
                     "last_collection_error": None,
@@ -166,25 +175,67 @@ class ResolvedSourcesTests(unittest.TestCase):
                 for item in load_resolved_sources(base_dir=base_dir, registry_path=registry_path)
             }
 
-            self.assertEqual(resolved["zerohedge"]["contract"]["source_role"], "monitor_only")
-            self.assertEqual(resolved["zerohedge"]["contract"]["fetch_via"], "direct_rss")
-            self.assertEqual(resolved["zerohedge"]["contract"]["timestamp_authority"], "feed_timestamp")
-            self.assertEqual(resolved["zerohedge"]["contract"]["content_mode"], "feed_index")
+            self.assertEqual(resolved["zerohedge"]["contract"]["source_role"], SourceRole.MONITOR_ONLY)
+            self.assertEqual(resolved["zerohedge"]["contract"]["fetch_via"], SourceFetchVia.DIRECT_RSS)
+            self.assertEqual(
+                resolved["zerohedge"]["contract"]["timestamp_authority"],
+                SourceTimestampAuthority.FEED_TIMESTAMP,
+            )
+            self.assertEqual(
+                resolved["zerohedge"]["contract"]["content_mode"],
+                SourceContentMode.FEED_INDEX,
+            )
 
-            self.assertEqual(resolved["us_bls_schedule"]["contract"]["source_role"], "supplementary")
-            self.assertEqual(resolved["us_bls_schedule"]["contract"]["fetch_via"], "direct_html")
-            self.assertEqual(resolved["us_bls_schedule"]["contract"]["timestamp_authority"], "retrieval_time_only")
-            self.assertEqual(resolved["us_bls_schedule"]["contract"]["content_mode"], "calendar_event")
+            self.assertEqual(
+                resolved["us_bls_schedule"]["contract"]["source_role"],
+                SourceRole.SUPPLEMENTARY,
+            )
+            self.assertEqual(
+                resolved["us_bls_schedule"]["contract"]["fetch_via"],
+                SourceFetchVia.DIRECT_HTML,
+            )
+            self.assertEqual(
+                resolved["us_bls_schedule"]["contract"]["timestamp_authority"],
+                SourceTimestampAuthority.RETRIEVAL_TIME_ONLY,
+            )
+            self.assertEqual(
+                resolved["us_bls_schedule"]["contract"]["content_mode"],
+                SourceContentMode.CALENDAR_EVENT,
+            )
 
-            self.assertEqual(resolved["seekingalpha_news"]["contract"]["source_role"], "monitor_only")
-            self.assertEqual(resolved["seekingalpha_news"]["contract"]["fetch_via"], "direct_html")
-            self.assertEqual(resolved["seekingalpha_news"]["contract"]["timestamp_authority"], "retrieval_time_only")
-            self.assertEqual(resolved["seekingalpha_news"]["contract"]["content_mode"], "snippet_only")
+            self.assertEqual(
+                resolved["seekingalpha_news"]["contract"]["source_role"],
+                SourceRole.MONITOR_ONLY,
+            )
+            self.assertEqual(
+                resolved["seekingalpha_news"]["contract"]["fetch_via"],
+                SourceFetchVia.DIRECT_HTML,
+            )
+            self.assertEqual(
+                resolved["seekingalpha_news"]["contract"]["timestamp_authority"],
+                SourceTimestampAuthority.RETRIEVAL_TIME_ONLY,
+            )
+            self.assertEqual(
+                resolved["seekingalpha_news"]["contract"]["content_mode"],
+                SourceContentMode.SNIPPET_ONLY,
+            )
 
-            self.assertEqual(resolved["wsj_markets"]["contract"]["source_role"], "supplementary")
-            self.assertEqual(resolved["wsj_markets"]["contract"]["fetch_via"], "direct_rss")
-            self.assertEqual(resolved["wsj_markets"]["contract"]["timestamp_authority"], "feed_timestamp")
-            self.assertEqual(resolved["wsj_markets"]["contract"]["content_mode"], "snippet_only")
+            self.assertEqual(
+                resolved["wsj_markets"]["contract"]["source_role"],
+                SourceRole.SUPPLEMENTARY,
+            )
+            self.assertEqual(
+                resolved["wsj_markets"]["contract"]["fetch_via"],
+                SourceFetchVia.DIRECT_RSS,
+            )
+            self.assertEqual(
+                resolved["wsj_markets"]["contract"]["timestamp_authority"],
+                SourceTimestampAuthority.FEED_TIMESTAMP,
+            )
+            self.assertEqual(
+                resolved["wsj_markets"]["contract"]["content_mode"],
+                SourceContentMode.SNIPPET_ONLY,
+            )
 
     def test_get_resolved_source_returns_none_for_missing_current_strategy_pointer(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -215,11 +266,11 @@ class ResolvedSourcesTests(unittest.TestCase):
                 {
                     "source_id": "reuters_business",
                     "is_active": 1,
-                    "strategy_state": "ready",
+                    "strategy_state": SourceStrategyState.READY,
                     "current_strategy_id": "strat_missing",
                     "latest_strategy_id": None,
                     "last_onboarding_run_id": None,
-                    "last_collection_status": "idle",
+                    "last_collection_status": SourceCollectionStatus.IDLE,
                     "last_collection_started_at": None,
                     "last_collection_finished_at": None,
                     "last_collection_error": None,

--- a/tests/agent/runtime/test_resolved_sources.py
+++ b/tests/agent/runtime/test_resolved_sources.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 
 import yaml
 
-from apps.agent.runtime.resolved_sources import load_resolved_sources
+from apps.agent.runtime.resolved_sources import get_resolved_source, load_resolved_sources
 from apps.agent.storage.source_control_plane import SourceControlPlaneStore
 
 
@@ -144,6 +144,16 @@ class ResolvedSourcesTests(unittest.TestCase):
                                 "fetch_interval": "daily",
                                 "tags": ["market_narrative", "equity_risk"],
                             },
+                            {
+                                "id": "wsj_markets",
+                                "name": "Wall Street Journal - Markets",
+                                "url": "https://feeds.a.dj.com/rss/RSSMarketsMain.xml",
+                                "type": "rss",
+                                "credibility_tier": 2,
+                                "paywall_policy": "metadata_only",
+                                "fetch_interval": "daily",
+                                "tags": ["market_narrative", "us"],
+                            },
                         ]
                     },
                     sort_keys=False,
@@ -170,6 +180,11 @@ class ResolvedSourcesTests(unittest.TestCase):
             self.assertEqual(resolved["seekingalpha_news"]["contract"]["fetch_via"], "direct_html")
             self.assertEqual(resolved["seekingalpha_news"]["contract"]["timestamp_authority"], "retrieval_time_only")
             self.assertEqual(resolved["seekingalpha_news"]["contract"]["content_mode"], "snippet_only")
+
+            self.assertEqual(resolved["wsj_markets"]["contract"]["source_role"], "supplementary")
+            self.assertEqual(resolved["wsj_markets"]["contract"]["fetch_via"], "direct_rss")
+            self.assertEqual(resolved["wsj_markets"]["contract"]["timestamp_authority"], "feed_timestamp")
+            self.assertEqual(resolved["wsj_markets"]["contract"]["content_mode"], "snippet_only")
 
     def test_get_resolved_source_returns_none_for_missing_current_strategy_pointer(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -213,8 +228,6 @@ class ResolvedSourcesTests(unittest.TestCase):
                     "updated_at": "2026-04-04T00:00:00Z",
                 }
             )
-
-            from apps.agent.runtime.resolved_sources import get_resolved_source
 
             resolved = get_resolved_source(
                 "reuters_business",

--- a/tests/agent/runtime/test_resolved_sources.py
+++ b/tests/agent/runtime/test_resolved_sources.py
@@ -157,16 +157,73 @@ class ResolvedSourcesTests(unittest.TestCase):
             }
 
             self.assertEqual(resolved["zerohedge"]["contract"]["source_role"], "monitor_only")
+            self.assertEqual(resolved["zerohedge"]["contract"]["fetch_via"], "direct_rss")
             self.assertEqual(resolved["zerohedge"]["contract"]["timestamp_authority"], "feed_timestamp")
             self.assertEqual(resolved["zerohedge"]["contract"]["content_mode"], "feed_index")
 
             self.assertEqual(resolved["us_bls_schedule"]["contract"]["source_role"], "supplementary")
+            self.assertEqual(resolved["us_bls_schedule"]["contract"]["fetch_via"], "direct_html")
             self.assertEqual(resolved["us_bls_schedule"]["contract"]["timestamp_authority"], "retrieval_time_only")
             self.assertEqual(resolved["us_bls_schedule"]["contract"]["content_mode"], "calendar_event")
 
             self.assertEqual(resolved["seekingalpha_news"]["contract"]["source_role"], "monitor_only")
+            self.assertEqual(resolved["seekingalpha_news"]["contract"]["fetch_via"], "direct_html")
             self.assertEqual(resolved["seekingalpha_news"]["contract"]["timestamp_authority"], "retrieval_time_only")
             self.assertEqual(resolved["seekingalpha_news"]["contract"]["content_mode"], "snippet_only")
+
+    def test_get_resolved_source_returns_none_for_missing_current_strategy_pointer(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            registry_path = base_dir / "registry.yaml"
+            registry_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "sources": [
+                            {
+                                "id": "reuters_business",
+                                "name": "Reuters - Business News",
+                                "url": "https://www.reuters.com/business/",
+                                "type": "rss",
+                                "credibility_tier": 2,
+                                "paywall_policy": "full",
+                                "fetch_interval": "daily",
+                            }
+                        ]
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            store = SourceControlPlaneStore(base_dir=base_dir)
+            store.upsert_operator_state(
+                {
+                    "source_id": "reuters_business",
+                    "is_active": 1,
+                    "strategy_state": "ready",
+                    "current_strategy_id": "strat_missing",
+                    "latest_strategy_id": None,
+                    "last_onboarding_run_id": None,
+                    "last_collection_status": "idle",
+                    "last_collection_started_at": None,
+                    "last_collection_finished_at": None,
+                    "last_collection_error": None,
+                    "activated_at": "2026-04-04T00:00:00Z",
+                    "deactivated_at": None,
+                    "updated_at": "2026-04-04T00:00:00Z",
+                }
+            )
+
+            from apps.agent.runtime.resolved_sources import get_resolved_source
+
+            resolved = get_resolved_source(
+                "reuters_business",
+                base_dir=base_dir,
+                registry_path=registry_path,
+            )
+
+            self.assertIsNone(resolved["current_strategy"])
+            self.assertFalse(resolved["runtime_eligible"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Replacement stacked PR for `#216` after follow-up review fixes.

Included in this PR:
- add conservative fallback semantics for unresolved source-contract fields
- avoid silently upgrading unannotated sources to authoritative semantics
- add a direct `get_resolved_source(...)` lookup path instead of scanning all resolved sources
- keep batch assembly in `load_resolved_sources(...)`
- add regression tests for:
  - conservative fallback defaults
  - missing current-strategy pointer
  - explicit fallback `fetch_via` expectations
- update the implementation plan doc so runtime eligibility matches the live code

Stacking note:
- base branch is `issue-215-source-control-plane`
- this PR supersedes the now-closed `#223`

## Issues

- Parent: `#214`
- Depends on: `#215`
- This PR implements: `#216`
- Supersedes: `#223`

## Verification

- `python -m unittest tests.agent.storage.test_source_control_plane tests.agent.runtime.test_resolved_sources tests.agent.runtime.test_source_scope -v`
- `python -m compileall -q apps tests tools scripts`
- `python scripts/validate_artifacts.py`
- `python scripts/validate_decision_record_schema.py`
